### PR TITLE
Remove global default model + fix tokenization

### DIFF
--- a/src/marvin/engine/language_models/anthropic.py
+++ b/src/marvin/engine/language_models/anthropic.py
@@ -82,6 +82,8 @@ class AnthropicStreamHandler(StreamHandler):
 
 
 class AnthropicChatLLM(ChatLLM):
+    model: str = "claude-2"
+
     def format_messages(
         self, messages: list[Message]
     ) -> Union[str, dict, list[Union[str, dict]]]:

--- a/src/marvin/engine/language_models/azure_openai.py
+++ b/src/marvin/engine/language_models/azure_openai.py
@@ -4,6 +4,8 @@ from .openai import OpenAIChatLLM
 
 
 class AzureOpenAIChatLLM(OpenAIChatLLM):
+    model: str = "gpt-35-turbo-0613"
+
     def _get_openai_settings(self) -> dict:
         # do not load the base openai settings; any azure settings must be set
         # explicitly

--- a/src/marvin/engine/language_models/base.py
+++ b/src/marvin/engine/language_models/base.py
@@ -65,7 +65,7 @@ class OpenAIFunction(MarvinBaseModel):
 
 class ChatLLM(MarvinBaseModel, abc.ABC):
     name: str = None
-    model: str = Field(default_factory=lambda: marvin.settings.llm_model)
+    model: str
     max_tokens: int = Field(default_factory=lambda: marvin.settings.llm_max_tokens)
     temperature: float = Field(default_factory=lambda: marvin.settings.llm_temperature)
 
@@ -133,4 +133,4 @@ def chat_llm(model: str = None, **kwargs) -> ChatLLM:
 
         return AzureOpenAIChatLLM(model=model_name, **kwargs)
     else:
-        raise ValueError(f"Unknown provider / model: {model}")
+        raise ValueError(f"Unknown provider/model: {model}")

--- a/src/marvin/engine/language_models/base.py
+++ b/src/marvin/engine/language_models/base.py
@@ -80,7 +80,12 @@ class ChatLLM(MarvinBaseModel, abc.ABC):
         return 4096
 
     def get_tokens(self, text: str, **kwargs) -> list[int]:
-        enc = tiktoken.encoding_for_model(self.model)
+        try:
+            enc = tiktoken.encoding_for_model(self.model)
+        # fallback to the gpt-3.5-turbo tokenizer if the model is not found
+        # note this will give the wrong answer for non-OpenAI models
+        except KeyError:
+            enc = tiktoken.encoding_for_model("gpt-3.5-turbo")
         return enc.encode(text)
 
     async def __call__(self, messages, *args, **kwargs):

--- a/src/marvin/engine/language_models/openai.py
+++ b/src/marvin/engine/language_models/openai.py
@@ -75,6 +75,8 @@ class OpenAIStreamHandler(StreamHandler):
 
 
 class OpenAIChatLLM(ChatLLM):
+    model: str = "gpt-3.5-turbo"
+
     @property
     def context_size(self) -> int:
         return CONTEXT_SIZES.get(self.model, 4096)


### PR DESCRIPTION
This should close #475, close #476, and supersede #479

- Removes the default `ChatLLM` model that is causing issues, because the setting its based on includes a provider prefix which is really only for dispatching via the `chat_llm` helper function, not for use by actual `ChatLLM` classes. Furthermore there is no sensible default for a global `ChatLLM` class
- adds default models for each provider (openai, azure openai, anthropic)
- fixes the tokenization lookup to fallback on gpt-3.5 turbo. Note: this is probably going to fail for non-openai models, but at this time openai is the only provider that allows us to do the logit bias trick anyway