### PR TITLE
`get_secret_value` in validator

### DIFF
--- a/src/marvin/settings.py
+++ b/src/marvin/settings.py
@@ -89,7 +89,7 @@ class Settings(BaseSettings):
         if v is not None:
             import openai
 
-            openai.api_key = v
+            openai.api_key = v.get_secret_value()
         return v
 
 


### PR DESCRIPTION
status quo
```python
In [1]: import openai

In [2]: openai.api_key
Out[2]: 'sk-myactualkey'

In [3]: import marvin

In [4]: openai.api_key
Out[4]: SecretStr('**********')
```