### PR TITLE
Add .map method for AI Models

### DIFF
--- a/src/marvin/components/ai_model.py
+++ b/src/marvin/components/ai_model.py
@@ -1,3 +1,4 @@
+import asyncio
 import functools
 from typing import Optional, Type, TypeVar
 
@@ -91,6 +92,26 @@ class AIModel(LoggerMixin, BaseModel):
         as_dict_: bool = False,
         **kwargs,
     ):
+        return run_sync(
+            cls._extract_async(
+                text_=text_,
+                instructions_=instructions_,
+                model_=model_,
+                as_dict_=as_dict_,
+                **kwargs,
+            )
+        )
+
+    @classmethod
+    async def _extract_async(
+        cls,
+        text_: str = None,
+        *,
+        instructions_: str = None,
+        model_: ChatLLM = None,
+        as_dict_: bool = False,
+        **kwargs,
+    ):
         """
         Class method to extract structured data from text.
 
@@ -105,7 +126,7 @@ class AIModel(LoggerMixin, BaseModel):
         prompts = extract_structured_data_prompts
         if instructions_:
             prompts.append(prompt_library.System(content=instructions_))
-        arguments = cls._get_arguments(
+        arguments = await cls._get_arguments(
             model=model_, prompts=prompts, render_kwargs=dict(input_text=text_)
         )
         arguments.update(kwargs)
@@ -141,7 +162,42 @@ class AIModel(LoggerMixin, BaseModel):
         return cls(**arguments)
 
     @classmethod
-    def _get_arguments(
+    def map(
+        cls, texts: list[str], instructions: str = None, model: ChatLLM = None
+    ) -> list["AIModel"]:
+        """
+        Map the AI function over a sequence of arguments. Runs concurrently.
+
+        Arguments should be provided as if calling the function normally, but
+        each argument must be a list. The function is called once for each item
+        in the list, and the results are returned in a list.
+
+        For example, fn.map([1, 2]) is equivalent to [fn(1), fn(2)].
+
+        fn.map([1, 2], x=['a', 'b']) is equivalent to [fn(1, x='a'), fn(2,
+        x='b')].
+        """
+
+        coros = [
+            cls._extract_async(
+                t,
+                instructions_=instructions,
+                model_=model,
+                as_dict_=True,
+            )
+            for t in texts
+        ]
+
+        # gather returns a future, but run_sync requires a coroutine
+        async def gather_coros():
+            return await asyncio.gather(*coros)
+
+        result = run_sync(gather_coros())
+
+        return [cls(**r) for r in result]
+
+    @classmethod
+    async def _get_arguments(
         cls, model: ChatLLM, prompts: list[Prompt], render_kwargs: dict = None
     ) -> Message:
         if model is None:
@@ -154,8 +210,7 @@ class AIModel(LoggerMixin, BaseModel):
             max_iterations=3,
         )
 
-        llm_call = executor.start(prompts=messages)
-        messages = run_sync(llm_call)
+        messages = await executor.start(prompts=messages)
         message = messages[-1]
 
         if message.data.get("is_error"):

--- a/tests/test_components/test_ai_model.py
+++ b/tests/test_components/test_ai_model.py
@@ -172,3 +172,38 @@ class TestInstructions:
 
         t2 = Test("Hello")
         assert t2.text == "Bonjour"
+
+
+@pytest_mark_class("llm")
+class TestAIModelMapping:
+    def test_arithmetic(self):
+        @ai_model
+        class Arithmetic(BaseModel):
+            sum: float
+
+        x = Arithmetic.map(["One plus six", "Two plus 100 minus one"])
+        assert len(x) == 2
+        assert x[0].sum == 7
+        assert x[1].sum == 101
+
+    def test_location(self):
+        @ai_model
+        class City(BaseModel):
+            name: str
+
+        result = City.map(["the windy city", "CHI", "chicago"])
+        assert len(result) == 3
+        expected = City(name="Chicago")
+        assert result[0] == expected
+        assert result[1] == expected
+        assert result[2] == expected
+
+    def test_instructions(self):
+        @ai_model
+        class Translate(BaseModel):
+            text: str
+
+        result = Translate.map(["Hello", "Goodbye"], instructions="Translate to French")
+        assert len(result) == 2
+        assert result[0].text == "Bonjour"
+        assert result[1].text == "Au revoir"

--- a/tests/test_components/test_ai_model.py
+++ b/tests/test_components/test_ai_model.py
@@ -191,12 +191,15 @@ class TestAIModelMapping:
         class City(BaseModel):
             name: str
 
-        result = City.map(["the windy city", "CHI", "chicago"])
-        assert len(result) == 3
+        result = City.map(
+            ["the windy city", "chicago IL", "chicago", "Chicago, Illinois, USA"]
+        )
+        assert len(result) == 4
         expected = City(name="Chicago")
         assert result[0] == expected
         assert result[1] == expected
         assert result[2] == expected
+        assert result[3] == expected
 
     def test_instructions(self):
         @ai_model

--- a/tests/test_components/test_ai_model.py
+++ b/tests/test_components/test_ai_model.py
@@ -3,7 +3,7 @@ from typing import List, Literal, Optional
 import pytest
 from marvin import ai_model
 from marvin.utilities.messages import Message, Role
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from tests.utils.mark import pytest_mark_class
 
@@ -189,17 +189,21 @@ class TestAIModelMapping:
     def test_location(self):
         @ai_model
         class City(BaseModel):
-            name: str
+            name: str = Field("The proper name of the city")
 
         result = City.map(
-            ["the windy city", "chicago IL", "chicago", "Chicago, Illinois, USA"]
+            [
+                "the windy city",
+                "chicago IL",
+                "Chicago",
+                "Chcago",
+                "chicago, Illinois, USA",
+                "chi-town",
+            ]
         )
-        assert len(result) == 4
+        assert len(result) == 6
         expected = City(name="Chicago")
-        assert result[0] == expected
-        assert result[1] == expected
-        assert result[2] == expected
-        assert result[3] == expected
+        assert all(r == expected for r in result)
 
     def test_instructions(self):
         @ai_model


### PR DESCRIPTION
Partially addresses #437 

```python
@ai_model
class Translate(BaseModel):
    text: str

result = Translate.map(["Hello", "Goodbye"], instructions="Translate to French")
assert len(result) == 2
assert result[0].text == "Bonjour"
assert result[1].text == "Au revoir"
```