### PR TITLE
ensure multiqueried excerpts are not too small

### DIFF
--- a/src/marvin/tools/chroma.py
+++ b/src/marvin/tools/chroma.py
@@ -108,7 +108,12 @@ class MultiQueryChroma(Tool):
         where_document: Optional[dict] = None,
         include: Optional[list[QueryResultType]] = None,
         max_characters: int = 2000,
+        max_queries: int = 5,
     ) -> str:
+        if len(queries) > max_queries:
+            # make sure excerpts are not too short
+            queries = queries[:max_queries]
+
         coros = [
             query_chroma(
                 query,


### PR DESCRIPTION
when the LLM provides a large number of queries to the tool, the max characters restriction makes the result for each query unhelpfully short