### PR TITLE
allow topic selection in `SimpleChromaSearch`

### DIFF
--- a/examples/bot_retrieval/bot_retrieval.py
+++ b/examples/bot_retrieval/bot_retrieval.py
@@ -1,0 +1,43 @@
+import marvin
+from marvin.plugins.chroma import SimpleChromaSearch
+from marvin.plugins.web import LoadAndStoreURL
+
+website = "https://www.weallcode.org/our-story/"
+topic = "we-all-code"
+
+chroma_search_instructions = """
+    Your job is to answer questions about the We All Code organization.
+    You will always need to call your plugins with JSON payloads to help and
+    get the most up-to-date information. Do not assume you know the answer
+    without calling a plugin. Do not ask the user for clarification before you
+    attempt a plugin call. Make sure to include any source links provided by
+    your plugins.
+    
+    Here are your plugins:
+        - `SimpleChromaSearch`: search for documents in Chroma that are related
+            to the user's query.
+        - `LoadAndStoreURL`: load a URL and store it in Chroma for later searches
+            via `SimpleChromaSearch`.
+    """
+
+
+weallcode_bot = marvin.Bot(
+    personality="Friendly and helpful.",
+    instructions=chroma_search_instructions,
+    plugins=[LoadAndStoreURL(), SimpleChromaSearch(topic=topic)],
+    llm_model_name="gpt-3.5-turbo",
+    llm_model_temperature=0,
+)
+
+
+async def main():
+    marvin.settings.log_level = "DEBUG"
+    await weallcode_bot.interactive_chat(
+        tui=False, first_message=f"hey pls load {website} to topic {topic}"
+    )
+
+
+if __name__ == "__main__":
+    import asyncio
+
+    asyncio.run(main())

--- a/src/marvin/plugins/chroma.py
+++ b/src/marvin/plugins/chroma.py
@@ -55,7 +55,7 @@ async def query_chroma(
     )
 
 
-async def keyword_query_chroma(query: str, where: dict, n: int = 4) -> str:
+async def keyword_query_chroma(query: str, where: dict, n: int = 4, topic=None) -> str:
     keywords = await extract_keywords(query)
 
     return await query_chroma(
@@ -64,17 +64,19 @@ async def keyword_query_chroma(query: str, where: dict, n: int = 4) -> str:
         include=["documents"],
         where=build_metadata_filter(where) if where else None,
         where_document=build_keyword_filter(keywords) if keywords else None,
+        topic=topic,
     )
 
 
 class SimpleChromaSearch(Plugin):
     description: str = (
-        "Semantic search for relevant documents."
+        "Use this plugin to search for relevant documents."
         " To use this plugin, simply provide a natural language `query`"
         " and relevant document excerpts will be returned to you."
     )
 
     keywords: list[str] = Field(default_factory=list)
+    topic: Optional[str] = None
 
     def get_full_description(self) -> str:
         base_description = super().get_full_description()
@@ -88,7 +90,7 @@ class SimpleChromaSearch(Plugin):
         return base_description
 
     async def run(self, query: str) -> str:
-        return await keyword_query_chroma(query, where=None)
+        return await keyword_query_chroma(query, where=None, topic=self.topic)
 
 
 """ --- decorator plugin definition ---


### PR DESCRIPTION
currently, `SimpleChromaSearch` only accepts `keywords` and should also accept a `topic` so a user could tell a bot to search in topic X or add a document to topic X (or Y)