### PR TITLE
Allow using bots that lack a description in the TUI

### DIFF
--- a/src/marvin/cli/tui.py
+++ b/src/marvin/cli/tui.py
@@ -151,7 +151,6 @@ class BotInfo(Container):
             personality.update(bot.personality)
 
 
-
 class Sidebar(VerticalScroll):
     def compose(self) -> ComposeResult:
         with Horizontal(id="bot-name-container"):

--- a/src/marvin/cli/tui.py
+++ b/src/marvin/cli/tui.py
@@ -143,9 +143,13 @@ class BotInfo(Container):
     def watch_bot(self, bot: marvin.models.bots.BotConfig):
         if self.app.is_mounted(self):
             description = self.query_one("#bot-info-description", Label)
+
+            if bot.description:
+                description.update(bot.description)
+
             personality = self.query_one("#bot-info-personality", Label)
-            description.update(bot.description)
             personality.update(bot.personality)
+
 
 
 class Sidebar(VerticalScroll):


### PR DESCRIPTION
Currently, if you create a bot without a description, the default value is `None`, which breaks the TUI. This PR ignores the bot description if the value is falsy.