### PR TITLE
fix typo in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ sentiment("These examples could use some work...") # -0.2
 
 ### AI Choice
 
-AI Choice lets you build a multi-label classifier with no code and no training data. It enumerates your options, and use logit_bias to force an LLM to deductively choose the index of the best option given your provided input. It then returns the choice associated to that index. It's bulletproof, cost-effective, and lets you build classifiers as quickly as you can write your classes.
+AI Choice lets you build a multi-label classifier with no code and no training data. It enumerates your options, and uses a [clever logit_bias trick](https://twitter.com/AAAzzam/status/1669753721574633473) to force an LLM to deductively choose the index of the best option given your provided input. It then returns the choice associated to that index. It's bulletproof, cost-effective, and lets you build classifiers as quickly as you can write your classes.
 
 You can learn more about AI Choice [here](https://www.askmarvin.ai/src/docs/components/ai_choice/).
 

--- a/docs/src/docs/components/ai_choice.ipynb
+++ b/docs/src/docs/components/ai_choice.ipynb
@@ -59,7 +59,7 @@
     "<div class=\"admonition info\">\n",
     "  <p class=\"admonition-title\">How it works</p>\n",
     "  <p>\n",
-    "    Marvin enumerates your options, and use logit_bias to force an LLM to deductively choose the index of the best option given your provided input. It then returns the choice associated to that index. \n",
+    "    Marvin enumerates your options, and uses logit_bias to force an LLM to deductively choose the index of the best option given your provided input. It then returns the choice associated to that index. \n",
     "  </p>\n",
     "</div>"
    ]

--- a/docs/src/docs/components/ai_choice.ipynb
+++ b/docs/src/docs/components/ai_choice.ipynb
@@ -59,7 +59,7 @@
     "<div class=\"admonition info\">\n",
     "  <p class=\"admonition-title\">How it works</p>\n",
     "  <p>\n",
-    "    Marvin enumerates your options, and uses logit_bias to force an LLM to deductively choose the index of the best option given your provided input. It then returns the choice associated to that index. \n",
+    "    Marvin enumerates your options, and uses a [clever logit_bias trick](https://twitter.com/AAAzzam/status/1669753721574633473) to force an LLM to deductively choose the index of the best option given your provided input. It then returns the choice associated to that index. \n",
     "  </p>\n",
     "</div>"
    ]

--- a/docs/src/docs/components/overview.ipynb
+++ b/docs/src/docs/components/overview.ipynb
@@ -135,12 +135,13 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "## AI Choice\n",
     "\n",
-    "AI Choice lets you build a multi-label classifier with no code and no training data. It enumerates your options, and use logit_bias to force an LLM to deductively choose the index of the best option given your provided input. It then returns the choice associated to that index. It's bulletproof, cost-effective, and lets you build classifiers as quickly as you can write your classes."
+    "AI Choice lets you build a multi-label classifier with no code and no training data. It enumerates your options, and uses a [clever logit_bias trick](https://twitter.com/AAAzzam/status/1669753721574633473) to force an LLM to deductively choose the index of the best option given your provided input. It then returns the choice associated to that index. It's bulletproof, cost-effective, and lets you build classifiers as quickly as you can write your classes."
    ]
   },
   {

--- a/docs/src/getting_started/quickstart.ipynb
+++ b/docs/src/getting_started/quickstart.ipynb
@@ -173,7 +173,7 @@
    "source": [
     "## AI Choice\n",
     "\n",
-    "AI Choice lets you build a multi-label classifier with no code and no training data. It enumerates your options, and uses logit_bias to force an LLM to deductively choose the index of the best option given your provided input. It then returns the choice associated to that index. It's bulletproof, cost-effective, and lets you build classifiers as quickly as you can write your classes."
+    "AI Choice lets you build a multi-label classifier with no code and no training data. It enumerates your options, and uses a [clever logit_bias trick](https://twitter.com/AAAzzam/status/1669753721574633473) to force an LLM to deductively choose the index of the best option given your provided input. It then returns the choice associated to that index. It's bulletproof, cost-effective, and lets you build classifiers as quickly as you can write your classes."
    ]
   },
   {

--- a/docs/src/getting_started/quickstart.ipynb
+++ b/docs/src/getting_started/quickstart.ipynb
@@ -173,7 +173,7 @@
    "source": [
     "## AI Choice\n",
     "\n",
-    "AI Choice lets you build a multi-label classifier with no code and no training data. It enumerates your options, and use logit_bias to force an LLM to deductively choose the index of the best option given your provided input. It then returns the choice associated to that index. It's bulletproof, cost-effective, and lets you build classifiers as quickly as you can write your classes."
+    "AI Choice lets you build a multi-label classifier with no code and no training data. It enumerates your options, and uses logit_bias to force an LLM to deductively choose the index of the best option given your provided input. It then returns the choice associated to that index. It's bulletproof, cost-effective, and lets you build classifiers as quickly as you can write your classes."
    ]
   },
   {


### PR DESCRIPTION
should be `uses logit_bias`.

logit_bias should probably also be explained or linked to and maybe `logit bias`. If you want to use a link this was the best I found: https://help.openai.com/en/articles/5247780-using-logit-bias-to-define-token-probability