### PR TITLE
Ensure the bots window has a scrollbar if needed

### DIFF
--- a/src/marvin/cli/tui.css
+++ b/src/marvin/cli/tui.css
@@ -263,7 +263,7 @@ BotInfo TextTable .label {
 #bots-info-container {
   layout: grid;
   grid-size: 3;
-  height: 90%;
+  overflow-y: scroll;
 }
 
 BotsList {

--- a/src/marvin/cli/tui.py
+++ b/src/marvin/cli/tui.py
@@ -102,6 +102,8 @@ class BotsOptionList(OptionList):
             if self.app.bot:
                 if b.name == self.app.bot.name:
                     self.highlighted = i
+        self.show_vertical_scrollbar = True
+        self.scroll_to_highlight()
 
     async def on_mount(self) -> None:
         await self.refresh_bots()


### PR DESCRIPTION
The option list wasn't showing a scrollbar even if it extended past the BotsDialogue limits, unless you resized the terminal window. This shows the scrollbar if needed.