### PR TITLE
Added support for Azure OpenAI APIs

### DIFF
--- a/src/marvin/config.py
+++ b/src/marvin/config.py
@@ -102,6 +102,11 @@ class Settings(BaseSettings):
     llm_request_timeout_seconds: Union[float, List[float], None] = Field(
         600.0, env=["MARVIN_LLM_REQUEST_TIMEOUT_SETTING"]
     )
+    openai_api_type = Field(
+        "", env=["OPENAI_API_TYPE"]
+    )
+    openai_model_type: str = "chat_model"
+    openai_llm_settings: dict = dict()
 
     # CHROMA
     chroma: ChromaSettings = Field(default_factory=ChromaSettings)


### PR DESCRIPTION
1. support of using AzureOpen APIs
2. support for both chat_model API and LLM API
3. support for customized settings for the OpenAI API calls

The change is 100% compatible with exsiting code and can be tested using the following code.

```
import os
os.environ['OPENAI_API_KEY'] = "your key"
os.environ["OPENAI_API_TYPE"] = "azure"
os.environ["OPENAI_API_BASE"] = "https://azeus-openai-01.openai.azure.com/"
os.environ["OPENAI_API_VERSION"] = "2023-03-15-preview"

from marvin import settings
settings.openai_model_type = "llm"
settings.openai_model_temperature = 0
settings.openai_model_max_tokens = 4000
settings.openai_model_name = "gpt-4-turbo"
settings.openai_llm_settings = {
    'engine': "gpt-4",
}

from marvin import ai_fn
@ai_fn
def list_fruits(n: int) -> list[str]:
    """Generate a list of n fruits"""


list_fruits(n=3) # ["apple", "banana", "orange"]
```
