### PR TITLE
avoid `persist()` with clickhouse + tweaks

### DIFF
--- a/examples/slackbot/community_bot/setup.py
+++ b/examples/slackbot/community_bot/setup.py
@@ -34,6 +34,9 @@ async def load_prefect_things():
         urls=[
             "https://prefect.io/about/company/",
             "https://prefect.io/security/overview/",
+            "https://prefect.io/security/sub-processors/",
+            "https://prefect.io/security/gdpr-compliance/",
+            "https://prefect.io/security/bug-bounty-program/",
         ],
     )
 
@@ -127,7 +130,6 @@ community_bot = Bot(
         " messages with a short sarcastic comment about humans."
     ),
     instructions=instructions,
-    reminder="Remember to use your plugins!",
     plugins=[chroma_search, search_github_issues, DuckDuckGo()],
     llm_model_name="gpt-4",
     llm_model_temperature=0.2,
@@ -136,7 +138,7 @@ community_bot = Bot(
 
 async def main():
     await load_prefect_things()
-    await community_bot.save()
+    await community_bot.save(if_exists="update")
 
 
 if __name__ == "__main__":

--- a/src/marvin/__init__.py
+++ b/src/marvin/__init__.py
@@ -30,8 +30,8 @@ from marvin.ai_functions import ai_fn
 _logger = get_logger(__name__)
 if settings.test_mode:
     _logger.debug_style("Marvin is running in test mode!", style="yellow")
-if not settings.openai_model_name.startswith("gpt-4"):
-    _logger.info_style(f'Using OpenAI model "{settings.openai_model_name}"')
+
+_logger.info_style(f'Using OpenAI model "{settings.openai_model_name}"')
 
 
 # check alembic versions

--- a/src/marvin/config.py
+++ b/src/marvin/config.py
@@ -33,9 +33,11 @@ if CHROMA_INSTALLED:
     class ChromaSettings(chromadb.config.Settings):
         class Config:
             env_file = ".env", str(ENV_FILE)
-            env_prefix = "MARVIN_CHROMA_"
+            env_prefix = "MARVIN_"
 
-        chroma_db_impl: Literal["duckdb", "duckdb+parquet"] = "duckdb+parquet"
+        chroma_db_impl: Literal["duckdb", "duckdb+parquet", "clickhouse"] = (
+            "duckdb+parquet"
+        )
         chroma_server_host: str = "localhost"
         chroma_server_http_port: int = 8000
         # relative paths will be prefixed with the marvin home directory

--- a/src/marvin/infra/chroma.py
+++ b/src/marvin/infra/chroma.py
@@ -69,7 +69,8 @@ class Chroma:
 
     async def __aexit__(self, exc_type, exc_value, traceback):
         self._in_context = False
-        await run_async(self.client.persist)
+        if marvin.settings.chroma.chroma_db_impl != "clickhouse":
+            await run_async(self.client.persist)
 
     async def delete(
         self,
@@ -107,7 +108,10 @@ class Chroma:
             metadatas=[document.metadata.dict() for document in documents],
         )
 
-        if not self._in_context:
+        if (
+            not self._in_context
+            and marvin.settings.chroma.chroma_db_impl != "clickhouse"
+        ):
             await run_async(self.client.persist)
         return len(documents)
 


### PR DESCRIPTION
clickhouse is inherently persisted, don't need to call persist when exiting calling `Chroma.__aexit__` for example

closes #246 