### PR TITLE
emit event upon slackbot response

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
   - repo: https://github.com/charliermarsh/ruff-pre-commit
     # Ruff version.
-    rev: 'v0.0.262'
+    rev: 'v0.0.269'
     hooks:
       - id: ruff
         args: [--fix]
@@ -10,5 +10,4 @@ repos:
     rev: 23.3.0
     hooks:
       - id: black
-        args: ["--preview"]
-        language_version: python3.9
+        args: ["--preview", "--target-version=py310"]

--- a/src/marvin/config.py
+++ b/src/marvin/config.py
@@ -7,6 +7,8 @@ from typing import List, Literal, Optional, Union
 try:
     import chromadb
 
+    print(chromadb.config.Settings, type(chromadb.config.Settings))
+
     CHROMA_INSTALLED = True
 except ModuleNotFoundError:
     CHROMA_INSTALLED = False

--- a/src/marvin/config.py
+++ b/src/marvin/config.py
@@ -7,8 +7,6 @@ from typing import List, Literal, Optional, Union
 try:
     import chromadb
 
-    print(chromadb.config.Settings, type(chromadb.config.Settings))
-
     CHROMA_INSTALLED = True
 except ModuleNotFoundError:
     CHROMA_INSTALLED = False

--- a/src/marvin/server/slackbot.py
+++ b/src/marvin/server/slackbot.py
@@ -341,12 +341,13 @@ async def _handle_approve_response(action: SlackAction):
     asking_user = action_value.get("asking_user")
     editing_user = action.user["id"]
 
-    feedback = f"""**{action_value["question"]}**\n\n
+    question_answer = f"""**{action_value["question"]}**\n\n
     
     {action_value["proposed_answer"]}
     """  # noqa
 
-    await create_chroma_document(text=feedback)
+    # creates and saves a document to chroma
+    await create_chroma_document(text=question_answer)
 
     await _slack_api_call(
         "POST",

--- a/src/marvin/server/slackbot.py
+++ b/src/marvin/server/slackbot.py
@@ -407,7 +407,7 @@ async def _slackbot_response(event: SlackEvent):
     response_tokens = count_tokens(response.content)
 
     # this will do nothing if Prefect credentials are not configured
-    emit_event(  # fmt: off
+    emit_event(
         event=f"bot.{bot.name.lower()}.responded",
         resource={"prefect.resource.id": f"bot.{bot.name.lower()}"},
         payload={
@@ -420,7 +420,7 @@ async def _slackbot_response(event: SlackEvent):
             "response_tokens": response_tokens,
             "total_tokens": prompt_tokens + response_tokens,
         },
-    )  # fmt: on
+    )
 
     if marvin.settings.QA_slack_bot_responses:
         await _post_QA_message(

--- a/src/marvin/utilities/meta.py
+++ b/src/marvin/utilities/meta.py
@@ -17,8 +17,8 @@ async def create_chroma_document(
 ):
     processed_feedback = await Document(
         text=text,
+        source="slack",
         metadata={
-            "source": "user feedback",
             "created_at": pendulum.now().isoformat(),
             **kwargs,
         },

--- a/tests/fixtures/infra.py
+++ b/tests/fixtures/infra.py
@@ -1,5 +1,4 @@
 import marvin
-import marvin.config
 import pytest
 import sqlmodel
 
@@ -28,13 +27,13 @@ async def clear_test_database(test_database, session):
     await session.commit()
 
 
-@pytest.fixture(autouse=True, scope="session")
-async def temporary_chromadb(session_tmp_path):
-    """Run chroma in a temporary directory"""
-    marvin.settings.chroma = marvin.config.ChromaSettings(
-        **marvin.settings.chroma.dict(exclude={"persist_directory"}),
-        persist_directory=str(session_tmp_path / "chroma"),
-    )
+# @pytest.fixture(autouse=True, scope="session")
+# async def temporary_chromadb(session_tmp_path):
+#     """Run chroma in a temporary directory"""
+#     marvin.settings.chroma = marvin.config.ChromaSettings(
+#         **marvin.settings.chroma.dict(exclude={"persist_directory"}),
+#         persist_directory=str(session_tmp_path / "chroma"),
+#     )
 
 
 @pytest.fixture

--- a/tests/fixtures/infra.py
+++ b/tests/fixtures/infra.py
@@ -27,15 +27,6 @@ async def clear_test_database(test_database, session):
     await session.commit()
 
 
-# @pytest.fixture(autouse=True, scope="session")
-# async def temporary_chromadb(session_tmp_path):
-#     """Run chroma in a temporary directory"""
-#     marvin.settings.chroma = marvin.config.ChromaSettings(
-#         **marvin.settings.chroma.dict(exclude={"persist_directory"}),
-#         persist_directory=str(session_tmp_path / "chroma"),
-#     )
-
-
 @pytest.fixture
 async def session():
     async with marvin.infra.database.session_context() as session:


### PR DESCRIPTION
```python
async def _slackbot_response(event: SlackEvent):

    ...

    response = await bot.say(text)

    slack_response = await _post_message(
        channel=event.channel, message=response.content, thread_ts=event.ts
    )

    prompt_tokens = count_tokens(text)
    response_tokens = count_tokens(response.content)

    # this will do nothing if Prefect credentials are not configured
    emit_event(
        event=f"bot.{bot.name.lower()}.responded",
        resource={"prefect.resource.id": f"bot.{bot.name.lower()}"},
        payload={
            "user": event.user,
            "channel": event.channel,
            "thread_ts": thread,
            "text": text,
            "response": response.content,
            "prompt_tokens": prompt_tokens,
            "response_tokens": response_tokens,
            "total_tokens": prompt_tokens + response_tokens,
        },
    )
    
    ...
```