### PR TITLE
Don't install Marvin bots by default

### DIFF
--- a/src/marvin/bots/__init__.py
+++ b/src/marvin/bots/__init__.py
@@ -16,7 +16,3 @@ async def install_bots():
                     await bot.save(if_exists="update")
     except Exception:
         logger.error("Failed to install bots", exc_info=True)
-
-
-if marvin.settings.bot_create_default_bots_on_startup:
-    asyncio.run(install_bots())

--- a/src/marvin/cli/tui.css
+++ b/src/marvin/cli/tui.css
@@ -235,6 +235,18 @@ BotsDialogue {
   height: 70%;
 }
 
+BotsDialogue Horizontal {
+  height: auto;
+}
+
+BotsDialogue Button {
+  margin-right: 2;
+}
+
+BotsDialogue #install-default-bots {
+  padding: 0 2;
+}
+
 BotsOptionList {
   border: solid white 50%;
   background: $boost;

--- a/src/marvin/config.py
+++ b/src/marvin/config.py
@@ -121,12 +121,6 @@ class Settings(BaseSettings):
     redis_connection_url: SecretStr = ""
 
     # BOTS
-    bot_create_default_bots_on_startup: bool = Field(
-        True,
-        description=(
-            "If True, default bots will be auto-created in the database on startup."
-        ),
-    )
     bot_create_profile_picture: bool = Field(
         False,
         description=(
@@ -206,8 +200,6 @@ class Settings(BaseSettings):
             values["bot_create_profile_picture"] = False
             # don't load default plugins
             values["bot_load_default_plugins"] = False
-            # don't create bots
-            values["bot_create_default_bots_on_startup"] = False
             # remove all model variance
             values["openai_model_temperature"] = 0.0
             # use 3.5 by default


### PR DESCRIPTION
I think this will address a problem related to #195.

- No longer automatically installs bots on startup (except for saving the default Marvin bot when the TUI opens)
- Other bots can be installed by clicking the "Install default bots" button in the bots dialogue window