### PR TITLE
Fix AI Model bugs with instructions and add docs

### DIFF
--- a/docs/src/docs/components/ai_model.ipynb
+++ b/docs/src/docs/components/ai_model.ipynb
@@ -25,9 +25,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Location(city='New York', state='NY')"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "from marvin import ai_model\n",
     "from pydantic import BaseModel, Field\n",
@@ -39,8 +50,7 @@
     "    state: str = Field(..., description=\"The two-letter state abbreviation\")\n",
     "\n",
     "\n",
-    "Location(\"The Big Apple\")\n",
-    "# Location(city='New York', state='NY')"
+    "Location(\"The Big Apple\")"
    ]
   },
   {
@@ -64,6 +74,178 @@
     "    </ol>\n",
     "  </p>\n",
     "</div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "\n",
+    "\n",
+    "\n",
+    "## Building a model\n",
+    "\n",
+    "AI Models are identical to Pydantic `BaseModels`, except that they can attempt to parse natural language to populate their fields. To build an effective AI Model, be as specific as possible with your field names, field descriptions, docstring, and instructions.\n",
+    "\n",
+    "To build a minimal AI model, decorate any standard Pydantic model, like this:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Location(city='New York', state='New York')"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "@ai_model\n",
+    "class Location(BaseModel):\n",
+    "    city: str\n",
+    "    state: str\n",
+    "\n",
+    "\n",
+    "Location(\"The Big Apple\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "\n",
+    "\n",
+    "A more complete model will provide instructions wherever possible, as all available information will be sent to the LLM:\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Location(city='New York', state='NY')"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "@ai_model\n",
+    "class Location(BaseModel):\n",
+    "    \"\"\"A representation of a US city and state\"\"\"\n",
+    "\n",
+    "    city: str = Field(description=\"The city's proper name\")\n",
+    "    state: str = Field(description=\"The state's two-letter abbreviation (e.g. NY)\")\n",
+    "\n",
+    "\n",
+    "Location(\"The Big Apple\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can experiment to find the optimal blend of clarity and performance."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Steering AI model behavior\n",
+    "\n",
+    "You can pass `instructions` to your model at runtime in order to guide its behavior. These instructions are combined with the model's docstring to form a complete set of guidelines for the LLM. This allows users to steer the model to a specific outcome without modifying the base class.\n",
+    "\n",
+    "Note that the kwarg is `instructions_` with a trailing underscore; this is to avoid conflicts with models that may have a real `instructions` field. If you accidentally pass \"instructions\" to a model without an \"instructions\" field, a helpful error will identify your mistake."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "original_text='Hello, world!' translated_text='Bonjour, monde!'\n",
+      "original_text='Hello, world!' translated_text='Hallo, Welt!'\n"
+     ]
+    }
+   ],
+   "source": [
+    "@ai_model\n",
+    "class Translation(BaseModel):\n",
+    "    \"\"\"Translates from one language to another language\"\"\"\n",
+    "\n",
+    "    original_text: str\n",
+    "    translated_text: str\n",
+    "\n",
+    "\n",
+    "print(Translation(\"Hello, world!\", instructions_=\"Translate to French\"))\n",
+    "print(Translation(\"Hello, world!\", instructions_=\"Translate to German\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "\n",
+    "<div class=\"admonition tip\">\n",
+    "  <p class=\"admonition-title\">Best practice: docstrings vs instructions</p>\n",
+    "  <p>\n",
+    "    To define an AI Model's behavior, you can either provide a docstring on the `BaseModel`, instructions to the `ai_model`, or both. As a matter of best practice, we recommend using docstrings to document class behavior and instructions to steer instance behavior, as appropriate for your use case. For example, the `Translation` class in the above example doesn't specify a language and relies on `instructions` to provide that information at runtime on a per-call basis. The docstring could have been more explicit that the object only translates to French, but then it would have been more appropriate to call the model a `FrenchTranslation` since that's the only language it would support.\n",
+    "  </p>\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Configuring the LLM\n",
+    "By default, `@ai_model` uses the global LLM settings. To specify a particular LLM, pass it as an argument to the decorator:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Location(city='New York', state='New York')"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from marvin.engine.language_models import chat_llm\n",
+    "\n",
+    "\n",
+    "@ai_model(model=chat_llm(model=\"openai/gpt-3.5-turbo\", temperature=0))\n",
+    "class Location(BaseModel):\n",
+    "    city: str\n",
+    "    state: str\n",
+    "\n",
+    "\n",
+    "Location(\"The Big Apple\")"
    ]
   },
   {
@@ -526,8 +708,22 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "marvin",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
-   "name": "python"
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.9"
   },
   "orig_nbformat": 4
  },

--- a/docs/src/docs/components/ai_model.ipynb
+++ b/docs/src/docs/components/ai_model.ipynb
@@ -248,7 +248,28 @@
    "metadata": {},
    "source": [
     "\n",
-    "Note that the kwarg is `instructions_` with a trailing underscore; this is to avoid conflicts with models that may have a real `instructions` field. If you accidentally pass \"instructions\" to a model without an \"instructions\" field, a helpful error will identify your mistake."
+    "Note that the kwarg is `instructions_` with a trailing underscore; this is to avoid conflicts with models that may have a real `instructions` field. If you accidentally pass \"instructions\" to a model without an \"instructions\" field, a helpful error will identify your mistake.\n",
+    "\n",
+    "Putting this all together, here is a model whose behavior is informed by a docstring on the class itself, an instruction provided to the decorator, and an instruction provided to the instance."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@ai_model(instructions=\"Always set color_2 to 'red'\")\n",
+    "class Test(BaseModel):\n",
+    "    \"\"\"Always set color_1 to 'orange'\"\"\"\n",
+    "\n",
+    "    color_1: str\n",
+    "    color_2: str\n",
+    "    color_3: str\n",
+    "\n",
+    "\n",
+    "t1 = Test(\"Hello\", instructions_=\"Always set color_3 to 'blue'\")\n",
+    "assert t1 == Test(color_1=\"orange\", color_2=\"red\", color_3=\"blue\")"
    ]
   },
   {
@@ -288,7 +309,8 @@
     "print(Location(\"The Big Apple\"))\n",
     "print(\n",
     "    Location(\n",
-    "        \"The Big Apple\", model_=chat_llm(model=\"openai/gpt-3.5-turbo\", temperature=1)\n",
+    "        \"The Big Apple\",\n",
+    "        model_=chat_llm(model=\"openai/gpt-3.5-turbo\", temperature=1),\n",
     "    )\n",
     ")"
    ]

--- a/docs/src/docs/components/ai_model.ipynb
+++ b/docs/src/docs/components/ai_model.ipynb
@@ -168,7 +168,7 @@
     "\n",
     "In addition to how you define the AI model itself, there are two ways to control its behavior at runtime: `instructions` and `model`.\n",
     "\n",
-    "### Providing Instructions\n",
+    "### Providing instructions\n",
     "When parsing text, AI Models can take up to three different forms of instruction:\n",
     "- the AI Model's docstring (set at the class level)\n",
     "- instructions passed to the `@ai_model` decorator (set at the class level)\n",

--- a/docs/src/docs/components/ai_model.ipynb
+++ b/docs/src/docs/components/ai_model.ipynb
@@ -83,7 +83,7 @@
     "\n",
     "\n",
     "\n",
-    "## Building a model\n",
+    "## Creating an AI Model\n",
     "\n",
     "AI Models are identical to Pydantic `BaseModels`, except that they can attempt to parse natural language to populate their fields. To build an effective AI Model, be as specific as possible with your field names, field descriptions, docstring, and instructions.\n",
     "\n",
@@ -92,7 +92,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
@@ -101,7 +101,7 @@
        "Location(city='New York', state='New York')"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 2,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -127,7 +127,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
@@ -136,7 +136,7 @@
        "Location(city='New York', state='NY')"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -164,23 +164,68 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Steering AI model behavior\n",
+    "## Configuring an AI Model\n",
     "\n",
-    "You can pass `instructions` to your model at runtime in order to guide its behavior. These instructions are combined with the model's docstring to form a complete set of guidelines for the LLM. This allows users to steer the model to a specific outcome without modifying the base class.\n",
+    "In addition to how you define the AI model itself, there are two ways to control its behavior at runtime: `instructions` and `model`.\n",
     "\n",
-    "Note that the kwarg is `instructions_` with a trailing underscore; this is to avoid conflicts with models that may have a real `instructions` field. If you accidentally pass \"instructions\" to a model without an \"instructions\" field, a helpful error will identify your mistake."
+    "### Providing Instructions\n",
+    "When parsing text, AI Models can take up to three different forms of instruction:\n",
+    "- the AI Model's docstring (set at the class level)\n",
+    "- instructions passed to the `@ai_model` decorator (set at the class level)\n",
+    "- instructions passed to the AI Model when instantiated (set at the instance / call level)\n",
+    "\n",
+    "The AI Model's docstring and the `@ai_model` instructions are roughly equivalent: they are both provided when the class is defined, not when it is instantiated, and are therefore applied to every instance of the class. Users can choose to put information in either location. If you only want to use one, our recommendation is to use the docstring for clarity. Alternatively, you may prefer to put the model's documentation in the docstring (as you would for a normal Pydantic model) and put parsing instructions in the `@ai_model` decorator, since those are unique to the LLM. This is entirely a matter of preference and users should opt for whichever is more clear; both the docstring and the `@ai_model` instructions are provided to the LLM in the same way.\n",
+    "\n",
+    "Here is an example of an AI model with a documentation docstring and parsing instructions provided to the decorator:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Translation(original_text='Hello, world!', translated_text='Bonjour le monde!')"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "@ai_model(instructions=\"Translate to French\")\n",
+    "class Translation(BaseModel):\n",
+    "    \"\"\"A record of original text and translated text\"\"\"\n",
+    "\n",
+    "    original_text: str\n",
+    "    translated_text: str\n",
+    "\n",
+    "\n",
+    "Translation(\"Hello, world!\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In the above case, we could have also put \"translate to French\" in the docstring (and perhaps renamed the object `FrenchTranslation`, since that's the only language it can represent).\n",
+    "\n",
+    "The third opportunity to provide instructions is when the model is actually instantiated. These instructions are **combined** with any other instructions to guide the model behavior. Here's how we could use the same `Translation` object to handle multiple languages:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "original_text='Hello, world!' translated_text='Bonjour, monde!'\n",
+      "original_text='Hello, world!' translated_text='Bonjour, le monde!'\n",
       "original_text='Hello, world!' translated_text='Hallo, Welt!'\n"
      ]
     }
@@ -188,7 +233,7 @@
    "source": [
     "@ai_model\n",
     "class Translation(BaseModel):\n",
-    "    \"\"\"Translates from one language to another language\"\"\"\n",
+    "    \"\"\"A record of original text and translated text\"\"\"\n",
     "\n",
     "    original_text: str\n",
     "    translated_text: str\n",
@@ -203,36 +248,31 @@
    "metadata": {},
    "source": [
     "\n",
-    "<div class=\"admonition tip\">\n",
-    "  <p class=\"admonition-title\">Best practice: docstrings vs instructions</p>\n",
-    "  <p>\n",
-    "    To define an AI Model's behavior, you can either provide a docstring on the `BaseModel`, instructions to the `ai_model`, or both. As a matter of best practice, we recommend using docstrings to document class behavior and instructions to steer instance behavior, as appropriate for your use case. For example, the `Translation` class in the above example doesn't specify a language and relies on `instructions` to provide that information at runtime on a per-call basis. The docstring could have been more explicit that the object only translates to French, but then it would have been more appropriate to call the model a `FrenchTranslation` since that's the only language it would support.\n",
-    "  </p>\n",
-    "</div>"
+    "Note that the kwarg is `instructions_` with a trailing underscore; this is to avoid conflicts with models that may have a real `instructions` field. If you accidentally pass \"instructions\" to a model without an \"instructions\" field, a helpful error will identify your mistake."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Configuring the LLM\n",
-    "By default, `@ai_model` uses the global LLM settings. To specify a particular LLM, pass it as an argument to the decorator:"
+    "### Configuring the LLM\n",
+    "By default, `@ai_model` uses the global LLM settings. To specify a particular LLM, pass it as an argument to the decorator or at instantiation. If you provide it to the decorator, it becomes the default for all uses of that model. If you provide it at instantiation, it is only used for that specific model. \n",
+    "\n",
+    "Note that the kwarg is `model_` with a trailing underscore; this is to avoid conflicts with models that may have a real `model` field. If you accidentally pass a \"model\" kwarg and there is no \"model\" field, a helpful error will identify your mistake."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "Location(city='New York', state='New York')"
-      ]
-     },
-     "execution_count": 7,
-     "metadata": {},
-     "output_type": "execute_result"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "city='New York' state='New York'\n",
+      "city='New York' state='New York'\n"
+     ]
     }
    ],
    "source": [
@@ -245,7 +285,12 @@
     "    state: str\n",
     "\n",
     "\n",
-    "Location(\"The Big Apple\")"
+    "print(Location(\"The Big Apple\"))\n",
+    "print(\n",
+    "    Location(\n",
+    "        \"The Big Apple\", model_=chat_llm(model=\"openai/gpt-3.5-turbo\", temperature=1)\n",
+    "    )\n",
+    ")"
    ]
   },
   {

--- a/docs/src/docs/components/ai_model.ipynb
+++ b/docs/src/docs/components/ai_model.ipynb
@@ -346,7 +346,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "##Examples \n",
+    "## Examples \n",
     "### Resumes"
    ]
   },

--- a/src/marvin/tools/format_response.py
+++ b/src/marvin/tools/format_response.py
@@ -50,7 +50,11 @@ class FormatResponse(Tool):
             )
             type_schema.pop("title", None)
             kwargs["type_schema"] = type_schema
+
         super().__init__(**kwargs)
+        if type_ is not SENTINEL:
+            if type_schema.get("description"):
+                self.description += f"\n\n {type_schema['description']}"
 
         if type_ is not SENTINEL:
             self._cached_type = type_

--- a/src/marvin/utilities/types.py
+++ b/src/marvin/utilities/types.py
@@ -86,7 +86,12 @@ def safe_issubclass(type_, classes):
 
 def type_to_schema(type_, set_root_type: bool = True) -> dict:
     if safe_issubclass(type_, pydantic.BaseModel):
-        return type_.schema()
+        schema = type_.schema()
+        # if the docstring was updated at runtime, make it the description
+        if type_.__doc__ and type_.__doc__ != schema.get("description"):
+            schema["description"] = type_.__doc__
+        return schema
+
     elif set_root_type:
 
         class Model(pydantic.BaseModel):

--- a/tests/test_components/test_ai_model.py
+++ b/tests/test_components/test_ai_model.py
@@ -169,7 +169,7 @@ class TestInstructions:
         with pytest.raises(ValueError, match="(Received `model` but this model)"):
             Test("Hello!", model=None)
 
-    def test_follow_instructions(self):
+    def test_follow_global_instructions(self):
         @ai_model
         class Test(BaseModel):
             text: str
@@ -200,6 +200,27 @@ class TestInstructions:
 
         t2 = Test("Hello", instructions_="Translate the text to French")
         assert t2.text == "Bonjour"
+
+    def test_follow_global_and_instance_instructions(self):
+        @ai_model(instructions="Always set color_1 to 'red'")
+        class Test(BaseModel):
+            color_1: str
+            color_2: str
+
+        t1 = Test("Hello", instructions_="Always set color_2 to 'blue'")
+        assert t1 == Test(color_1="red", color_2="blue")
+
+    def test_follow_docstring_and_global_and_instance_instructions(self):
+        @ai_model(instructions="Always set color_1 to 'red'")
+        class Test(BaseModel):
+            """Always set color_3 to 'orange'"""
+
+            color_1: str
+            color_2: str
+            color_3: str
+
+        t1 = Test("Hello", instructions_="Always set color_2 to 'blue'")
+        assert t1 == Test(color_1="red", color_2="blue", color_3="orange")
 
     def test_follow_multiple_instructions(self):
         # ensure that instructions don't bleed to other invocations


### PR DESCRIPTION
A few AI model bugs:
- if provided, instructions were added to the global stack so they were applied to subsequent calls of ai models
- docstrings were not being provided to the openai functions call in a very clear way (now added to the FormatResponse tool description rather than implicitly in the parameter description)

And improvements:
- if values for instructions or model are passed to `@ai_model`, they can be added to (for instructions) or overridden (for model) when an instance is called. For example this test now passes:

```python

        @ai_model(instructions="Always set color_1 to 'red'")
        class Test(BaseModel):
            """Always set color_3 to 'orange'"""

            color_1: str
            color_2: str
            color_3: str

        t1 = Test("Hello", instructions_="Always set color_2 to 'blue'")
        assert t1 == Test(color_1="red", color_2="blue", color_3="orange")

```