### PR TITLE
add pdf loader

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,7 @@ dev = [
 ]
 postgres = ["asyncpg~=0.27.0"]
 chromadb = ["chromadb~=0.3"]
+pdf = ["pypdf~=3.7.0"]
 
 [project.urls]
 Code = "https://github.com/prefecthq/marvin"

--- a/src/marvin/loaders/pdf.py
+++ b/src/marvin/loaders/pdf.py
@@ -47,20 +47,3 @@ class PDFLoader(Loader):
                 )
                 for i, page in enumerate(pdf_reader.pages)
             ]
-
-
-if __name__ == "__main__":
-    import asyncio
-
-    async def main():
-        remote_pdf_document = await PDFLoader(
-            file_path="https://www.cs.cmu.edu/~jgc/publication/The_Use_MMR_Diversity_Based_LTMIR_1998.pdf"
-        ).load()
-
-        local_pdf_document = await PDFLoader(
-            file_path="/Users/nate/Downloads/MMR.pdf"
-        ).load()
-
-        assert remote_pdf_document[0].text == local_pdf_document[0].text
-
-    asyncio.run(main())

--- a/src/marvin/loaders/pdf.py
+++ b/src/marvin/loaders/pdf.py
@@ -1,0 +1,47 @@
+from contextlib import asynccontextmanager
+from tempfile import NamedTemporaryFile
+from typing import List
+from urllib.parse import urlparse
+
+import httpx
+import pypdf
+
+from marvin.loaders.base import Loader
+from marvin.models.documents import Document
+
+
+async def download_pdf(url: str) -> bytes:
+    async with httpx.AsyncClient() as client:
+        response = await client.get(url)
+        return response.content
+
+
+def is_valid_url(url):
+    parsed = urlparse(url)
+    return bool(parsed.netloc) and bool(parsed.scheme)
+
+
+class PDFLoader(Loader):
+    @asynccontextmanager
+    async def open_pdf_file(self, file_path: str):
+        if is_valid_url(file_path):
+            raw_pdf_content = await download_pdf(file_path)
+            with NamedTemporaryFile() as temp_file:
+                temp_file.write(raw_pdf_content)
+                temp_file.flush()
+                yield temp_file
+        else:
+            with open(file_path, "rb") as pdf_file_obj:
+                yield pdf_file_obj
+
+    async def load(self, file_path: str) -> List[Document]:
+        async with self.open_pdf_file(file_path) as pdf_file_obj:
+            pdf_reader = pypdf.PdfReader(pdf_file_obj)
+            return [
+                Document(
+                    text=page.extract_text(),
+                    metadata={"source": file_path, "page": i},
+                    order=i,
+                )
+                for i, page in enumerate(pdf_reader.pages)
+            ]

--- a/src/marvin/loaders/pdf.py
+++ b/src/marvin/loaders/pdf.py
@@ -4,7 +4,14 @@ from typing import List
 from urllib.parse import urlparse
 
 import httpx
-import pypdf
+
+try:
+    import pypdf
+except ModuleNotFoundError:
+    raise ImportError(
+        "The PDF loader requires the pypdf package. "
+        "Install it with `pip install marvin[pdf]`."
+    )
 
 from marvin.loaders.base import Loader
 from marvin.models.documents import Document


### PR DESCRIPTION
may also want a bulk pdf loader at some point to avoid extra chroma clients

closes #161 

```python
import asyncio

async def main():
    remote_pdf_document = await PDFLoader(
        file_path="https://www.cs.cmu.edu/~jgc/publication/The_Use_MMR_Diversity_Based_LTMIR_1998.pdf"
    ).load()

    local_pdf_document = await PDFLoader(
        file_path="/Users/nate/Downloads/MMR.pdf"
    ).load()
    assert len(remote_pdf_document) == len(local_pdf_document)

    assert remote_pdf_document[0].text == local_pdf_document[0].text
    assert remote_pdf_document[0].order == local_pdf_document[0].order

    assert remote_pdf_document[-1].text == local_pdf_document[-1].text
    assert remote_pdf_document[-1].order == local_pdf_document[-1].order

asyncio.run(main())
```