### PR TITLE
Refactor ai functions into a class

### DIFF
--- a/src/marvin/ai_functions/__init__.py
+++ b/src/marvin/ai_functions/__init__.py
@@ -1,3 +1,3 @@
-from .base import ai_fn
+from .base import ai_fn, AIFunction
 
 from . import data, strings, entities

--- a/src/marvin/ai_functions/base.py
+++ b/src/marvin/ai_functions/base.py
@@ -2,18 +2,28 @@ import asyncio
 import inspect
 import re
 import sys
-from functools import partial, wraps
-from typing import Any, Callable, TypeVar
+from functools import partial
+from typing import Callable, TypeVar
 
 from marvin.bot import Bot
 from marvin.bot.history import InMemoryHistory
 from marvin.utilities.strings import jinja_env
 
 AI_FN_INSTRUCTIONS = jinja_env.from_string(inspect.cleandoc("""
+    ## Objective
+    
     Your job is to generate outputs for a Python function with the following
     signature and docstring:
     
     {{ function_def }}        
+    
+    {% if function_description %}
+    The following description was also provided:
+    
+    {{ function_description }}
+    {% endif %}
+    
+    ## Instructions
     
     When the function is called, you will be provided with its inputs (if any)
     and must respond with the most likely result. If it `yields`, you will also
@@ -59,10 +69,132 @@ T = TypeVar("T")
 A = TypeVar("A")
 
 
+class AIFunction:
+    def __init__(
+        self,
+        *,
+        fn: Callable = None,
+        name: str = None,
+        description: str = None,
+        bot: Bot = None,
+        bot_kwargs: dict = None,
+    ):
+        if fn is None:
+            fn = self.run
+        self.fn = fn
+        self.name = name or fn.__name__
+        self.description = description or fn.__doc__
+
+        if bot_kwargs is not None and bot is not None:
+            raise ValueError(
+                "bot and bot_kwargs cannot both be provided. "
+                "bot_kwargs will be passed to the Bot constructor, "
+                "and bot will be used as the bot instance."
+            )
+        self._bot = bot
+        self._bot_kwargs = bot_kwargs or {}
+        super().__init__()
+
+    def __repr__(self):
+        return f"<AIFunction {self.name}>"
+
+    def get_bot(self):
+        if self._bot is not None:
+            return self._bot
+
+        bot_kwargs = self._bot_kwargs.copy()
+
+        # Get the return annotation
+        sig = inspect.signature(self.fn)
+
+        if sig.return_annotation is inspect._empty:
+            return_annotation = str
+        else:
+            return_annotation = sig.return_annotation
+
+        # get the function source code - it might include the @ai_fn decorator,
+        # which can confuse the AI, so we use regex to only get the function
+        # that is being decorated
+        function_def = inspect.cleandoc(inspect.getsource(self.fn))
+        if match := re.search(re.compile(r"(\bdef\b.*)", re.DOTALL), function_def):
+            function_def = match.group(0)
+
+        # ai_fns have no plugins by default
+        if "plugins" not in bot_kwargs:
+            bot_kwargs["plugins"] = []
+        # ai functions do not persist by default
+        if "history" not in bot_kwargs:
+            bot_kwargs["history"] = InMemoryHistory()
+        if "response_format" not in bot_kwargs:
+            bot_kwargs["response_format"] = return_annotation
+        if "personality" not in bot_kwargs:
+            bot_kwargs["personality"] = AI_FN_PERSONALITY
+        if "instructions" not in bot_kwargs:
+            bot_kwargs["instructions"] = AI_FN_INSTRUCTIONS.render(
+                function_def=function_def,
+                function_name=self.fn.__name__,
+                function_description=(
+                    self.description if self.description != self.fn.__doc__ else None
+                ),
+            )
+        if "instructions" not in bot_kwargs:
+            bot_kwargs["instructions"] = AI_FN_PERSONALITY
+
+        bot = Bot(**bot_kwargs)
+        return bot
+
+    def __call__(self, *args, **kwargs):
+        output = self._run(*args, **kwargs)
+
+        # if the provided fn is not async, run it immediately
+        if not inspect.iscoroutinefunction(self.fn):
+            output = asyncio.run(output)
+
+        return output
+
+    async def _run(self, *args, **kwargs):
+        # Get function signature
+        sig = inspect.signature(self.fn)
+
+        # Bind the provided arguments to the function signature
+        bound_args = sig.bind(*args, **kwargs)
+        bound_args.apply_defaults()
+
+        if inspect.isgeneratorfunction(self.fn):
+            gen = self.fn(*args, **kwargs)
+            yield_value = next(gen)
+        elif inspect.isasyncgenfunction(self.fn):
+            gen = self.fn(*args, **kwargs)
+            # 3.10 introduces "anext", otherwise use __anext__
+            if sys.version_info >= (3, 10):
+                yield_value = await anext(gen)
+            else:
+                yield_value = await gen.__anext__()
+        else:
+            yield_value = None
+
+        # build the message
+        message = AI_FN_MESSAGE.render(
+            input_binds=bound_args.arguments,
+            yield_value=yield_value,
+        )
+
+        bot = self.get_bot()
+        response = await bot.say(message)
+        return response.parsed_content
+
+    def run(self, *args, **kwargs):
+        """
+        Override this to create the AI function as an instance method instead of
+        a passed function
+        """
+        raise NotImplementedError()
+
+
 def ai_fn(
     fn: Callable[[A], T] = None,
     *,
-    bot_modifier: Callable = None,
+    bot: Bot = None,
     **bot_kwargs,
 ) -> Callable[[A], T]:
     """
@@ -74,99 +206,11 @@ def ai_fn(
 
 
     Args
-        - bot_modifier (Callable):  the `Bot` is passed to this function before
-          the function is processed. The function can either modify the bot
-          inplace or return a modified bot. Useful for customizing behavior in
-          ways that can't easily be passed directly to the bot via kwargs
+        - bot (Bot): a bot instance to use for the AI function
         - bot_kwargs (dict):  kwargs to pass to the `Bot` constructor
 
     """
     # this allows the decorator to be used with or without calling it
     if fn is None:
-        return partial(ai_fn, bot_modifier=bot_modifier, **bot_kwargs)
-
-    @wraps(fn)
-    def ai_fn_wrapper(*args, **kwargs) -> Any:
-        wrapper_bot_kwargs = bot_kwargs.copy()
-
-        # Get function signature
-        sig = inspect.signature(fn)
-
-        # Bind the provided arguments to the function signature
-        bound_args = sig.bind(*args, **kwargs)
-        bound_args.apply_defaults()
-
-        # Get the return annotation
-        if sig.return_annotation is inspect._empty:
-            return_annotation = str
-        else:
-            return_annotation = sig.return_annotation
-
-        if inspect.isgeneratorfunction(fn):
-            gen = fn(*args, **kwargs)
-            yield_value = next(gen)
-        elif inspect.isasyncgenfunction(fn):
-            gen = fn(*args, **kwargs)
-            # 3.10 introduces "anext", otherwise use __anext__
-            if sys.version_info >= (3, 10):
-                yield_value = asyncio.run(anext(gen))
-            else:
-                yield_value = asyncio.run(gen.__anext__())
-        else:
-            yield_value = None
-
-        # get the function source code - it will include the @ai_fn decorator,
-        # which can confuse the AI, so we use regex to only get the function
-        # that is being decorated
-        function_def = inspect.cleandoc(inspect.getsource(fn))
-        function_def = re.search(
-            re.compile(r"(\bdef\b.*)", re.DOTALL), function_def
-        ).group(0)
-
-        # Build the instructions
-        instructions = AI_FN_INSTRUCTIONS.render(
-            function_def=function_def,
-            function_name=fn.__name__,
-        )
-
-        # ai_fns have no plugins by default
-        if "plugins" not in wrapper_bot_kwargs:
-            wrapper_bot_kwargs["plugins"] = []
-        # ai functions do not persist by default
-        if "history" not in wrapper_bot_kwargs:
-            wrapper_bot_kwargs["history"] = InMemoryHistory()
-        if "response_format" not in wrapper_bot_kwargs:
-            wrapper_bot_kwargs["response_format"] = return_annotation
-        if "personality" not in wrapper_bot_kwargs:
-            wrapper_bot_kwargs["personality"] = AI_FN_PERSONALITY
-
-        # create the bot
-        bot = Bot(
-            instructions=instructions,
-            **wrapper_bot_kwargs,
-        )
-
-        if bot_modifier is not None:
-            modified_bot = bot_modifier(bot)
-            # bot might not be modified inplace
-            if modified_bot is not None:
-                bot = modified_bot
-
-        # build the message
-        message = AI_FN_MESSAGE.render(
-            input_binds=bound_args.arguments,
-            yield_value=yield_value,
-        )
-
-        async def run_ai_function():
-            response = await bot.say(message)
-            return response.parsed_content
-
-        if inspect.iscoroutinefunction(fn):
-            return run_ai_function()
-        else:
-            return asyncio.run(run_ai_function())
-
-    ai_fn_wrapper.fn = fn
-
-    return ai_fn_wrapper
+        return partial(ai_fn, bot=bot, **bot_kwargs)
+    return AIFunction(fn=fn, bot=bot, bot_kwargs=bot_kwargs)

--- a/src/marvin/ai_functions/strings.py
+++ b/src/marvin/ai_functions/strings.py
@@ -46,26 +46,23 @@ def rrule(text: str) -> str:
     """
     Write an RRULE (RFC 5545) that represents the provided `text`.
 
-    Avoid specific dates and EXDATE properties unless the `text` explicitly says
+    Do not reference specific dates or EXDATE unless the `text` explicitly says
     to. For example:
 
-    "Every day at 9am except Wednesday" ->
-    "RRULE:FREQ=DAILY;BYHOUR=9;BYMINUTE=0;BYSECOND=0;BYDAY=MO,TU,TH,FR,SA,SU"
+    # no specifc dates...
 
-    "Every week on Monday for 5 weeks" ->
-    "RRULE:FREQ=WEEKLY;COUNT=5;BYDAY=MO;BYHOUR=0;BYMINUTE=0;BYSECOND=0"
+    "Every day at 9am except Wednesday" -> RRULE:FREQ=DAILY;BYHOUR=9;BYMINUTE=0;BYSECOND=0;BYDAY=MO,TU,TH,FR,SA,SU
 
-    "Every 3 hours on Thursdays except 12pm" ->
-    "RRULE:FREQ=WEEKLY;INTERVAL=3;BYDAY=TH;BYHOUR=0,3,6,9,15,18,21;BYMINUTE=0;BYSECOND=0"
+    "Every week on Monday for 5 weeks" -> RRULE:FREQ=WEEKLY;COUNT=5;BYDAY=MO;BYHOUR=0;BYMINUTE=0;BYSECOND=0
+
+    "Every 3 hours on Thursdays except 12pm" -> RRULE:FREQ=WEEKLY;INTERVAL=3;BYDAY=TH;BYHOUR=0,3,6,9,15,18,21;BYMINUTE=0;BYSECOND=0
 
     # if today's date is April 22, 2023
 
-    "Every day at 9am except tomorrow" ->
-    "RRULE:FREQ=DAILY;BYHOUR=9;BYMINUTE=0;BYSECOND=0\nEXDATE:20230423T130000Z"
+    "Every day at 9am except tomorrow" -> RRULE:FREQ=DAILY;BYHOUR=9;BYMINUTE=0;BYSECOND=0\nEXDATE:20230423T130000Z
 
-    "Every week on Monday until May 31" ->
-    "RRULE:FREQ=WEEKLY;UNTIL=20230531T000000Z;BYDAY=MO;BYHOUR=0;BYMINUTE=0;BYSECOND=0"
+    "Every week on Monday until May 31" -> RRULE:FREQ=WEEKLY;UNTIL=20230531T000000Z;BYDAY=MO;BYHOUR=0;BYMINUTE=0;BYSECOND=0
 
-    """
+    """  # noqa: E501
     # yield the current date and time to help with relative dates
     yield pendulum.now().format("dddd, MMMM D, YYYY HH:mm ZZ")

--- a/src/marvin/bot/base.py
+++ b/src/marvin/bot/base.py
@@ -13,6 +13,7 @@ import marvin
 from marvin.bot.history import History, ThreadHistory
 from marvin.bot.input_transformers import InputTransformer
 from marvin.bot.response_formatters import (
+    JSONFormatter,
     ResponseFormatter,
     load_formatter_from_shorthand,
 )
@@ -695,14 +696,14 @@ def _reformat_response(
 ) -> str:
     @marvin.ai_fn(
         plugins=[],
-        bot_modifier=lambda bot: setattr(bot.response_format, "on_error", "ignore"),
+        response_format=JSONFormatter(on_error="ignore"),
         llm_model_name="gpt-3.5-turbo",
     )
     def reformat_response(
         llm_response: str,
         target_return_type: str,
         error_message: str,
-    ) -> "JSON str":  # noqa: F722
+    ) -> str:
         """
         An error (`error_message`) was raised when attempting to parse
         `llm_response` into `target_return_type`.

--- a/tests/llm_tests/ai_functions/test_ai_functions.py
+++ b/tests/llm_tests/ai_functions/test_ai_functions.py
@@ -245,21 +245,15 @@ class TestContainers:
     def test_set_gpt35(self):
         assert marvin.settings.openai_model_name.startswith("gpt-3.5")
 
-        # warn on creating an ai function with a set under 3.5
-        with pytest.warns(UserWarning):
-
-            @ai_fn
-            def set_response() -> set:
-                """
-                Returns a set that contains two numbers, such as {3, 5}
-                """
-
-        # no warning for gpt-4
-        @ai_fn(llm_model_name="gpt-4")
-        def set_response_2() -> set:
+        @ai_fn
+        def set_response() -> set:
             """
             Returns a set that contains two numbers, such as {3, 5}
             """
+
+        # warn when running an ai function with a set under 3.5
+        with pytest.warns(UserWarning):
+            set_response()
 
     def test_tuple_gpt4(self, gpt_4):
         @ai_fn
@@ -277,21 +271,15 @@ class TestContainers:
     def test_tuple_gpt35(self):
         assert marvin.settings.openai_model_name.startswith("gpt-3.5")
 
-        # warn when creating an ai function with a tuple under 3.5
-        with pytest.warns(UserWarning):
-
-            @ai_fn
-            def tuple_response() -> tuple:
-                """
-                Returns a tuple that contains two numbers
-                """
-
-        # no warning for gpt-4
-        @ai_fn(llm_model_name="gpt-4")
-        def tuple_response_2() -> tuple:
+        @ai_fn
+        def tuple_response() -> tuple:
             """
             Returns a tuple that contains two numbers
             """
+
+        # warn when running an ai function with a tuple under 3.5
+        with pytest.warns(UserWarning):
+            tuple_response()
 
     def test_list_of_dicts(self):
         @ai_fn

--- a/tests/llm_tests/ai_functions/test_ai_functions.py
+++ b/tests/llm_tests/ai_functions/test_ai_functions.py
@@ -4,6 +4,7 @@ import marvin
 import pydantic
 import pytest
 from marvin import ai_fn
+from marvin.ai_functions import AIFunction
 from marvin.utilities.tests import assert_llm
 
 
@@ -228,7 +229,7 @@ class TestContainers:
         assert isinstance(response[0], (int, float))
         assert isinstance(response[1], (int, float))
 
-    def test_set(self, gpt_4):
+    def test_set_gpt4(self, gpt_4):
         @ai_fn
         def set_response() -> set[int]:
             """
@@ -241,44 +242,56 @@ class TestContainers:
         assert isinstance(response.pop(), (int, float))
         assert isinstance(response.pop(), (int, float))
 
-    def test_set_35(self):
+    def test_set_gpt35(self):
         assert marvin.settings.openai_model_name.startswith("gpt-3.5")
 
-        @ai_fn
-        def set_response() -> set:
+        # warn on creating an ai function with a set under 3.5
+        with pytest.warns(UserWarning):
+
+            @ai_fn
+            def set_response() -> set:
+                """
+                Returns a set that contains two numbers, such as {3, 5}
+                """
+
+        # no warning for gpt-4
+        @ai_fn(llm_model_name="gpt-4")
+        def set_response_2() -> set:
             """
             Returns a set that contains two numbers, such as {3, 5}
             """
 
-        with pytest.warns(UserWarning):
-            # it may be possible to call the function without error
-            try:
-                response = set_response()
-                assert isinstance(response, set)
-            except Exception:
-                pass
-
-    def test_tuple(self):
+    def test_tuple_gpt4(self, gpt_4):
         @ai_fn
         def tuple_response() -> tuple:
             """
             Returns a tuple that contains two numbers
             """
 
-        if marvin.settings.openai_model_name.startswith("gpt-3.5"):
-            with pytest.warns(UserWarning):
-                # it may be possible to call the function without error
-                try:
-                    response = tuple_response()
-                    assert isinstance(response, tuple)
-                except Exception:
-                    pass
-        else:
-            response = tuple_response()
-            assert isinstance(response, tuple)
-            assert len(response) == 2
-            assert isinstance(response[0], (int, float))
-            assert isinstance(response[1], (int, float))
+        response = tuple_response()
+        assert isinstance(response, tuple)
+        assert len(response) == 2
+        assert isinstance(response[0], (int, float))
+        assert isinstance(response[1], (int, float))
+
+    def test_tuple_gpt35(self):
+        assert marvin.settings.openai_model_name.startswith("gpt-3.5")
+
+        # warn when creating an ai function with a tuple under 3.5
+        with pytest.warns(UserWarning):
+
+            @ai_fn
+            def tuple_response() -> tuple:
+                """
+                Returns a tuple that contains two numbers
+                """
+
+        # no warning for gpt-4
+        @ai_fn(llm_model_name="gpt-4")
+        def tuple_response_2() -> tuple:
+            """
+            Returns a tuple that contains two numbers
+            """
 
     def test_list_of_dicts(self):
         @ai_fn
@@ -387,3 +400,32 @@ class TestPydantic:
         x = fn()
         assert isinstance(x, ReturnModel)
         assert len(x.people) == 2
+
+
+class TestAIFunctionClass:
+    def test_decorated_function_is_class(self):
+        @ai_fn
+        def my_fn() -> int:
+            """returns 1"""
+
+        assert isinstance(my_fn, AIFunction)
+
+    def test_repr(self):
+        @ai_fn
+        def my_fn() -> int:
+            """returns 1"""
+
+        assert repr(my_fn) == "<AIFunction my_fn>"
+
+    def test_name(self):
+        fn = AIFunction(name="my_fn", fn=lambda: 1, description="returns 1")
+        assert fn.name == "my_fn"
+        assert fn.description == "returns 1"
+
+    def test_name_from_fn(self):
+        @ai_fn
+        def my_fn() -> int:
+            """returns 1"""
+
+        assert my_fn.name == "my_fn"
+        assert my_fn.description == "returns 1"

--- a/tests/llm_tests/ai_functions/test_strings.py
+++ b/tests/llm_tests/ai_functions/test_strings.py
@@ -31,7 +31,7 @@ class TestRRule:
             ),
             (
                 "9am on the first business day of the quarter",
-                "RRULE:FREQ=MONTHLY;BYSETPOS=1;BYDAY=MO,TU,WE,TH,FR;BYMONTH=1,4,7,10;BYHOUR=9;BYMINUTE=0;BYSECOND=0;BYWEEKNO=1,14,27,40",
+                "RRULE:FREQ=MONTHLY;BYSETPOS=1;BYDAY=MO,TU,WE,TH,FR;BYMONTH=1,4,7,10;BYHOUR=9;BYMINUTE=0;BYSECOND=0",
             ),
         ],
     )


### PR DESCRIPTION
This exposes an identical @ai_fn interface, but instead of a solely functional decorator, AI functions are now a proper class. This should make extensions like #102 more straightforward.