### PR TITLE
add sub setting for azure llm model

### DIFF
--- a/src/marvin/engine/language_models/azure_openai.py
+++ b/src/marvin/engine/language_models/azure_openai.py
@@ -36,10 +36,10 @@ class AzureOpenAIChatLLM(OpenAIChatLLM):
 
     @validator("model", always=True)
     def validate_model(cls, v):
-        if not v.startswith("azure"):
+        if not v.startswith("azure_openai"):
             raise ValueError(
                 "Azure OpenAI models must have the form"
-                f" 'azure/<MODEL NAME>'. Received {v}."
+                f" 'azure_openai/<MODEL NAME>'. Received {v}."
                 " You can set the default model via `marvin.settings.llm_model`"
                 " as a runtime setting, set the `MARVIN_LLM_MODEL` env var"
                 " or pass a `model` kwarg to `AzureOpenAIChatLLM`"

--- a/src/marvin/settings.py
+++ b/src/marvin/settings.py
@@ -45,6 +45,7 @@ class AzureOpenAI(MarvinBaseSettings):
     class Config:
         env_prefix = "MARVIN_AZURE_OPENAI_"
 
+    llm_model: str = "azure/gpt-35-turbo-0613"
     api_key: SecretStr = None
     api_type: Literal["azure", "azure_ad"] = "azure"
     api_base: str = Field(

--- a/src/marvin/settings.py
+++ b/src/marvin/settings.py
@@ -45,7 +45,7 @@ class AzureOpenAI(MarvinBaseSettings):
     class Config:
         env_prefix = "MARVIN_AZURE_OPENAI_"
 
-    llm_model: str = "azure/gpt-35-turbo-0613"
+    llm_model: str = "azure_openai/gpt-35-turbo-0613"
     api_key: SecretStr = None
     api_type: Literal["azure", "azure_ad"] = "azure"
     api_base: str = Field(


### PR DESCRIPTION
tiktokens `get_token` in `ai_classifier` was looking at `ChatLLM`'s `model`, which is `marvin.settings.llm_model` by default, this PR adds a `llm_model` setting to `AzureOpenAI` that becomes `AzureOpenAIChatLLM`'s default `model`

closes #476 