### PR TITLE
fix #261 got IndexError while call talk_to_bot API

### DIFF
--- a/src/marvin/api/bots.py
+++ b/src/marvin/api/bots.py
@@ -124,7 +124,7 @@ async def talk_to_bot(
     """
     bot = await marvin.Bot.load(name=name)
     await bot.set_thread(thread_lookup_key=thread_lookup_key)
-    response = await bot.say(message=message)
+    response = await bot.say(message)
     return MessageRead(**response.dict())
 
 


### PR DESCRIPTION
fix #261 

Currently, the default input_prompt was set to "{0}", which caused `bot.say` to throw an exception when receiving keyword arguments. However, all other uses of bot.say already utilized positional arguments. Therefore, I modified this line to use positional arguments as well, resolving the issue.