### PR TITLE
Store llm settings for each bot

### DIFF
--- a/src/marvin/bot/base.py
+++ b/src/marvin/bot/base.py
@@ -176,12 +176,8 @@ class Bot(MarvinBaseModel, LoggerMixin):
         None, description="A list of plugins that the bot can use."
     )
     history: History = Field(None, repr=False)
-    llm_model_name: str = Field(
-        default_factory=lambda: marvin.settings.openai_model_name, repr=False
-    )
-    llm_model_temperature: float = Field(
-        default_factory=lambda: marvin.settings.openai_model_temperature, repr=False
-    )
+    llm_model_name: str = Field(None, repr=False)
+    llm_model_temperature: float = Field(None, repr=False)
 
     input_transformers: list[InputTransformer] = Field(
         default_factory=list,
@@ -283,6 +279,12 @@ class Bot(MarvinBaseModel, LoggerMixin):
     def to_bot_config(self) -> "BotConfig":
         from marvin.models.bots import BotConfig
 
+        llm_settings = {}
+        if self.llm_model_name is not None:
+            llm_settings.update(llm_model_name=self.llm_model_name)
+        if self.llm_model_temperature is not None:
+            llm_settings.update(llm_model_temperature=self.llm_model_temperature)
+
         return BotConfig(
             id=self.id,
             name=self.name,
@@ -291,6 +293,7 @@ class Bot(MarvinBaseModel, LoggerMixin):
             plugins=[p.dict() for p in self.plugins],
             input_transformers=[t.dict() for t in self.input_transformers],
             description=self.description,
+            llm_settings=llm_settings,
         )
 
     @classmethod
@@ -303,6 +306,7 @@ class Bot(MarvinBaseModel, LoggerMixin):
             plugins=bot_config.plugins,
             input_transformers=bot_config.input_transformers,
             description=bot_config.description,
+            **bot_config.llm_settings,
         )
 
     async def save(self, if_exists: str = None):

--- a/src/marvin/cli/cli.py
+++ b/src/marvin/cli/cli.py
@@ -5,7 +5,6 @@ import dotenv
 import openai
 import openai.error
 import typer
-from fastapi import HTTPException
 from rich import print as rprint
 from rich.prompt import Prompt
 
@@ -83,7 +82,8 @@ def chat(
 
     try:
         bot = marvin.Bot.load_sync(name=bot)
-    except HTTPException:
+    except Exception as exc:
+        marvin.get_logger().warning(exc)
         bot = None
     app = MarvinApp(default_bot=bot)
     app.run()

--- a/src/marvin/infra/alembic/versions/2023_04_01_1739-4d10660798b7_initial_migration.py
+++ b/src/marvin/infra/alembic/versions/2023_04_01_1739-4d10660798b7_initial_migration.py
@@ -8,7 +8,7 @@ Create Date: 2023-04-01 17:39:22.762982
 import sqlalchemy as sa
 import sqlmodel
 from alembic import op
-from sqlalchemy.dialects import sqlite
+from marvin.infra.database import JSONType
 
 # revision identifiers, used by Alembic.
 revision = "4d10660798b7"
@@ -42,9 +42,9 @@ def upgrade() -> None:
                 server_default=sa.text("(CURRENT_TIMESTAMP)"),
                 nullable=False,
             ),
-            sa.Column("plugins", sqlite.JSON(), server_default="[]", nullable=False),
+            sa.Column("plugins", JSONType(), server_default="[]", nullable=False),
             sa.Column(
-                "input_transformers", sqlite.JSON(), server_default="[]", nullable=False
+                "input_transformers", JSONType(), server_default="[]", nullable=False
             ),
             sa.Column("id", sqlmodel.sql.sqltypes.AutoString(), nullable=False),
             sa.Column("name", sqlmodel.sql.sqltypes.AutoString(), nullable=False),
@@ -88,7 +88,7 @@ def upgrade() -> None:
                 server_default=sa.text("(CURRENT_TIMESTAMP)"),
                 nullable=False,
             ),
-            sa.Column("context", sqlite.JSON(), server_default="{}", nullable=False),
+            sa.Column("context", JSONType(), server_default="{}", nullable=False),
             sa.Column("id", sqlmodel.sql.sqltypes.AutoString(), nullable=False),
             sa.Column("lookup_key", sqlmodel.sql.sqltypes.AutoString(), nullable=True),
             sa.Column("name", sqlmodel.sql.sqltypes.AutoString(), nullable=True),
@@ -115,7 +115,7 @@ def upgrade() -> None:
                 server_default=sa.text("(CURRENT_TIMESTAMP)"),
                 nullable=False,
             ),
-            sa.Column("data", sqlite.JSON(), server_default="{}", nullable=False),
+            sa.Column("data", JSONType(), server_default="{}", nullable=False),
             sa.Column("id", sqlmodel.sql.sqltypes.AutoString(), nullable=False),
             sa.Column("role", sqlmodel.sql.sqltypes.AutoString(), nullable=False),
             sa.Column("content", sqlmodel.sql.sqltypes.AutoString(), nullable=False),

--- a/src/marvin/infra/alembic/versions/2023_04_21_1255-62b0e04ac765_store_bot_config_llm_settings.py
+++ b/src/marvin/infra/alembic/versions/2023_04_21_1255-62b0e04ac765_store_bot_config_llm_settings.py
@@ -1,0 +1,27 @@
+"""store bot config LLM settings
+
+Revision ID: 62b0e04ac765
+Revises: 62dbb6aaed4d
+Create Date: 2023-04-21 12:55:59.689423
+
+"""
+import sqlalchemy as sa
+from alembic import op
+from marvin.infra.database import JSONType
+
+# revision identifiers, used by Alembic.
+revision = "62b0e04ac765"
+down_revision = "62dbb6aaed4d"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "bot_config",
+        sa.Column("llm_settings", JSONType(), server_default="{}", nullable=False),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("bot_config", "llm_settings")

--- a/src/marvin/models/bots.py
+++ b/src/marvin/models/bots.py
@@ -21,6 +21,10 @@ class BotConfig(MarvinSQLModel, CreatedUpdatedMixin, table=True):
     personality: str
     instructions: str
     description: str = None
+    llm_settings: dict = Field(
+        default_factory=dict,
+        sa_column=sa.Column(JSONType, nullable=False, server_default="{}"),
+    )
     plugins: list[dict] = Field(
         default_factory=list,
         sa_column=sa.Column(JSONType, nullable=False, server_default="[]"),
@@ -43,6 +47,7 @@ class BotConfigCreate(MarvinBaseModel):
     )
     plugins: list[Plugin] = Field(default_factory=list)
     input_transformers: list[InputTransformer] = Field(default_factory=list)
+    llm_settings: dict = Field(default_factory=dict)
 
 
 class BotConfigUpdate(MarvinBaseModel):
@@ -51,6 +56,7 @@ class BotConfigUpdate(MarvinBaseModel):
     instructions: str = None
     plugins: list[Plugin] = None
     profile_picture: str = None
+    llm_settings: dict = None
 
 
 class BotConfigRead(MarvinBaseModel):
@@ -64,3 +70,4 @@ class BotConfigRead(MarvinBaseModel):
     profile_picture: str = None
     created_at: datetime.datetime = None
     updated_at: datetime.datetime = None
+    llm_settings: dict = None

--- a/src/marvin/utilities/llms.py
+++ b/src/marvin/utilities/llms.py
@@ -113,9 +113,13 @@ def get_llm(
                 [StreamingCallbackHandler(on_token_callback=on_token_callback)]
             ),
         )
+    if model_name is None:
+        model_name = marvin.settings.openai_model_name
+    if temperature is None:
+        temperature = marvin.settings.openai_model_temperature
     return ChatOpenAI(
-        model_name=model_name or marvin.settings.openai_model_name,
-        temperature=temperature or marvin.settings.openai_model_temperature,
+        model_name=model_name,
+        temperature=temperature,
         openai_api_key=(
             openai_api_key or marvin.settings.openai_api_key.get_secret_value()
         ),


### PR DESCRIPTION
Allows bots to set model name / temp and store in the DB. Useful for #234 . 

Also fixes a minor bug where a bot with a manually-set 0 temperature wouldn't be respected