### PR TITLE
Use OpenAI API directly where appropriate

### DIFF
--- a/src/marvin/config.py
+++ b/src/marvin/config.py
@@ -139,7 +139,7 @@ class Settings(BaseSettings):
             " aren't directly exposed."
         ),
     )
-    llm_max_tool_iterations: float = None
+    llm_max_function_iterations: float = None
     llm_model_for_response_format: str = Field(
         None,
         description=(

--- a/src/marvin/config.py
+++ b/src/marvin/config.py
@@ -139,7 +139,7 @@ class Settings(BaseSettings):
             " aren't directly exposed."
         ),
     )
-    llm_max_tool_iterations: float = 10
+    llm_max_tool_iterations: float = None
     llm_model_for_response_format: str = Field(
         None,
         description=(

--- a/src/marvin/openai/ai_functions/base.py
+++ b/src/marvin/openai/ai_functions/base.py
@@ -8,8 +8,7 @@ from pydantic import BaseModel
 
 from marvin.models.threads import Message
 from marvin.openai.tools.format_response import FormatResponse
-from marvin.utilities.llms import get_model
-from marvin.utilities.openai import call_llm_with_tools
+from marvin.utilities.openai import call_llm_chat
 from marvin.utilities.strings import jinja_env
 from marvin.utilities.types import safe_issubclass
 
@@ -124,16 +123,14 @@ class AIFunction:
             content=AI_FN_USER_MESSAGE.render(input_binds=bound_args.arguments),
         )
 
-        llm = get_model()
-        llm_call = call_llm_with_tools(
-            llm,
+        llm_call = call_llm_chat(
             messages=[system_message, user_message],
-            tools=[FormatResponse(type_=return_annotation)],
+            functions=[FormatResponse(type_=return_annotation).as_openai_function()],
             function_call={"name": "FormatResponse"},
         )
 
-        model = asyncio.run(llm_call)
-        return model
+        response = asyncio.run(llm_call)
+        return response.data["result"]
 
     def run(self, *args, **kwargs):
         """

--- a/src/marvin/openai/tools/base.py
+++ b/src/marvin/openai/tools/base.py
@@ -2,8 +2,9 @@ import inspect
 from functools import partial
 from typing import Callable, Optional
 
-from pydantic import Field, validator
+from pydantic import validator
 
+from marvin.utilities.openai import OpenAIFunction
 from marvin.utilities.strings import jinja_env
 from marvin.utilities.types import LoggerMixin, MarvinBaseModel, function_to_schema
 
@@ -14,19 +15,13 @@ class Tool(MarvinBaseModel, LoggerMixin):
     name: str = None
     description: str = None
     fn: Optional[Callable] = None
-    is_final: bool = Field(
-        False,
-        description="This tool's response should be returned directly to the user",
-    )
 
     @classmethod
-    def from_function(
-        cls, fn, name: str = None, description: str = None, is_final=False
-    ):
+    def from_function(cls, fn, name: str = None, description: str = None):
         # assuming fn has a name and a description
         name = name or fn.__name__
         description = description or fn.__doc__
-        return cls(name=name, description=description, fn=fn, is_final=is_final)
+        return cls(name=name, description=description, fn=fn)
 
     @validator("name", always=True)
     def default_name_from_class_name(cls, v):
@@ -43,30 +38,25 @@ class Tool(MarvinBaseModel, LoggerMixin):
     def __call__(self, *args, **kwargs):
         return self.run(*args, **kwargs)
 
-    def as_function_schema(self) -> dict:
+    def as_openai_function(self) -> OpenAIFunction:
         schema = function_to_schema(self.fn or self.run)
-        schema.pop("title", None)
-
         if self.description:
             description = jinja_env.from_string(inspect.cleandoc(self.description))
             description = description.render(**self.dict(), TOOL=self)
         else:
-            description = ""
-        return dict(
+            description = None
+        return OpenAIFunction(
             name=self.name,
             description=description,
             parameters=schema,
+            fn=self,
         )
 
 
-def tool(
-    arg=None, *, name: str = None, description: str = None, is_final: bool = False
-):
+def tool(arg=None, *, name: str = None, description: str = None):
     if callable(arg):  # Direct function decoration
-        return Tool.from_function(
-            arg, name=name, description=description, is_final=is_final
-        )
+        return Tool.from_function(arg, name=name, description=description)
     elif arg is None:  # Partial application
-        return partial(tool, name=name, description=description, is_final=is_final)
+        return partial(tool, name=name, description=description)
     else:
         raise TypeError("Invalid argument passed to decorator.")

--- a/src/marvin/openai/tools/format_response.py
+++ b/src/marvin/openai/tools/format_response.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel, Field, PrivateAttr
 
 import marvin
 from marvin.openai.tools import Tool
+from marvin.utilities.openai import OpenAIFunction
 from marvin.utilities.types import (
     genericalias_contains,
     safe_issubclass,
@@ -20,7 +21,6 @@ class FormatResponse(Tool):
     type_schema: dict[str, Any] = Field(
         ..., description="The OpenAPI schema for the type"
     )
-    is_final: bool = True
     description: str = (
         "You MUST always call this function before responding to the user to ensure"
         " that your final response is formatted correctly and complies with the output"
@@ -70,9 +70,10 @@ class FormatResponse(Tool):
             kwargs = kwargs["data"]
         return pydantic.parse_obj_as(type_, kwargs)
 
-    def as_function_schema(self) -> dict:
-        return dict(
+    def as_openai_function(self) -> OpenAIFunction:
+        return OpenAIFunction(
             name=self.__class__.__name__,
             description=self.description,
             parameters=self.type_schema,
+            fn=self,
         )

--- a/src/marvin/utilities/openai.py
+++ b/src/marvin/utilities/openai.py
@@ -1,16 +1,174 @@
+import inspect
 import json
+import math
 from logging import Logger
 from typing import TYPE_CHECKING, Any, Callable, Union
 
+import openai
 from langchain.schema import AIMessage
 
 import marvin
 import marvin.utilities.llms
 from marvin.models.threads import Message
 from marvin.utilities.logging import get_logger
+from marvin.utilities.types import MarvinBaseModel
 
 if TYPE_CHECKING:
     from marvin.openai.tools import Tool
+
+
+def prepare_messages(messages: list[Message]) -> list[dict[str, Any]]:
+    openai_messages = []
+    for msg in messages:
+        if msg.role == "system":
+            openai_messages.append({"role": "system", "content": msg.content})
+        elif msg.role == "ai":
+            openai_messages.append({"role": "assistant", "content": msg.content})
+        elif msg.role == "user":
+            openai_messages.append({"role": "user", "content": msg.content})
+        elif msg.role == "function":
+            openai_messages.append(
+                {"role": "function", "name": msg.name, "content": msg.content}
+            )
+        else:
+            raise ValueError(f"Unrecognized role: {msg.role}")
+    return openai_messages
+
+
+class OpenAIFunction(MarvinBaseModel):
+    name: str
+    description: str = None
+    parameters: dict[str, Any] = {"type": "object", "properties": {}}
+    function: Callable = None
+
+    @classmethod
+    def from_function(cls, fn: Callable, **kwargs):
+        return cls(
+            name=kwargs.get("name", fn.__name__),
+            description=kwargs.get("description", fn.__doc__),
+            parameters=marvin.utilities.types.function_to_schema(fn),
+            function=fn,
+        )
+
+
+class OpenAIFunctionCall(MarvinBaseModel):
+    name: str
+    arguments: dict[str, Any]
+    function: OpenAIFunction
+
+
+async def call_llm_chat(
+    messages: list[Message],
+    *,
+    model: str = None,
+    temperature: float = None,
+    max_tokens: int = None,
+    functions: list[OpenAIFunction] = None,
+    function_call: Union[str, dict[str, str]] = None,
+    logger: Logger = None,
+    **kwargs,
+) -> Union[Message, OpenAIFunctionCall]:
+    """Calls an OpenAI LLM with a list of messages and returns the response."""
+
+    # ----------------------------------
+    # Validate arguments
+    # ----------------------------------
+
+    if functions is None:
+        functions = []
+    if function_call is None:
+        function_call = "auto"
+    elif function_call not in [
+        "auto",
+        "none",
+        *[{"name": f.name for f in functions or []}],
+    ]:
+        raise ValueError(f"Invalid function_call value: {function_call}")
+    if model is None:
+        model = marvin.settings.llm_model
+    if temperature is None:
+        temperature = marvin.settings.llm_temperature
+    if max_tokens is None:
+        max_tokens = marvin.settings.llm_max_tokens
+    if logger is None:
+        logger = get_logger("llm")
+
+    # ----------------------------------
+    # Form OpenAI-specific arguments
+    # ----------------------------------
+
+    openai_messages = prepare_messages(messages)
+    openai_functions = [
+        f.dict(include={"name", "description", "parameters"}, exclude_none=True)
+        for f in functions
+    ]
+
+    # add separately because empty parameters are not allowed
+    if functions:
+        kwargs["functions"] = openai_functions
+        kwargs["function_call"] = function_call
+
+    # ----------------------------------
+    # Call OpenAI LLM
+    # ----------------------------------
+
+    response: openai.openai_object.OpenAIObject = await openai.ChatCompletion.acreate(
+        model=model,
+        messages=openai_messages,
+        temperature=temperature,
+        max_tokens=max_tokens,
+        **kwargs,
+    )
+    # ----------------------------------
+    # Format response
+    # ----------------------------------
+
+    msg = response.choices[0].message.to_dict_recursive()
+    if msg["role"] == "assistant":
+        if fn_call := msg.get("function_call"):
+            try:
+                # retrieve the function
+                function = next(f for f in functions if f.name == fn_call["name"])
+                arguments = json.loads(fn_call["arguments"])
+
+                if not isinstance(arguments, dict):
+                    raise ValueError(
+                        "Expected a dictionary of arguments, got a"
+                        f" {type(arguments).__name__}. Try calling the function again"
+                        " using the correct keyword names."
+                    )
+
+                # call the function
+                if function.function is not None:
+                    logger.debug(
+                        f"Running function '{function.name}' with payload {arguments}"
+                    )
+                    fn_result = function.function(**arguments)
+                    if inspect.isawaitable(fn_result):
+                        fn_result = await fn_result
+
+                # if the function is undefined, return the arguments as its output
+                else:
+                    fn_result = arguments
+                logger.debug(f"Result of function '{function.name}': {fn_result}")
+
+            except Exception as exc:
+                logger.error(exc)
+                fn_result = (
+                    f"The function '{function.name}' encountered an error:"
+                    f" {str(exc)}\n\nThe payload you provided was: {arguments}\n\nYou"
+                    " can try calling the function again.'"
+                )
+
+            response = Message(
+                role="function",
+                name=function.name,
+                content=str(fn_result),
+                data=dict(arguments=arguments, result=fn_result),
+            )
+        else:
+            response = Message(role="ai", content=msg["content"])
+    return response
 
 
 async def call_llm_with_tools(
@@ -42,17 +200,20 @@ async def call_llm_with_tools(
 
     functions = [t.as_function_schema() for t in tools]
 
+    if (max_iterations := marvin.settings.llm_max_tool_iterations) is None:
+        max_iterations = math.inf
+
     i = 1
-    while i <= marvin.settings.llm_max_tool_iterations:
+    while i <= max_iterations:
+        response = openai.ChatCompletion.create
+
         response = await marvin.utilities.llms.call_llm_messages(
             llm,
             messages,
             logger,
             functions=functions,
             # force no function call if we're at  max iterations
-            function_call=(
-                function_call if i < marvin.settings.llm_max_tool_iterations else "none"
-            ),
+            function_call=(function_call if i < max_iterations else "none"),
             **kwargs,
         )
 


### PR DESCRIPTION
Uses the OpenAI API directly in `marvin.openai`

Notable differences:
- introduces a structured `OpenAIFunction` object
- does NOT implement a function loop in `call_llm_chat`, but rather calls functions and returns a message with `role=function`. The caller can decide to pass that back in for reevaluation
- relatedly, adds a function loop in the AI Application `run` method. This removes the need for `message_processor` since the AI application can easily update its system message to account for state changes