### PR TITLE
WIP: Adding Support for Google's Vertex AI PaLM

### DIFF
--- a/docs/guide/introduction/configuration.md
+++ b/docs/guide/introduction/configuration.md
@@ -98,3 +98,13 @@ MARVIN_LLM_MODEL='gpt-4'
 ```
 MARVIN_DATABASE_CONNECTION_URL=
 ```
+
+#### PaLM / Google Cloud Platform / Vertex AI
+
+```
+MARVIN_LLM_BACKEND="VertexAI"
+MARVIN_LLM_MODEL="text-bison@001"
+MARVIN_LLM_MAX_TOKENS=1024
+MARVIN_OPENAI_API_KEY="set to avoid warnings"
+MARVIN_LLM_EXTRA_KWARGS="{\"project\": \"my-project\"}"
+```

--- a/docs/guide/introduction/configuration.md
+++ b/docs/guide/introduction/configuration.md
@@ -16,8 +16,10 @@ At this time, valid options include:
 | `AzureOpenAI` | OpenAI completion models via Azure | (same as `OpenAI`) |
 | `Anthropic` | Anthropic models | `claude-v1`, `claude-v1.3`, `claude-v1.3-100k`, any other [available model](https://console.anthropic.com/docs/api/reference#parameters) |
 | `HuggingFaceHub` | Models hosted on HuggingFaceHub | Any valid `repo/model` combination | Support for these models is **experimental** and quality will vary. |
+| `VertexAI` | Google's enterprise text generation (PaLM) | `text-bison@001`, etc. | See [Google's docs](https://cloud.google.com/vertex-ai/docs/generative-ai/learn/overview). Note: Vertex AI uses [Application Default Credentials](https://cloud.google.com/docs/authentication/application-default-credentials) rather than API keys. |
+| `VertexAIChat` | Google's enterprise chat model (PaLM) | `chat-bison@001`, etc. | See [Google's docs](https://cloud.google.com/vertex-ai/docs/generative-ai/learn/overview). Note: Vertex AI uses [Application Default Credentials](https://cloud.google.com/docs/authentication/application-default-credentials) rather than API keys. |
 
- 
+
 Models may have unique settings which are detailed below.
 
 ### OpenAI

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,7 @@ dev = [
 postgres = ["asyncpg~=0.27.0"]
 chromadb = ["chromadb~=0.3.25"]
 pdf = ["pypdf~=3.7.0"]
+gcp = ["google-cloud-aiplatform>=1.25.0"]
 
 [project.urls]
 Code = "https://github.com/prefecthq/marvin"

--- a/src/marvin/bot/base.py
+++ b/src/marvin/bot/base.py
@@ -1,3 +1,4 @@
+import ast
 import asyncio
 import functools
 import inspect
@@ -729,10 +730,13 @@ def _reformat_response(
     target_return_type: Any,
     error_message: str,
 ) -> str:
+    try:
+        return json.dumps(ast.literal_eval(llm_response))
+    except ValueError:
+        pass
     @marvin.ai_fn(
         plugins=[],
         response_format=JSONFormatter(on_error="ignore"),
-        llm_model="gpt-3.5-turbo",
         llm_temperature=0,
     )
     def reformat_response(

--- a/src/marvin/config.py
+++ b/src/marvin/config.py
@@ -57,10 +57,6 @@ def infer_llm_backend(model: str = None) -> LLMBackend:
         return LLMBackend.OpenAI
     elif model.startswith("claude"):
         return LLMBackend.Anthropic
-    elif model.startswith("text-bison"):
-        return LLMBackend.VertexAI
-    elif model.startswith("chat-bison"):
-        return LLMBackend.VertexAIChat
     else:
         raise ValueError(
             "No LLM backend provided and could not infer one from `llm_model`."

--- a/src/marvin/config.py
+++ b/src/marvin/config.py
@@ -38,7 +38,7 @@ class LLMBackend(str, Enum):
     Anthropic = "Anthropic"
     HuggingFaceHub = "HuggingFaceHub"
     VertexAI = "VertexAI"
-    ChatVertexAI = "ChatVertexAI"
+    VertexAIChat = "VertexAIChat"
 
 
 def infer_llm_backend(model: str = None) -> LLMBackend:
@@ -60,7 +60,7 @@ def infer_llm_backend(model: str = None) -> LLMBackend:
     elif model.startswith("text-bison"):
         return LLMBackend.VertexAI
     elif model.startswith("chat-bison"):
-        return LLMBackend.ChatVertexAI
+        return LLMBackend.VertexAIChat
     else:
         raise ValueError(
             "No LLM backend provided and could not infer one from `llm_model`."

--- a/src/marvin/config.py
+++ b/src/marvin/config.py
@@ -37,6 +37,8 @@ class LLMBackend(str, Enum):
     AzureOpenAIChat = "AzureOpenAIChat"
     Anthropic = "Anthropic"
     HuggingFaceHub = "HuggingFaceHub"
+    VertexAI = "VertexAI"
+    ChatVertexAI = "ChatVertexAI"
 
 
 def infer_llm_backend(model: str = None) -> LLMBackend:
@@ -55,6 +57,10 @@ def infer_llm_backend(model: str = None) -> LLMBackend:
         return LLMBackend.OpenAI
     elif model.startswith("claude"):
         return LLMBackend.Anthropic
+    elif model.startswith("text-bison"):
+        return LLMBackend.VertexAI
+    elif model.startswith("chat-bison"):
+        return LLMBackend.ChatVertexAI
     else:
         raise ValueError(
             "No LLM backend provided and could not infer one from `llm_model`."

--- a/src/marvin/utilities/llms.py
+++ b/src/marvin/utilities/llms.py
@@ -155,8 +155,6 @@ def get_model(
     elif backend == LLMBackend.VertexAI:
         from langchain.llms import VertexAI
 
-        # Note: No API Key. Uses Google's Application Default Credentials.
-        # https://cloud.google.com/docs/authentication/provide-credentials-adc
         return VertexAI(
             model_name=model,
             max_output_tokens=max_tokens,
@@ -165,11 +163,9 @@ def get_model(
         )
 
     # Google Vertex AI Chat (PaLM)
-    elif backend == LLMBackend.ChatVertexAI:
+    elif backend == LLMBackend.VertexAIChat:
         from langchain.chat_models import ChatVertexAI
 
-        # Note: No API Key. Uses Google's Application Default Credentials.
-        # https://cloud.google.com/docs/authentication/provide-credentials-adc
         return ChatVertexAI(
             model=model,
             max_output_tokens=max_tokens,

--- a/src/marvin/utilities/llms.py
+++ b/src/marvin/utilities/llms.py
@@ -151,6 +151,32 @@ def get_model(
             **llm_kwargs,
         )
 
+    # Google Vertex AI (PaLM)
+    elif backend == LLMBackend.VertexAI:
+        from langchain.llms import VertexAI
+
+        # Note: No API Key. Uses Google's Application Default Credentials.
+        # https://cloud.google.com/docs/authentication/provide-credentials-adc
+        return VertexAI(
+            model_name=model,
+            max_output_tokens=max_tokens,
+            temperature=temperature,
+            **llm_kwargs,
+        )
+
+    # Google Vertex AI Chat (PaLM)
+    elif backend == LLMBackend.ChatVertexAI:
+        from langchain.chat_models import ChatVertexAI
+
+        # Note: No API Key. Uses Google's Application Default Credentials.
+        # https://cloud.google.com/docs/authentication/provide-credentials-adc
+        return ChatVertexAI(
+            model=model,
+            max_output_tokens=max_tokens,
+            temperature=temperature,
+            **llm_kwargs,
+        )
+
     # Anthropic chat models
     elif backend == LLMBackend.Anthropic:
         from langchain.chat_models import ChatAnthropic


### PR DESCRIPTION
This adds support for the new Google Vertex AI endpoints.  Google's API is strategy is pretty confusing, as they've released both a [PaLM API](https://developers.googleblog.com/2023/03/announcing-palm-api-and-makersuite.html) and an [Enterprise Vertex AI API](https://cloud.google.com/vertex-ai/docs/generative-ai/learn/overview) for the exact same model 😮‍💨 .  `langchain` supports both, so adding the regular `PaLM` model is not too bad, but I'm unable to test as I'm still on the waitlist for an API key.  If the team is okay merging in Google's Palm Models, I'll add support for the non-Vertex AI version when I get the API key.


TODO:

- [ ] More local smoke testing
- [ ] Understand unit tests here, add as needed

Closes #341.