### PR TITLE
add `__version__` and cli command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,3 +172,6 @@ local_examples/
 
 # Chroma
 .chroma/
+
+# Marvin
+src/marvin/_version.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,7 @@ requires = ["setuptools>=45", "setuptools_scm[toml]>=6.2"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
+write_to = "src/marvin/_version.py"
 
 # pytest configuration
 [tool.pytest.ini_options]

--- a/src/marvin/__init__.py
+++ b/src/marvin/__init__.py
@@ -9,6 +9,12 @@ from .components import (
     AIModelFactory,
 )
 
+try:
+    from ._version import version as __version__
+except ImportError:
+    __version__ = "unknown"
+
+
 from .core.ChatCompletion import ChatCompletion
 
 __all__ = [

--- a/src/marvin/cli/__init__.py
+++ b/src/marvin/cli/__init__.py
@@ -15,7 +15,7 @@ app.acommand()(chat)
 def version():
     from marvin import __version__
 
-    print(f"{__version__=!r}")
+    print(__version__)
 
 
 if __name__ == "__main__":

--- a/src/marvin/cli/__init__.py
+++ b/src/marvin/cli/__init__.py
@@ -1,5 +1,6 @@
 from .typer import AsyncTyper
 
+
 from .admin import app as admin
 from .chat import chat
 
@@ -8,6 +9,13 @@ app = AsyncTyper()
 app.add_typer(admin, name="admin")
 
 app.acommand()(chat)
+
+
+@app.command()
+def version():
+    from marvin import __version__
+
+    print(f"{__version__=!r}")
 
 
 if __name__ == "__main__":

--- a/src/marvin/cli/__init__.py
+++ b/src/marvin/cli/__init__.py
@@ -1,6 +1,5 @@
 from .typer import AsyncTyper
 
-
 from .admin import app as admin
 from .chat import chat
 
@@ -13,9 +12,15 @@ app.acommand()(chat)
 
 @app.command()
 def version():
+    import platform
+    import sys
     from marvin import __version__
 
-    print(__version__)
+    print(f"Version:\t\t{__version__}")
+
+    print(f"Python version:\t\t{sys.version.split()[0]}")
+
+    print(f"OS/Arch:\t\t{platform.system().lower()}/{platform.machine().lower()}")
 
 
 if __name__ == "__main__":

--- a/src/marvin/core/ChatCompletion/base/__init__.py
+++ b/src/marvin/core/ChatCompletion/base/__init__.py
@@ -294,7 +294,8 @@ class BaseChatCompletion(
                 fn_args = message.get("function_call", {}).get("arguments")
 
                 logger.debug_kv(
-                    f"Running function [{fn_name} with payload: {fn_args}",
+                    "Function",
+                    f"Running {fn_name!r} with payload: {fn_args}",
                     key_style="green",
                 )
                 try:


### PR DESCRIPTION
closes #535 

adds a `__version__` via `setuptools_scm` and a cli command to display it

```python
In [1]: import marvin

In [2]: marvin.__version__
Out[2]: '1.4.2.dev1+gfe9c58ae.d20230914'

In [3]: !marvin version
Version:		1.4.2.dev1+gfe9c58ae.d20230914
Python version:		3.11.4
OS/Arch:		darwin/arm64
```
