### PR TITLE
rm createdupdated mixin from metadata

### DIFF
--- a/src/marvin/models/metadata.py
+++ b/src/marvin/models/metadata.py
@@ -1,9 +1,9 @@
 from pydantic import Field
 
-from marvin.utilities.models import CreatedUpdatedMixin, MarvinBaseModel
+from marvin.utilities.models import MarvinBaseModel
 
 
-class Metadata(MarvinBaseModel, CreatedUpdatedMixin):
+class Metadata(MarvinBaseModel):
     link: str = Field(default=None)
     title: str = Field(default="[untitled]")
     source: str = Field(default="unknown")


### PR DESCRIPTION
the inclusion of the `CreatedUpdatedMixin` overrides user-set selections of those fields and throws a validation error when the documents are added to chroma

this is something I fixed in slackbot branch and had not yet merged into main

from discord (same problem I saw):
>I was having trouble using loaders after updating (started by deleting my .marvin folder). it was trying to submit created_at and updated_at chroma entries as datetime's. 
> `raise ValueError(f"Expected metadata value to be a str, int, or float, got {value}")`
> but I couldn't figure out how marvin was submitting that. It was even overriding what I was directly putting in to my document Metadata.
