### PR TITLE
Track llm_response on Message objects and AI Models

### DIFF
--- a/src/marvin/components/ai_model.py
+++ b/src/marvin/components/ai_model.py
@@ -2,10 +2,10 @@ import functools
 from typing import Optional, Type, TypeVar
 
 from pydantic import BaseModel, PrivateAttr
-from zmq import Message
 
 from marvin.engine.executors import OpenAIExecutor
 from marvin.engine.language_models import ChatLLM
+from marvin.models.messages import Message
 from marvin.prompts import library as prompt_library
 from marvin.prompts import render_prompts
 from marvin.prompts.base import Prompt
@@ -60,8 +60,6 @@ class AIModel(LoggerMixin, BaseModel):
             instructions_: Additional instructions to assist the model.
             model_: The language model to use.
         """
-        # the loggingmixin hasn't been instantiated yet
-
         if text_:
             # use the extract constructor to build the class
             kwargs = self.__class__.extract(
@@ -71,8 +69,10 @@ class AIModel(LoggerMixin, BaseModel):
                 as_dict_=True,
                 **kwargs,
             )
+        message = kwargs.pop("_message", None)
         super().__init__(**kwargs)
-        self._message = kwargs.pop("_message", None)
+        # set private attr after init
+        self._message = message
 
     @classmethod
     def route(cls):

--- a/src/marvin/engine/executors.py
+++ b/src/marvin/engine/executors.py
@@ -203,4 +203,5 @@ class OpenAIExecutor(Executor):
             name=fn_name,
             content=str(fn_result),
             data=response_data,
+            llm_response=response.llm_response,
         )

--- a/src/marvin/engine/language_models.py
+++ b/src/marvin/engine/language_models.py
@@ -189,7 +189,6 @@ class ChatLLM(MarvinBaseModel):
             return msg
 
         else:
-            breakpoint()
             llm_response = response.to_dict_recursive()
             msg = llm_response["choices"][0]["message"]
             msg = Message(

--- a/src/marvin/engine/language_models.py
+++ b/src/marvin/engine/language_models.py
@@ -71,13 +71,12 @@ class StreamHandler(MarvinBaseModel):
         Accumulate chunk deltas into a full response. Returns the full message.
         Passes partial messages to the callback, if provided.
         """
-        response = {"role": None, "content": "", "data": {}}
+        response = {"role": None, "content": "", "data": {}, "llm_response": None}
 
         async for r in openai_response:
-            delta = r.choices[0].delta
+            response["data"]["llm_response"] = r.to_dict_recursive()
 
-            # streaming deltas are stored in the 'data' field during streaming
-            response["data"]["streaming_delta"] = delta.to_dict_recursive()
+            delta = r.choices[0].delta
 
             if "role" in delta:
                 response["role"] = delta.role
@@ -100,8 +99,6 @@ class StreamHandler(MarvinBaseModel):
                 if inspect.isawaitable(callback_result):
                     create_task(callback_result(Message(**response)))
 
-        # remove the streaming delta from the response data
-        response["data"].pop("streaming_delta", None)
         return Message(**response)
 
 
@@ -192,9 +189,13 @@ class ChatLLM(MarvinBaseModel):
             return msg
 
         else:
-            msg = response.choices[0].message.to_dict_recursive()
-            return Message(
+            breakpoint()
+            llm_response = response.to_dict_recursive()
+            msg = llm_response["choices"][0]["message"]
+            msg = Message(
                 role=msg.pop("role").upper(),
                 content=msg.pop("content"),
                 data=msg,
+                llm_response=llm_response,
             )
+            return msg

--- a/src/marvin/models/messages.py
+++ b/src/marvin/models/messages.py
@@ -3,7 +3,9 @@ from datetime import datetime
 from enum import Enum
 from zoneinfo import ZoneInfo
 
-from pydantic import BaseModel, Field, validator
+from pydantic import Field, validator
+
+from marvin.utilities.types import MarvinBaseModel
 
 
 class Role(Enum):
@@ -21,12 +23,13 @@ class Role(Enum):
         return None
 
 
-class Message(BaseModel):
+class Message(MarvinBaseModel):
     role: Role
     content: str = None
     name: str = None
     timestamp: datetime = Field(default_factory=lambda: datetime.now(ZoneInfo("UTC")))
     data: dict = {}
+    llm_response: dict = Field(None, description="The raw LLM response", repr=False)
 
     @validator("content")
     def clean_content(cls, v):

--- a/tests/test_components/test_ai_model.py
+++ b/tests/test_components/test_ai_model.py
@@ -2,6 +2,7 @@ from typing import List, Literal, Optional
 
 import pytest
 from marvin import ai_model
+from marvin.models.messages import Message, Role
 from pydantic import BaseModel
 
 from tests.utils.mark import pytest_mark_class
@@ -139,6 +140,19 @@ class TestAIModels:
                 ]
             )
         )
+
+
+@pytest_mark_class("llm")
+class TestAIModelsMessage:
+    def test_arithmetic_message(self):
+        @ai_model
+        class Arithmetic(BaseModel):
+            sum: float
+
+        x = Arithmetic("One plus six")
+        assert x.sum == 7
+        assert isinstance(x._message, Message)
+        assert x._message.role == Role.FUNCTION
 
 
 @pytest_mark_class("llm")


### PR DESCRIPTION
This PR adds a `Message.llm_response` field to persist the raw LLM response on Marvin messages, e.g. for token tracking.

In addition, this adds a private `_message` attribute to all `@ai_model` models, which contains the message that created the model.

```python
from pydantic import BaseModel
from marvin import ai_model

@ai_model
class Location(BaseModel):
    city: str
    state: str

l = Location("The Big Apple")
l._message.llm_response
```

Returns
```python
{'id': 'chatcmpl-7cCyBbW7V1jhvcl4HVXlH6drSjZc8',
 'object': 'chat.completion',
 'created': 1689340675,
 'model': 'gpt-3.5-turbo-0613',
 'choices': [{'index': 0,
   'message': {'function_call': {'name': 'FormatResponse',
     'arguments': '{\n  "city": "New York",\n  "state": "New York"\n}'}},
   'finish_reason': 'stop'}],
 'usage': {'prompt_tokens': 163, 'completion_tokens': 18, 'total_tokens': 181}}
```

This is considered a private interface for now because `Message` is not a user-facing class and the `AIModel` attribute is explicitly private.