### PR TITLE
allow passing host to `marvin server start`

### DIFF
--- a/src/marvin/cli/server.py
+++ b/src/marvin/cli/server.py
@@ -8,6 +8,12 @@ server_app = typer.Typer(help="Server commands")
 
 @server_app.command()
 def start(
+    host: str = typer.Option(
+        marvin.settings.api_base_url,
+        "--host",
+        "-h",
+        help="Host to run the server on",
+    ),
     port: int = typer.Option(
         marvin.settings.api_port,
         "--port",
@@ -22,5 +28,9 @@ def start(
     ),
 ):
     uvicorn.run(
-        "marvin.server:app", port=port, log_level=log_level.lower(), reload=reload
+        "marvin.server:app",
+        host=host,
+        port=port,
+        log_level=log_level.lower(),
+        reload=reload,
     )


### PR DESCRIPTION
wasnt passing through host here so always went to fastapi's default

```bash
❯ marvin server start -h localhost
INFO:     Started server process [45785]
INFO:     Waiting for application startup.
INFO:     Application startup complete.
INFO:     Uvicorn running on http://localhost:4200 (Press CTRL+C to quit)
```