### PR TITLE
Add huggingfacehub support

### DIFF
--- a/src/marvin/bot/base.py
+++ b/src/marvin/bot/base.py
@@ -598,9 +598,18 @@ class Bot(MarvinBaseModel, LoggerMixin):
                 "Sending messages to LLM", messages_repr, key_style="green"
             )
 
-        result = await llm.apredict_messages(
-            messages=langchain_messages, stop=["</stop>"]
-        )
+        try:
+            result = await llm.apredict_messages(
+                messages=langchain_messages, stop=["</stop>"]
+            )
+        # some LLMs, like HuggingFaceHub, don't support async
+        except NotImplementedError as exc:
+            if "Async generation not implemented for this LLM" in str(exc):
+                result = llm.predict_messages(
+                    messages=langchain_messages, stop=["</stop>"]
+                )
+            else:
+                raise
 
         return result.content
 

--- a/src/marvin/config.py
+++ b/src/marvin/config.py
@@ -145,17 +145,25 @@ class Settings(BaseSettings):
     # OPENAI
     openai_api_key: SecretStr = Field(
         None,
-        # for the OpenAI key we check two env vars for legacy reasons
+        # for third-party LLM services we check global env vars as well
         env=["MARVIN_OPENAI_API_KEY", "OPENAI_API_KEY"],
     )
     openai_organization: str = Field(None)
     openai_api_base: str = None
 
     # ANTHROPIC
-    anthropic_api_key: SecretStr = Field(None)
+    anthropic_api_key: SecretStr = Field(
+        None,
+        # for third-party LLM services we check global env vars as well
+        env=["MARVIN_ANTHROPIC_API_KEY", "ANTHROPIC_API_KEY"],
+    )
 
     # HUGGINGFACE HUB
-    huggingfacehub_api_token: SecretStr = Field(None)
+    huggingfacehub_api_token: SecretStr = Field(
+        None,
+        # for third-party LLM services we check global env vars as well
+        env=["MARVIN_HUGGINGFACEHUB_API_TOKEN", "HUGGINGFACEHUB_API_TOKEN"],
+    )
 
     # CHROMA
     chroma: ChromaSettings = Field(default_factory=ChromaSettings)

--- a/src/marvin/utilities/llms.py
+++ b/src/marvin/utilities/llms.py
@@ -13,7 +13,7 @@ from marvin.config import LLMBackend, infer_llm_backend
 from marvin.models.threads import Message
 
 
-class StreamingCallbackHandler(AsyncCallbackHandler):
+class AsyncStreamingCallbackHandler(AsyncCallbackHandler):
     """
     Callback handler for streaming responses.
     """
@@ -73,7 +73,9 @@ def get_model(
     if on_token_callback is not None:
         llm_kwargs.update(
             streaming=True,
-            callbacks=[StreamingCallbackHandler(on_token_callback=on_token_callback)],
+            callbacks=[
+                AsyncStreamingCallbackHandler(on_token_callback=on_token_callback)
+            ],
         )
 
     if model is None:
@@ -134,7 +136,6 @@ def get_model(
 
     # HuggingFaceHub models
     elif backend == LLMBackend.HuggingFaceHub:
-        raise ValueError("HuggingFaceHub models are not fully supported yet.")
         from langchain.llms import HuggingFaceHub
 
         return HuggingFaceHub(


### PR DESCRIPTION
Two notes:
- due a Langchain limitation, HFH models do not run async. This means streaming will not work at this time, as we use an async callback.
- support for these models is **experimental** as Marvin is optimized for chat-tuned models. In particular, `stop` words are difficult to anticipate and the models can hallucinate human inputs. 