### PR TITLE
merge openai api key

### DIFF
--- a/docs/src/docs/utilities/openai.ipynb
+++ b/docs/src/docs/utilities/openai.ipynb
@@ -30,7 +30,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import marvin\n",
+    "import marvin.openai\n",
     "\n",
     "marvin.openai.ChatCompletion(model=\"gpt-3.5-turbo\").create(\n",
     "    messages=[{\"role\": \"user\", \"content\": \"Tell me a joke!\"}]\n",
@@ -54,7 +54,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import marvin\n",
+    "import marvin.openai\n",
     "\n",
     "# Define a smart model.\n",
     "gpt3 = marvin.openai.ChatCompletion(model=\"gpt-3.5-turbo\")\n",
@@ -82,8 +82,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import marvin\n",
-    "\n",
     "pirate_system_message = {\"role\": \"system\", \"content\": \"You talk like a pirate\"}\n",
     "\n",
     "# Define a smart, public model.\n",
@@ -632,7 +630,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.3"
+   "version": "3.11.4"
   },
   "orig_nbformat": 4
  },

--- a/src/marvin/openai/ChatCompletion/__init__.py
+++ b/src/marvin/openai/ChatCompletion/__init__.py
@@ -1,14 +1,20 @@
-import openai
-import pydantic
 import functools
 
+import openai
+from pydantic import BaseSettings, Field
 
-class ChatCompletionConfig(pydantic.BaseSettings):
+import marvin
+
+
+class ChatCompletionConfig(BaseSettings):
     model: str = "gpt-3.5-turbo"
     temperature: float = 0
     functions: list = []
     messages: list = []
-    api_key: str = pydantic.Field(default="", env="OPENAI_API_KEY")
+    api_key: str = Field(
+        default_factory=lambda: marvin.settings.openai.api_key.get_secret_value() or "",
+        env="OPENAI_API_KEY",
+    )
 
     def merge(self, *args, **kwargs):
         _dict = self.dict(exclude_unset=True)

--- a/src/marvin/openai/ChatCompletion/__init__.py
+++ b/src/marvin/openai/ChatCompletion/__init__.py
@@ -1,7 +1,7 @@
 import functools
 
 import openai
-from pydantic import BaseSettings, Field, validator
+from pydantic import BaseSettings, Field
 
 import marvin
 

--- a/src/marvin/openai/ChatCompletion/__init__.py
+++ b/src/marvin/openai/ChatCompletion/__init__.py
@@ -1,7 +1,7 @@
 import functools
 
 import openai
-from pydantic import BaseSettings, Field, SecretStr
+from pydantic import BaseSettings, Field, validator
 
 import marvin
 
@@ -9,29 +9,28 @@ import marvin
 class ChatCompletionConfig(BaseSettings):
     model: str = "gpt-3.5-turbo"
     temperature: float = 0
-    functions: list = []
-    messages: list = []
+    functions: list = Field(default_factory=list)
+    messages: list = Field(default_factory=list)
     api_key: str = Field(
         default_factory=lambda: (
             marvin.settings.openai.api_key.get_secret_value()
-            if isinstance(marvin.settings.openai.api_key, SecretStr)
-            else ""
-        )
+            if marvin.settings.openai.api_key is not None
+            else None
+        ),
+        env="OPENAI_API_KEY",
     )
 
     def merge(self, *args, **kwargs):
-        _dict = self.dict(exclude_unset=True)
         for key, value in kwargs.items():
             if type(value) == list:
-                _dict[key] = _dict.get(key, []) + value
+                setattr(self, key, getattr(self, key, []) + value)
             else:
-                _dict[key] = value
-        return _dict
+                setattr(self, key, value)
+        return {k: v for k, v in self.__dict__.items() if v != []}
 
 
 class ChatCompletion(openai.ChatCompletion):
     def __new__(cls, *args, **kwargs):
-        print(ChatCompletionConfig(**kwargs))
         subclass = type(
             "ChatCompletion",
             (ChatCompletion,),

--- a/src/marvin/openai/ChatCompletion/__init__.py
+++ b/src/marvin/openai/ChatCompletion/__init__.py
@@ -1,7 +1,7 @@
 import functools
 
 import openai
-from pydantic import BaseSettings, Field
+from pydantic import BaseSettings, Field, SecretStr
 
 import marvin
 
@@ -12,8 +12,11 @@ class ChatCompletionConfig(BaseSettings):
     functions: list = []
     messages: list = []
     api_key: str = Field(
-        default_factory=lambda: marvin.settings.openai.api_key.get_secret_value() or "",
-        env="OPENAI_API_KEY",
+        default_factory=lambda: (
+            marvin.settings.openai.api_key.get_secret_value()
+            if isinstance(marvin.settings.openai.api_key, SecretStr)
+            else ""
+        )
     )
 
     def merge(self, *args, **kwargs):
@@ -28,6 +31,7 @@ class ChatCompletionConfig(BaseSettings):
 
 class ChatCompletion(openai.ChatCompletion):
     def __new__(cls, *args, **kwargs):
+        print(ChatCompletionConfig(**kwargs))
         subclass = type(
             "ChatCompletion",
             (ChatCompletion,),


### PR DESCRIPTION
as mentioned in #497, the `marvin.openai.ChatCompletion` was not respecting `marvin.settings.openai.api_key` because `merge` was not passing it through to `create`

this now works (tested in colab) by setting either `marvin.settings.openai.api_key` or `openai.api_key`

```python
import marvin

marvin.settings.openai.api_key = "sk-..."

marvin.openai.ChatCompletion(model="gpt-3.5-turbo").create(
    messages=[{"role": "user", "content": "Tell me a joke!"}]
)
```