### PR TITLE
Ensure async streaming functions are called

### DIFF
--- a/src/marvin/cli/tui.py
+++ b/src/marvin/cli/tui.py
@@ -656,7 +656,11 @@ class MainScreen(Screen):
                 ),
             )
 
-            self.query_one("Conversation", Conversation)
+            # call once to populate the response in case there was any trouble
+            # streaming live
+            await self.stream_bot_response(
+                token_buffer=[response.content], response=bot_response
+            )
 
             # if this is one of the first few responses, rename the thread
             # appropriately

--- a/src/marvin/utilities/llms.py
+++ b/src/marvin/utilities/llms.py
@@ -51,10 +51,9 @@ class StreamingCallbackHandler(BaseCallbackHandler):
         """Run on new LLM token. Only available when streaming is enabled."""
         self.buffer.append(token)
         if self.on_token_callback is not None:
-            if inspect.iscoroutinefunction(self.on_token_callback):
+            output = self.on_token_callback(self.buffer)
+            if inspect.iscoroutine(output):
                 asyncio.run(self.on_token_callback(self.buffer))
-            else:
-                self.on_token_callback(self.buffer)
 
     def on_llm_end(self, response: LLMResult, **kwargs: Any) -> Any:
         """Run when LLM ends running."""


### PR DESCRIPTION
Since the streaming callback is wrapped in a partial, it isn't recognized as needing to be awaited; in addition the creation of the bot response only happens in the streaming callback. As a fix, ensure it is called by checking if its output is a coroutine and also call the streaming callback manually on the full response.