### PR TITLE
Condense AI function instructions

### DIFF
--- a/src/marvin/ai_functions/__init__.py
+++ b/src/marvin/ai_functions/__init__.py
@@ -1,3 +1,3 @@
 from .base import ai_fn
 
-from . import data, strings
+from . import data, strings, entities

--- a/src/marvin/ai_functions/base.py
+++ b/src/marvin/ai_functions/base.py
@@ -1,6 +1,7 @@
 import asyncio
 import inspect
 import re
+import sys
 from functools import partial, wraps
 from typing import Any, Callable, TypeVar
 
@@ -105,7 +106,11 @@ def ai_fn(
             yield_value = next(gen)
         elif inspect.isasyncgenfunction(fn):
             gen = fn(*args, **kwargs)
-            yield_value = asyncio.run(anext(gen))
+            # 3.10 introduces "anext", otherwise use __anext__
+            if sys.version_info >= (3, 10):
+                yield_value = asyncio.run(anext(gen))
+            else:
+                yield_value = asyncio.run(gen.__anext__())
         else:
             yield_value = None
 

--- a/src/marvin/ai_functions/base.py
+++ b/src/marvin/ai_functions/base.py
@@ -50,8 +50,9 @@ AI_FN_MESSAGE = jinja_env.from_string(inspect.cleandoc("""
     {{ yield_value }}
     {% endif %}
     
-    Generate the output. Do not explain the type signature or give guidance on
-    parsing.
+    # Instructions 
+    Generate the function's output. Do not explain the type signature or give
+    guidance on parsing.
     """))
 
 T = TypeVar("T")

--- a/src/marvin/ai_functions/data.py
+++ b/src/marvin/ai_functions/data.py
@@ -18,11 +18,12 @@ def map_categories(data: list[str], categories: list[str]) -> list[str]:
 @ai_fn
 def categorize(data: list[str], description: str) -> list[str]:
     """
-    Map each item in `data` to a value that matches the `description`
-    as close as possible. For example, if the description is "pets",
-    valid categories would be "cat", "dog", "fish", etc. The category
-    description may include examples. Return a list of assigned categories the
-    same length and order as `data`.
+    Given a `description` of some possible categories, map each item in `data`
+    to the most relevant category. For example, if the description is "pets",
+    valid categories would be "cat", "dog", "fish", etc. If the description is
+    "airports (JFK, etc.)" then valid categories would be "LGA", "LAX", "IAD",
+    etc. Return a list of assigned categories the same length and order as
+    `data`.
     """
 
 

--- a/src/marvin/ai_functions/entities.py
+++ b/src/marvin/ai_functions/entities.py
@@ -18,6 +18,10 @@ def extract_keywords(text: str) -> list[str]:
 
 
 class NamedEntity(MarvinBaseModel):
+    """
+    A named entity extracted from a text string.
+    """
+
     entity: str = Field(description="The entity name")
     type: str = Field(description="The entity type (based on spaCy NER types)")
 
@@ -25,8 +29,8 @@ class NamedEntity(MarvinBaseModel):
 @ai_fn
 def extract_named_entities(text: str) -> list[NamedEntity]:
     """
-    Extract named entities from the given `text` and return a list of
-    NamedEntity objects. Correct capitalization if needed.
+    Extract named entities from the given `text`. Correct capitalization if
+    necessary.
     """
 
 

--- a/src/marvin/bot/base.py
+++ b/src/marvin/bot/base.py
@@ -92,7 +92,7 @@ DEFAULT_INSTRUCTIONS_TEMPLATE = """
     
     # Date
     
-    Your training ended in the past. Today's date is {{pendulum.now().format("dddd, MMMM D, YYYY") }}.
+    Your training ended in the past. Today is {{ pendulum.now().format("dddd, MMMM D, YYYY at HH:mm ZZ") }}.
     
     {% endif -%}
     """  # noqa: E501

--- a/src/marvin/bot/base.py
+++ b/src/marvin/bot/base.py
@@ -92,8 +92,7 @@ DEFAULT_INSTRUCTIONS_TEMPLATE = """
     
     # Date
     
-    Your training ended in the past. Today's date is {{
-    pendulum.now().format("dddd, MMMM D, YYYY") }}.
+    Your training ended in the past. Today's date is {{pendulum.now().format("dddd, MMMM D, YYYY") }}.
     
     {% endif -%}
     """  # noqa: E501

--- a/src/marvin/bot/response_formatters.py
+++ b/src/marvin/bot/response_formatters.py
@@ -23,12 +23,18 @@ class ResponseFormatter(DiscriminatedUnionType, LoggerMixin):
     format: str = Field(None, description="The format of the response")
     on_error: Literal["reformat", "raise", "ignore"] = "reformat"
 
-    def validate_response(self, response):
+    def validate_response(self, response: str):
         # by default, try to parse the response to validate it
         self.parse_response(response)
 
-    def parse_response(self, response):
+    def parse_response(self, response: str) -> str:
         return response
+
+
+class StringFormatter(ResponseFormatter):
+    format: str = (
+        "The response will be parsed as a string. Do not add unecessary quotes."
+    )
 
 
 class JSONFormatter(ResponseFormatter):
@@ -186,10 +192,12 @@ class PydanticFormatter(ResponseFormatter):
 
 
 def load_formatter_from_shorthand(shorthand_response_format) -> ResponseFormatter:
-    if shorthand_response_format in (None, str):
+    if shorthand_response_format is None:
         return ResponseFormatter()
     elif isinstance(shorthand_response_format, ResponseFormatter):
         return shorthand_response_format
+    elif shorthand_response_format is str:
+        return StringFormatter()
     elif shorthand_response_format is bool:
         return BooleanFormatter()
     elif isinstance(shorthand_response_format, str):

--- a/src/marvin/bot/response_formatters.py
+++ b/src/marvin/bot/response_formatters.py
@@ -186,7 +186,7 @@ class PydanticFormatter(ResponseFormatter):
 
 
 def load_formatter_from_shorthand(shorthand_response_format) -> ResponseFormatter:
-    if shorthand_response_format is None:
+    if shorthand_response_format in (None, str):
         return ResponseFormatter()
     elif isinstance(shorthand_response_format, ResponseFormatter):
         return shorthand_response_format

--- a/tests/llm_tests/ai_functions/test_ai_functions.py
+++ b/tests/llm_tests/ai_functions/test_ai_functions.py
@@ -146,7 +146,7 @@ class TestBool:
             """
 
         x = build_json()
-        assert x == "{'a': 1}"
+        assert x == '{"a": 1}'
 
     def test_functions_are_not_run(self):
         @ai_fn

--- a/tests/llm_tests/ai_functions/test_ai_functions.py
+++ b/tests/llm_tests/ai_functions/test_ai_functions.py
@@ -148,6 +148,55 @@ class TestBool:
         x = build_json()
         assert x == "{'a': 1}"
 
+    def test_functions_are_not_run(self):
+        @ai_fn
+        def number_one() -> int:
+            """
+            Always returns 1
+            """
+            raise ValueError("This will not be raised")
+
+        result = number_one()
+        assert result == 1
+
+    def test_generators_are_run(self):
+        @ai_fn
+        def number_one() -> int:
+            """
+            Always returns 1
+            """
+            raise ValueError("This will be raised")
+            yield
+
+        with pytest.raises(ValueError, match="(This will be raised)"):
+            number_one()
+
+    async def test_async_generators_are_run(self):
+        @ai_fn
+        async def number_one() -> int:
+            """
+            Always returns 1
+            """
+            raise ValueError("This will be raised")
+            yield
+
+        with pytest.raises(ValueError, match="(This will be raised)"):
+            number_one()
+
+    def test_yield_from_function(self):
+        # assign p outside the function source code
+        p = 99
+
+        @ai_fn
+        def yielding_fn() -> int:
+            """
+            Returns -1 * a number generated at runtime.
+            """
+            yield p
+
+        result = yielding_fn()
+        assert result == -1 * p
+
 
 class TestContainers:
     """tests untyped containers"""

--- a/tests/llm_tests/ai_functions/test_data.py
+++ b/tests/llm_tests/ai_functions/test_data.py
@@ -14,7 +14,7 @@ class TestCategorize:
     def test_categorize_colors(self):
         result = data_fns.categorize(
             ["red", "teal", "sunflower", "cyan"],
-            description="colors of the rainbow",
+            description="nearest color of the rainbow",
         )
         assert result == ["red", "blue", "yellow", "blue"]
 

--- a/tests/llm_tests/ai_functions/test_entities.py
+++ b/tests/llm_tests/ai_functions/test_entities.py
@@ -32,7 +32,7 @@ class TestNamedEntityExtraction:
         )
         result = entities_fns.extract_named_entities(text)
         assert result == [
-            entities_fns.NamedEntity(entity="United States", type="GPE"),
+            entities_fns.NamedEntity(entity="The United States", type="GPE"),
             entities_fns.NamedEntity(entity="John Smith", type="PERSON"),
             entities_fns.NamedEntity(entity="2025", type="DATE"),
         ]

--- a/tests/llm_tests/bots/test_bots.py
+++ b/tests/llm_tests/bots/test_bots.py
@@ -76,7 +76,7 @@ class TestResponseFormatShorthand:
 
     async def test_list_str(self):
         bot = Bot(
-            instructions="solve the math problems and return only the answer",
+            instructions="solve each math problem and return only the answers",
             response_format=list[str],
         )
         response = await bot.say("Problem 1: 1 + 1\n\nProblem 2: 2 + 2")
@@ -86,7 +86,7 @@ class TestResponseFormatShorthand:
 
     async def test_natural_language_list(self):
         bot = Bot(
-            instructions="solve the math problems and return only the answer",
+            instructions="solve each math problem and return only the answers",
             response_format="a list of strings",
         )
         response = await bot.say("Problem 1: 1 + 1\n\nProblem 2: 2 + 2")
@@ -102,7 +102,7 @@ class TestResponseFormatShorthand:
 
     async def test_natural_language_list_with_json_keyword(self):
         bot = Bot(
-            instructions="solve the math problems and return only the answer",
+            instructions="solve each math problem and return only the answers",
             response_format="a JSON list of strings",
         )
         response = await bot.say("Problem 1: 1 + 1\n\nProblem 2: 2 + 2")


### PR DESCRIPTION
- condense AI function instructions
- simplify response instructions for `→ str` signature (and improve tests)
- ensures that `ai_functions.entities` are imported
- changes `return` statements to `yield` statements for evaluating AI functions