### PR TITLE
Prevent classifier use with non-GPT models

### DIFF
--- a/src/marvin/components/ai_classifier.py
+++ b/src/marvin/components/ai_classifier.py
@@ -39,6 +39,11 @@ def ai_classifier(
         raise ValueError(
             "The model must be configured with max_tokens=1 to use ai_classifier"
         )
+    elif not model.name.startswith("gpt-"):
+        raise ValueError(
+            "At this time, AI Classifiers rely on a tokenized approach that is only"
+            " compatible with OpenAI models."
+        )
     if system_prompt is None:
         system_prompt = ClassifierSystem
     if user_prompt is None:

--- a/src/marvin/components/ai_classifier.py
+++ b/src/marvin/components/ai_classifier.py
@@ -35,14 +35,15 @@ def ai_classifier(
 
     if model is None:
         model = chat_llm(max_tokens=1, temperature=0)
-    elif model.max_tokens != 1:
-        raise ValueError(
-            "The model must be configured with max_tokens=1 to use ai_classifier"
-        )
-    elif not model.name.startswith("gpt-"):
+
+    if not model.model.startswith("gpt-"):
         raise ValueError(
             "At this time, AI Classifiers rely on a tokenized approach that is only"
             " compatible with OpenAI models."
+        )
+    elif model.max_tokens != 1:
+        raise ValueError(
+            "The model must be configured with max_tokens=1 to use ai_classifier"
         )
     if system_prompt is None:
         system_prompt = ClassifierSystem

--- a/tests/test_components/test_ai_classifier.py
+++ b/tests/test_components/test_ai_classifier.py
@@ -1,0 +1,23 @@
+from enum import Enum
+
+import pytest
+from marvin import ai_classifier
+from marvin.engine.language_models import chat_llm
+
+
+class TestAIClassifiers:
+    def test_invalid_model(self):
+        with pytest.raises(ValueError, match="(only compatible with OpenAI models)"):
+
+            @ai_classifier(model=chat_llm("anthropic/claude-2"))
+            class Sentiment(Enum):
+                POSITIVE = "Positive"
+                NEGATIVE = "Negative"
+
+    def test_invalid_max_tokens(self):
+        with pytest.raises(ValueError, match="(max_tokens=1)"):
+
+            @ai_classifier(model=chat_llm("openai/gpt-4", max_tokens=100))
+            class Sentiment(Enum):
+                POSITIVE = "Positive"
+                NEGATIVE = "Negative"


### PR DESCRIPTION
In fixing tokenization in #480, it occurred to me that AI Classifiers *require* an openai compatible model because 1) we have the tokenizer and 2) we use the logit_bias trick to restrict tokens. Therefore, trying to use a classifier with any other provider would fail at this time. This PR adds an error message in that circumstance (using `gpt-` as a valid model prefix which I think is good enough? But we could expand it if not. cc @aaazzam )