### PR TITLE
Reflect 1.0-style settings

### DIFF
--- a/docs/src/docs/configuration/openai.md
+++ b/docs/src/docs/configuration/openai.md
@@ -17,7 +17,7 @@ You can set your API key at runtime like this:
 ```python
 import marvin
 
-marvin.settings.openai.api_key = YOUR_API_KEY
+marvin.settings.openai_api_key = YOUR_API_KEY
 ```
 
 However, it is preferable to pass sensitive settings as an environment variable: `MARVIN_OPENAI_API_KEY`. 

--- a/src/marvin/settings.py
+++ b/src/marvin/settings.py
@@ -112,5 +112,34 @@ class Settings(MarvinBaseSettings):
         marvin.utilities.logging.setup_logging(level=v)
         return v
 
+    # --- deprecated settings
+
+    @property
+    def openai_api_key(self):
+        import marvin.utilities.logging
+
+        logger = marvin.utilities.logging.get_logger("Settings")
+        logger.warn(
+            "`settings.openai_api_key` is deprecated. Use the provider-specific"
+            " `settings.openai.api_key` instead."
+        )
+        return self.openai.api_key
+
+    def __setattr__(self, name, value):
+        # handle deprecated setting and forward to correct location
+        # this should be a property setter but Pydantic doesn't support it
+        if name == "openai_api_key":
+            import marvin.utilities.logging
+
+            logger = marvin.utilities.logging.get_logger("Settings")
+            logger.warn(
+                "`settings.openai_api_key` is deprecated. Use the provider-specific"
+                " `settings.openai.api_key` instead."
+            )
+            # assign to correct location
+            self.openai.api_key = value
+        else:
+            super().__setattr__(name, value)
+
 
 settings = Settings()


### PR DESCRIPTION
Follow up to #468, fixes one other place the 1.1 format leaked and adds a deprecation warning for the old API key setting (if set or accessed manually)