### PR TITLE
Add streaming response support

### DIFF
--- a/docs/guide/concepts/bots.md
+++ b/docs/guide/concepts/bots.md
@@ -62,6 +62,16 @@ Bots can be loaded with the `Bot.load()` method.
 bot = await Bot.load("Ford")
 ```
 
+### Streaming responses
+By default, bots process an entire response and return it as a structured object. However, you can get a streaming response by providing a custom `on_token_callback` function. Every time the bot generates a token, the callback will be called with a buffer of all the tokens generated to that point. You can access the most recent token as `buffer[-1]`. 
+
+For example, to print each token as it's generated:
+```python
+bot = marvin.Bot()
+await bot.say("Hello!", on_token_callback=lambda buffer: print(buffer[-1]))
+```
+
+Note that this works for both the async `say()` and synchronous `say_sync()` methods.
 ## CLI
 
 ### Interactive use

--- a/src/marvin/bots/base.py
+++ b/src/marvin/bots/base.py
@@ -115,7 +115,13 @@ class Bot(MarvinBaseModel, LoggerMixin):
         None, description="A list of plugins that the bot can use."
     )
     history: History = None
-    llm: Callable = Field(default=None, repr=False)
+    llm_model_name: str = Field(
+        default_factory=lambda: marvin.settings.openai_model_name
+    )
+    llm_model_temperature: float = Field(
+        default_factory=lambda: marvin.settings.openai_model_temperature
+    )
+
     input_transformers: list[InputTransformer] = Field(
         default_factory=list,
         description=(
@@ -148,19 +154,6 @@ class Bot(MarvinBaseModel, LoggerMixin):
         True,
         description="Include the date in the prompt. Disable for testing.",
     )
-
-    @validator("llm", always=True)
-    def default_llm(cls, v):
-        if v is None:
-            # deferred import for performance
-            from langchain.chat_models import ChatOpenAI
-
-            return ChatOpenAI(
-                model_name=marvin.settings.openai_model_name,
-                temperature=marvin.settings.openai_model_temperature,
-                openai_api_key=marvin.settings.openai_api_key.get_secret_value(),
-            )
-        return v
 
     @validator("name", always=True)
     def default_name(cls, v):
@@ -265,7 +258,9 @@ class Bot(MarvinBaseModel, LoggerMixin):
         bot_config = await marvin.api.bots.get_bot_config(name=name)
         return cls.from_bot_config(bot_config=bot_config)
 
-    async def say(self, *args, response_format=None, **kwargs) -> BotResponse:
+    async def say(
+        self, *args, response_format=None, on_token_callback: Callable = None, **kwargs
+    ) -> BotResponse:
         # process inputs
         message = self.input_prompt.format(*args, **kwargs)
 
@@ -305,7 +300,9 @@ class Bot(MarvinBaseModel, LoggerMixin):
                 finished = True
             else:
                 counter += 1
-                response = await self._call_llm(messages=messages)
+                response = await self._call_llm(
+                    messages=messages, on_token_callback=on_token_callback
+                )
             if not finished:
                 plugin_messages = await self._check_for_plugins(response=response)
 
@@ -498,31 +495,31 @@ class Bot(MarvinBaseModel, LoggerMixin):
     async def _get_history(self) -> list[Message]:
         return await self.history.get_messages(max_tokens=2500)
 
-    async def _call_llm(self, messages: list[Message]) -> str:
+    async def _call_llm(
+        self, messages: list[Message], on_token_callback: Callable = None
+    ) -> str:
         """
         Format and send messages via langchain
         """
+
         # deferred import for performance
-        from langchain.schema import AIMessage, HumanMessage, SystemMessage
 
-        langchain_messages = []
+        import marvin.utilities.llms
 
-        for msg in messages:
-            if msg.role == "system":
-                langchain_messages.append(SystemMessage(content=msg.content))
-            elif msg.role == "ai":
-                langchain_messages.append(AIMessage(content=msg.content))
-            elif msg.role == "user":
-                langchain_messages.append(HumanMessage(content=msg.content))
-            else:
-                raise ValueError(f"Unrecognized role: {msg.role}")
+        langchain_messages = marvin.utilities.llms.prepare_messages(messages)
+        llm = marvin.utilities.llms.get_llm(
+            model_name=self.llm_model_name,
+            temperature=self.llm_model_temperature,
+            on_token_callback=on_token_callback,
+        )
 
         if marvin.settings.verbose:
             messages_repr = "\n".join(repr(m) for m in langchain_messages)
             self.logger.debug(f"Sending messages to LLM: {messages_repr}")
         try:
-            result = await self.llm.agenerate(
-                messages=[langchain_messages], stop=["Plugin output:", "Plugin Output:"]
+            result = await llm.agenerate(
+                messages=[langchain_messages],
+                stop=["Plugin output:", "Plugin Output:"],
             )
         except InvalidRequestError as exc:
             if "does not exist" in str(exc):

--- a/src/marvin/bots_lab/utilities.py
+++ b/src/marvin/bots_lab/utilities.py
@@ -1,22 +1,10 @@
 import inspect
-from typing import Callable
 
 from pydantic import Field
 
-import marvin
 from marvin.bots import Bot
 from marvin.bots.history import History, InMemoryHistory
 from marvin.plugins.base import Plugin
-
-
-def utility_llm():
-    from langchain.chat_models import ChatOpenAI
-
-    return ChatOpenAI(
-        model_name="gpt-3.5-turbo",
-        temperature=0,
-        openai_api_key=marvin.settings.openai_api_key.get_secret_value(),
-    )
 
 
 class UtilityBot(Bot):
@@ -27,7 +15,8 @@ class UtilityBot(Bot):
     plugins: list[Plugin] = []
     include_date_in_prompt: bool = False
     history: History = Field(default_factory=lambda: InMemoryHistory(max_messages=1))
-    llm: Callable = Field(default_factory=utility_llm)
+    llm_model_name: str = "gpt-3.5-turbo"
+    llm_model_temperature: float = 0
 
 
 summarize_bot = UtilityBot(

--- a/src/marvin/cli/cli.py
+++ b/src/marvin/cli/cli.py
@@ -92,8 +92,6 @@ def chat(
     if not marvin.settings.openai_api_key.get_secret_value():
         setup_openai()
 
-    from langchain.chat_models import ChatOpenAI
-
     if bot_name and any([name, personality, instructions, model]):
         raise ValueError(
             "You can't specify both `--bot` and any of "
@@ -107,11 +105,8 @@ def chat(
             name=name,
             personality=personality,
             instructions=instructions,
-            llm=ChatOpenAI(
-                model_name=model or marvin.settings.openai_model_name,
-                temperature=marvin.settings.openai_model_temperature,
-                openai_api_key=marvin.settings.openai_api_key.get_secret_value(),
-            ),
+            llm_model_name=model or marvin.settings.openai_model_name,
+            llm_temperature=marvin.settings.openai_model_temperature,
         )
 
     asyncio.run(bot.interactive_chat(first_message=" ".join(message)))

--- a/src/marvin/utilities/__init__.py
+++ b/src/marvin/utilities/__init__.py
@@ -1,1 +1,2 @@
+# llms not imported by default because it's a heavy dependency
 from . import logging, async_utils, types, strings, collections, models

--- a/src/marvin/utilities/llms.py
+++ b/src/marvin/utilities/llms.py
@@ -1,0 +1,136 @@
+from typing import Any, Callable, Union
+
+from langchain.callbacks.base import BaseCallbackHandler, CallbackManager
+from langchain.chat_models import ChatOpenAI
+from langchain.schema import (
+    AgentAction,
+    AgentFinish,
+    AIMessage,
+    HumanMessage,
+    LLMResult,
+    SystemMessage,
+)
+
+import marvin
+from marvin.models.threads import Message
+
+
+class StreamingCallbackHandler(BaseCallbackHandler):
+    """
+    Callback handler for streaming responses.
+    """
+
+    def __init__(self, buffer: list[str] = None, on_token_callback: Callable = None):
+        """
+        Args:
+            - buffer: The buffer to store the tokens in. Will be created if not
+              provided.
+            - on_token_callback: A callback to run on each new token. It will be
+              called with the entire buffer as an argument; the last token can
+              be accessed with buffer[-1].
+        """
+        if buffer is None:
+            buffer = []
+        self.buffer = buffer
+        self.on_token_callback = on_token_callback
+        super().__init__()
+
+    @property
+    def always_verbose(self) -> bool:
+        return True
+
+    def on_llm_start(
+        self, serialized: dict[str, Any], prompts: list[str], **kwargs: Any
+    ) -> None:
+        """Run when LLM starts running."""
+        self.buffer.clear()
+
+    def on_llm_new_token(self, token: str, **kwargs: Any) -> None:
+        """Run on new LLM token. Only available when streaming is enabled."""
+        self.buffer.append(token)
+        if self.on_token_callback is not None:
+            self.on_token_callback(self.buffer)
+
+    def on_llm_end(self, response: LLMResult, **kwargs: Any) -> Any:
+        """Run when LLM ends running."""
+
+    def on_llm_error(
+        self, error: Union[Exception, KeyboardInterrupt], **kwargs: Any
+    ) -> Any:
+        """Run when LLM errors."""
+
+    def on_chain_start(
+        self, serialized: dict[str, Any], inputs: dict[str, Any], **kwargs: Any
+    ) -> Any:
+        """Run when chain starts running."""
+
+    def on_chain_end(self, outputs: dict[str, Any], **kwargs: Any) -> Any:
+        """Run when chain ends running."""
+
+    def on_chain_error(
+        self, error: Union[Exception, KeyboardInterrupt], **kwargs: Any
+    ) -> Any:
+        """Run when chain errors."""
+
+    def on_tool_start(
+        self, serialized: dict[str, Any], input_str: str, **kwargs: Any
+    ) -> Any:
+        """Run when tool starts running."""
+
+    def on_tool_end(self, output: str, **kwargs: Any) -> Any:
+        """Run when tool ends running."""
+
+    def on_tool_error(
+        self, error: Union[Exception, KeyboardInterrupt], **kwargs: Any
+    ) -> Any:
+        """Run when tool errors."""
+
+    def on_text(self, text: str, **kwargs: Any) -> Any:
+        """Run on arbitrary text."""
+
+    def on_agent_action(self, action: AgentAction, **kwargs: Any) -> Any:
+        """Run on agent action."""
+
+    def on_agent_finish(self, finish: AgentFinish, **kwargs: Any) -> Any:
+        """Run on agent end."""
+
+
+def get_llm(
+    model_name: str = None,
+    temperature: float = None,
+    openai_api_key: str = None,
+    on_token_callback: Callable = None,
+) -> ChatOpenAI:
+    kwargs = dict()
+    if on_token_callback is not None:
+        kwargs.update(
+            streaming=True,
+            callback_manager=CallbackManager(
+                [StreamingCallbackHandler(on_token_callback=on_token_callback)]
+            ),
+        )
+    return ChatOpenAI(
+        model_name=model_name or marvin.settings.openai_model_name,
+        temperature=temperature or marvin.settings.openai_model_temperature,
+        openai_api_key=(
+            openai_api_key or marvin.settings.openai_api_key.get_secret_value()
+        ),
+        **kwargs,
+    )
+
+
+def prepare_messages(
+    messages: list[Message],
+) -> Union[AIMessage, HumanMessage, SystemMessage]:
+    """Prepare messages for LLM."""
+    langchain_messages = []
+    for msg in messages:
+        if msg.role == "system":
+            langchain_messages.append(SystemMessage(content=msg.content))
+        elif msg.role == "ai":
+            langchain_messages.append(AIMessage(content=msg.content))
+        elif msg.role == "user":
+            langchain_messages.append(HumanMessage(content=msg.content))
+        else:
+            raise ValueError(f"Unrecognized role: {msg.role}")
+    return langchain_messages

--- a/src/marvin/utilities/tests.py
+++ b/src/marvin/utilities/tests.py
@@ -27,14 +27,9 @@ def assert_approx_equal(statement_1: str, statement_2: str):
 
 
 def assert_llm(response: str, expectation: Any, model_name: str = None):
-    from langchain.chat_models import ChatOpenAI
-
     @ai_fn(
-        llm=ChatOpenAI(
-            model_name=model_name or marvin.settings.openai_model_name,
-            temperature=0,
-            openai_api_key=marvin.settings.openai_api_key.get_secret_value(),
-        ),
+        llm_model_name=model_name or marvin.settings.openai_model_name,
+        llm_model_temperature=0,
     )
     def _assert_llm(response: Any, expectation: Any) -> bool:
         """

--- a/tests/llm_tests/bots/test_bots.py
+++ b/tests/llm_tests/bots/test_bots.py
@@ -23,6 +23,34 @@ class TestBotResponse:
         )
 
 
+class TestStreamingBotResponse:
+    async def test_streaming_response(self):
+        buffer = []
+        bot = Bot()
+
+        def callback(x):
+            return buffer.append(x)
+
+        response = await bot.say("hello!", on_token_callback=callback)
+
+        assert len(buffer) > 1
+        assert isinstance(buffer[-1], list)
+        assert "".join(buffer[-1]) == response.content
+
+    def test_streaming_response_sync(self):
+        buffer = []
+        bot = Bot()
+
+        def callback(x):
+            return buffer.append(x)
+
+        response = bot.say_sync("hello!", on_token_callback=callback)
+
+        assert len(buffer) > 1
+        assert isinstance(buffer[-1], list)
+        assert "".join(buffer[-1]) == response.content
+
+
 class TestResponseFormatShorthand:
     async def test_int(self):
         bot = Bot(response_format=int)


### PR DESCRIPTION
New feature that allows users to receive tokens as they are generated instead of waiting for the entire response.

To use it, provide an `on_token_callback` when calling either `.say()` or `.say_sync()`. The callback will be called with a buffer that contains all the tokens generated to date.

For example, to print each token as it's generated:

```python
bot = Bot()
await bot.say("Hello!", on_token_callback=lambda buffer: print(buffer[-1]))
```

Updated documentation: https://github.com/PrefectHQ/marvin/pull/164/files#diff-489dcae932f843cd42a5eaae1dec2d9c91a7e76ad9c888def9e867ac33e8b68dR65