### PR TITLE
Added missing names to plugins. Works better with gpt-3.5-turbo

### DIFF
--- a/src/marvin/plugins/chroma.py
+++ b/src/marvin/plugins/chroma.py
@@ -56,6 +56,7 @@ async def keyword_query_chroma(query: str, where: dict, n: int = 4) -> str:
 
 
 class SimpleChromaSearch(Plugin):
+    name: str = "simple-chroma-search"
     description: str = (
         "Semantic search for relevant documents."
         " To use this plugin, simply provide a natural language `query`"

--- a/src/marvin/plugins/duckduckgo.py
+++ b/src/marvin/plugins/duckduckgo.py
@@ -42,6 +42,7 @@ async def search_ddg(query: str, n: int = 5) -> str:
 
 
 class DuckDuckGo(Plugin):
+    name: str = "duckduckgo"
     description: str = (
         "Search the web with DuckDuckGo. Useful for current events. If you already know"
         " the answer, you don't need to use this unless asked to. Works best with"


### PR DESCRIPTION
When chroma plugin doesn't have a name, gpt-3.5-turbo almost never uses it when asked for it.