### PR TITLE
implements mapping for `ai_fn` and `ai_model`

### DIFF
--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -2,3 +2,4 @@ from .infra import *
 from .objects import *
 from .rest_api import *
 from .llms import *
+from .prefect_utils import *

--- a/tests/fixtures/prefect_utils.py
+++ b/tests/fixtures/prefect_utils.py
@@ -1,0 +1,8 @@
+import pytest
+from prefect.testing.utilities import prefect_test_harness
+
+
+@pytest.fixture(scope="session")
+def prefect_db():
+    with prefect_test_harness():
+        yield

--- a/tests/llm_tests/ai_functions/test_ai_functions.py
+++ b/tests/llm_tests/ai_functions/test_ai_functions.py
@@ -417,3 +417,19 @@ class TestAIFunctionClass:
 
         assert my_fn.name == "my_fn"
         assert my_fn.description == "returns 1"
+
+
+class TestAIFunctionMapping:
+    def test_mapping_sync(self, prefect_db):
+        @ai_fn
+        def opposite(thing: str) -> str:
+            """returns the opposite of the input"""
+
+        assert opposite.map(["up", "happy"]) == ["down", "sad"]
+
+    async def test_mapping_async(self, prefect_db):
+        @ai_fn
+        async def opposite(thing: str) -> str:
+            """returns the opposite of the input"""
+
+        assert await opposite.map(["up", "happy"]) == ["down", "sad"]

--- a/tests/llm_tests/ai_models/test_ai_models.py
+++ b/tests/llm_tests/ai_models/test_ai_models.py
@@ -131,3 +131,29 @@ class TestAIModels:
                 ]
             )
         )
+
+
+class TestAIModelsMapping:
+    def test_mapping_sync(self, prefect_db):
+        @ai_model
+        class CardinalDirection(pydantic.BaseModel):
+            """use a single capital letter for each cardinal direction."""
+
+            direction: str
+
+        assert CardinalDirection.map(["sunrise", "sunset"]) == [
+            CardinalDirection(direction="E"),
+            CardinalDirection(direction="W"),
+        ]
+
+    async def test_mapping_async(self, prefect_db):
+        @ai_model
+        class CardinalDirection(pydantic.BaseModel):
+            """use a single capital letter for each cardinal direction."""
+
+            direction: str
+
+        assert await CardinalDirection.map(["sunrise", "sunset"]) == [
+            CardinalDirection(direction="E"),
+            CardinalDirection(direction="W"),
+        ]

--- a/tests/llm_tests/ai_models/test_ai_models.py
+++ b/tests/llm_tests/ai_models/test_ai_models.py
@@ -140,10 +140,11 @@ class TestAIModelsMapping:
             """use a single capital letter for each cardinal direction."""
 
             direction: str
+            degrees: int
 
         assert CardinalDirection.map(["sunrise", "sunset"]) == [
-            CardinalDirection(direction="E"),
-            CardinalDirection(direction="W"),
+            CardinalDirection(direction="E", degrees=90),
+            CardinalDirection(direction="W", degrees=270),
         ]
 
     async def test_mapping_async(self, prefect_db):
@@ -152,8 +153,9 @@ class TestAIModelsMapping:
             """use a single capital letter for each cardinal direction."""
 
             direction: str
+            degrees: int
 
         assert await CardinalDirection.map(["sunrise", "sunset"]) == [
-            CardinalDirection(direction="E"),
-            CardinalDirection(direction="W"),
+            CardinalDirection(direction="E", degrees=90),
+            CardinalDirection(direction="W", degrees=270),
         ]


### PR DESCRIPTION
uses `sync_compatible` to enable sync or async mapping, depending on the caller's context

and adds basic test coverage

## ai functions
```python
In [1]: from marvin import ai_fn, ai_model

In [2]: @ai_fn(llm_model_name="gpt-3.5-turbo")
   ...: def opposite(thing: str) -> str:
   ...:     """returns the opposite of 'thing'"""
   ...:

In [3]: opposite.map(["up", "happy", "night"])
15:11:04.107 | INFO    | prefect.engine - Created flow run 'famous-spider' for flow 'opposite'
15:11:04.785 | INFO    | Flow run 'famous-spider' - Created task run 'opposite-1' for task 'opposite'
15:11:04.786 | INFO    | Flow run 'famous-spider' - Submitted task run 'opposite-1' for execution.
15:11:04.804 | INFO    | Flow run 'famous-spider' - Created task run 'opposite-2' for task 'opposite'
15:11:04.805 | INFO    | Flow run 'famous-spider' - Submitted task run 'opposite-2' for execution.
15:11:04.810 | INFO    | Flow run 'famous-spider' - Created task run 'opposite-0' for task 'opposite'
15:11:04.811 | INFO    | Flow run 'famous-spider' - Submitted task run 'opposite-0' for execution.
15:11:06.336 | INFO    | Task run 'opposite-1' - Finished in state Completed()
15:11:06.685 | INFO    | Task run 'opposite-2' - Finished in state Completed()
15:11:06.739 | INFO    | Task run 'opposite-0' - Finished in state Completed()
15:11:06.868 | INFO    | Flow run 'famous-spider' - Finished in state Completed('All states completed.')

Out[3]: ['down', 'sad', 'day']

In [5]: from prefect.tasks import task_input_hash

In [6]: opposite.map(["up", "happy", "night"], task_kwargs={"cache_key_fn": task_input_hash})

15:13:32.148 | INFO    | prefect.engine - Created flow run 'cute-urchin' for flow 'opposite'
15:13:32.850 | INFO    | Flow run 'cute-urchin' - Created task run 'opposite-0' for task 'opposite'
15:13:32.852 | INFO    | Flow run 'cute-urchin' - Submitted task run 'opposite-0' for execution.
15:13:32.869 | INFO    | Flow run 'cute-urchin' - Created task run 'opposite-1' for task 'opposite'
15:13:32.870 | INFO    | Flow run 'cute-urchin' - Submitted task run 'opposite-1' for execution.
15:13:32.874 | INFO    | Flow run 'cute-urchin' - Created task run 'opposite-2' for task 'opposite'
15:13:32.874 | INFO    | Flow run 'cute-urchin' - Submitted task run 'opposite-2' for execution.
15:13:33.148 | INFO    | Task run 'opposite-2' - Finished in state Cached(type=COMPLETED)
15:13:33.151 | INFO    | Task run 'opposite-1' - Finished in state Cached(type=COMPLETED)
15:13:33.342 | INFO    | Task run 'opposite-0' - Finished in state Cached(type=COMPLETED)
15:13:33.478 | INFO    | Flow run 'cute-urchin' - Finished in state Completed('All states completed.')
Out[6]: ['down', 'sad', 'day']
```

## ai models
```python
In [10]: @ai_model(llm_model_name='gpt-3.5-turbo')
    ...: class Location(BaseModel):
    ...:     city: str
    ...:     state: str
    ...:

In [11]: Location.map(["windy city", "big apple", "mile high city"])
15:14:48.856 | INFO    | prefect.engine - Created flow run 'successful-axolotl' for flow 'Location'
15:14:49.681 | INFO    | Flow run 'successful-axolotl' - Created task run 'Location-0' for task 'Location'
15:14:49.684 | INFO    | Flow run 'successful-axolotl' - Submitted task run 'Location-0' for execution.
15:14:49.701 | INFO    | Flow run 'successful-axolotl' - Created task run 'Location-2' for task 'Location'
15:14:49.702 | INFO    | Flow run 'successful-axolotl' - Submitted task run 'Location-2' for execution.
15:14:49.799 | INFO    | Flow run 'successful-axolotl' - Created task run 'Location-1' for task 'Location'
15:14:49.799 | INFO    | Flow run 'successful-axolotl' - Submitted task run 'Location-1' for execution.

15:14:53.640 | INFO    | Task run 'Location-1' - Finished in state Completed()
15:14:53.651 | INFO    | Task run 'Location-2' - Finished in state Completed()
15:14:54.793 | INFO    | Task run 'Location-0' - Finished in state Completed()
15:14:54.967 | INFO    | Flow run 'successful-axolotl' - Finished in state Completed('All states completed.')

Out[11]:
[Location(city='Chicago', state='Illinois'),
 Location(city='New York', state='New York'),
 Location(city='Denver', state='Colorado')]
```