### PR TITLE
move out prompt generation from _run to own _method

### DIFF
--- a/src/marvin/ai_functions/base.py
+++ b/src/marvin/ai_functions/base.py
@@ -151,7 +151,7 @@ class AIFunction:
             output = asyncio.run(output)
 
         return output
-    
+
     async def __prompt__(self, *args, **kwargs):
         # Get function signature
         sig = inspect.signature(self.fn)
@@ -178,6 +178,7 @@ class AIFunction:
             input_binds=bound_args.arguments,
             yield_value=yield_value,
         )
+        return message
 
     async def _run(self, *args, **kwargs):
         message = await self.__prompt__(*args, **kwargs)

--- a/src/marvin/ai_functions/base.py
+++ b/src/marvin/ai_functions/base.py
@@ -151,8 +151,8 @@ class AIFunction:
             output = asyncio.run(output)
 
         return output
-
-    async def _run(self, *args, **kwargs):
+    
+    async def __prompt__(self, *args, **kwargs):
         # Get function signature
         sig = inspect.signature(self.fn)
 
@@ -179,6 +179,8 @@ class AIFunction:
             yield_value=yield_value,
         )
 
+    async def _run(self, *args, **kwargs):
+        message = await self.__prompt__(*args, **kwargs)
         bot = self.get_bot()
         response = await bot.say(message)
         return response.parsed_content


### PR DESCRIPTION
Separating out prompt generation from prompt 'execution'. 
- Enables visibility into prompt before actual execution. 