### PR TITLE
FIX openai utilities documentation

### DIFF
--- a/docs/src/docs/utilities/openai.ipynb
+++ b/docs/src/docs/utilities/openai.ipynb
@@ -148,7 +148,7 @@
     "    return x + y\n",
     "\n",
     "\n",
-    "add.schema"
+    "add.schema()"
    ]
   },
   {
@@ -169,8 +169,11 @@
     "    \"name\": \"add\",\n",
     "    \"description\": \"Adds two numbers together\",\n",
     "    \"parameters\": {\n",
-    "        \"x\": {\"type\": \"int\", \"description\": null},\n",
-    "        \"y\": {\"type\": \"int\", \"description\": null},\n",
+    "        \"type\": \"object\",\n",
+    "        \"properties\": {\n",
+    "            \"x\": {\"title\": \"X\", \"type\": \"integer\"},\n",
+    "            \"y\": {\"title\": \"Y\", \"type\": \"integer\"},\n",
+    "        },\n",
     "        \"required\": [\"x\", \"y\"],\n",
     "    },\n",
     "}"
@@ -202,7 +205,9 @@
     "\n",
     "\n",
     "response = openai.ChatCompletion.create(\n",
-    "    messages=[{\"role\": \"user\", \"content\": \"What is 123123 + 85858?\"}]\n",
+    "    model=\"gpt-4\",\n",
+    "    functions=[add.schema()],\n",
+    "    messages=[{\"role\": \"user\", \"content\": \"What is 123123 + 85858?\"}],\n",
     ")\n",
     "\n",
     "add.from_response(response) == 208981"
@@ -321,6 +326,7 @@
     "\n",
     "\n",
     "response = openai.ChatCompletion.create(\n",
+    "    model=\"gpt-4\",\n",
     "    functions=registry.schema,\n",
     "    messages=[{\"role\": \"user\", \"content\": \"What is 123123 - 85858?\"}],\n",
     ")\n",
@@ -474,10 +480,10 @@
     "    \"messages\": [\n",
     "        {\n",
     "            \"role\": \"user\",\n",
-    "            \"content\": f\"\"\"A function in python that described by the following schema:\\n {add.schema}\"\"\",\n",
+    "            \"content\": f\"\"\"A function in python that described by the following schema:\\n {add.schema()}\"\"\",\n",
     "        },\n",
     "    ],\n",
-    "    **write_code.schema,\n",
+    "    **write_code.schema(),\n",
     "}"
    ]
   },


### PR DESCRIPTION
This is only a partial fix. Multiple locations in the notebook invoked schema as property. However, at least outside of function registries, it is a method. Given recent refactors, I assume this was correct at one point but no longer?

Also changed the evaluation section to include both model and functions parameters. The model one may have been omitted for pedagogical reasons but absence of the functions one makes things confusing (i.e. i thought there was a global implicit operation induced by annotating with openai_fn before the immediately following section.)

Also not sure where `.code()` comes from in the codegen example. Didn't investigate just noticed i couldn't run the cells there.

Assume the actual fix is turning schema into a property, but I don't know the code-base/history enough to make that call. So this is probably a code-documented issue rather than a PR.