### PR TITLE
Resolve conflicts between fn and run

### DIFF
--- a/src/marvin/openai/tools/base.py
+++ b/src/marvin/openai/tools/base.py
@@ -34,16 +34,13 @@ class Tool(MarvinBaseModel):
         if not self.fn:
             raise NotImplementedError()
         else:
-            return self.fn
+            return self.fn(*args, **kwargs)
 
     def __call__(self, *args, **kwargs):
-        if not self.fn:
-            raise NotImplementedError()
-        else:
-            return self.fn.__call__(*args, **kwargs)
+        return self.run(*args, **kwargs)
 
     def as_function_schema(self) -> dict:
-        schema = function_to_schema(self.fn)
+        schema = function_to_schema(self.fn or self.run)
         schema.pop("title", None)
         return dict(
             name=self.name,


### PR DESCRIPTION
Classes that implement `run()` aren't properly picked up by the schema inspection; classes that implement `fn` may not be properly called in run().