### PR TITLE
fix pydantic v1 behavior - allow `BaseModel` return for `ai_fn`

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -38,14 +38,14 @@ jobs:
         python-version: ['3.9', '3.10', '3.11']
         test-type: ['not llm']
         llm_model: ['openai/gpt-3.5-turbo']
-        pydantic_version: ['>2.4.2']
+        pydantic_version: ['>=2.4.2']
 
         include:
           - python-version: '3.9'
             os: 'ubuntu-latest'
             test-type: 'llm'
             llm_model: 'openai/gpt-3.5-turbo'
-            pydantic_version: '>2.4.2'
+            pydantic_version: '>=2.4.2'
           
           - python-version: '3.9'
             os: 'ubuntu-latest'

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Install Marvin
         run: pip install ".[tests]"
       - name: Run ${{ matrix.test-type }} tests (${{ matrix.llm_model }})
-        run: pip install "pydantic${{ matrix.pydantic_version }}" ".[tests]"
+        run: pip install ".[tests]" "pydantic${{ matrix.pydantic_version }}"
         env:
           MARVIN_LLM_MODEL: ${{ matrix.llm_model }}
         if: ${{ !(github.event.pull_request.head.repo.fork && matrix.test-type == 'llm') }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -75,13 +75,8 @@ jobs:
       - name: Install Marvin
         run: pip install ".[tests]"
 
-      - name: Install pydantic v1
-        run: pip install "pydantic<2"
-        if: ${{ matrix.pydantic_version == '<2' }}
-
-      - name: Install pydantic v2
-        run: pip install ".[pydantic-v2]"
-        if: ${{ matrix.pydantic_version == '>=2.4.2' }}
+      - name: Install pydantic
+        run: pip install "pydantic${{ matrix.pydantic_version }}"
 
 
       - name: Run ${{ matrix.test-type }} tests (${{ matrix.llm_model }})

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -30,7 +30,7 @@ permissions:
 
 jobs:
   run_tests:
-    name: ${{ matrix.test-type }} w/ python ${{ matrix.python-version }} on ${{ matrix.os }}
+    name: ${{ matrix.test-type }} w/ python ${{ matrix.python-version }} | pydantic ${{ matrix.pydantic_version }} on ${{ matrix.os }}
     timeout-minutes: 15
     strategy:
       matrix:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -38,12 +38,26 @@ jobs:
         python-version: ['3.9', '3.10', '3.11']
         test-type: ['not llm']
         llm_model: ['openai/gpt-3.5-turbo']
+        pydantic_version: ['']
 
         include:
           - python-version: '3.9'
             os: 'ubuntu-latest'
             test-type: 'llm'
             llm_model: 'openai/gpt-3.5-turbo'
+            pydantic_version: ''
+          
+          - python-version: '3.9'
+            os: 'ubuntu-latest'
+            test-type: 'llm'
+            llm_model: 'openai/gpt-3.5-turbo'
+            pydantic_version: '<2'
+
+          - python-version: '3.9'
+            os: 'ubuntu-latest'
+            test-type: 'not llm'
+            llm_model: 'openai/gpt-3.5-turbo'
+            pydantic_version: '<2'
 
     runs-on: ${{ matrix.os }}
 
@@ -61,7 +75,7 @@ jobs:
       - name: Install Marvin
         run: pip install ".[tests]"
       - name: Run ${{ matrix.test-type }} tests (${{ matrix.llm_model }})
-        run: pytest -vv -m "${{ matrix.test-type }}"
+        run: pip install "pydantic${{ matrix.pydantic_version }}" ".[tests]"
         env:
           MARVIN_LLM_MODEL: ${{ matrix.llm_model }}
         if: ${{ !(github.event.pull_request.head.repo.fork && matrix.test-type == 'llm') }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -74,8 +74,18 @@ jobs:
           cache: "pip"
       - name: Install Marvin
         run: pip install ".[tests]"
+
+      - name: Install pydantic v1
+        run: pip install "pydantic<2"
+        if: ${{ matrix.pydantic_version == '<2' }}
+
+      - name: Install pydantic v2
+        run: pip install ".[pydantic-v2]"
+        if: ${{ matrix.pydantic_version == '>=2.4.2' }}
+
+
       - name: Run ${{ matrix.test-type }} tests (${{ matrix.llm_model }})
-        run: pip install ".[tests]" "pydantic${{ matrix.pydantic_version }}"
+        run: pytest -vv -m ${{ matrix.test-type }}
         env:
           MARVIN_LLM_MODEL: ${{ matrix.llm_model }}
         if: ${{ !(github.event.pull_request.head.repo.fork && matrix.test-type == 'llm') }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -38,14 +38,14 @@ jobs:
         python-version: ['3.9', '3.10', '3.11']
         test-type: ['not llm']
         llm_model: ['openai/gpt-3.5-turbo']
-        pydantic_version: ['']
+        pydantic_version: ['>2.4.2']
 
         include:
           - python-version: '3.9'
             os: 'ubuntu-latest'
             test-type: 'llm'
             llm_model: 'openai/gpt-3.5-turbo'
-            pydantic_version: ''
+            pydantic_version: '>2.4.2'
           
           - python-version: '3.9'
             os: 'ubuntu-latest'

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -85,7 +85,7 @@ jobs:
 
 
       - name: Run ${{ matrix.test-type }} tests (${{ matrix.llm_model }})
-        run: pytest -vv -m ${{ matrix.test-type }}
+        run: pytest -vv -m "${{ matrix.test-type }}"
         env:
           MARVIN_LLM_MODEL: ${{ matrix.llm_model }}
         if: ${{ !(github.event.pull_request.head.repo.fork && matrix.test-type == 'llm') }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dev = [
     "mkdocstrings[python]~=0.22",
     "pdbpp~=0.10",
     "pre-commit>=2.21,<4.0",
+    "pydantic",
     "ruff",
 ]
 tests = [
@@ -49,8 +50,6 @@ tests = [
     "pytest-sugar~=0.9",
     "pytest~=7.3.1",
 ]
-
-pydantic-v2 = ["pydantic>=2.4.2", "pydantic-settings>=2.0.0"]
 
 framework = [
     "aiosqlite>=0.19.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,8 +48,10 @@ tests = [
     "pytest-rerunfailures>=10,<13",
     "pytest-sugar~=0.9",
     "pytest~=7.3.1",
-    "pydantic-settings>=2.0.0",
 ]
+
+pydantic-v2 = ["pydantic>=2.4.2", "pydantic-settings>=2.0.0"]
+
 framework = [
     "aiosqlite>=0.19.0",
     "alembic>=1.11.1",

--- a/src/marvin/_compat.py
+++ b/src/marvin/_compat.py
@@ -10,10 +10,7 @@ from typing import (
     get_origin,
 )
 
-from pydantic import create_model
 from pydantic.version import VERSION as PYDANTIC_VERSION
-
-_ModelT = TypeVar("_ModelT", bound="BaseModel")
 
 PYDANTIC_V2 = PYDANTIC_VERSION.startswith("2.")
 
@@ -22,7 +19,10 @@ if PYDANTIC_V2:
         BaseModel,
         BaseSettings,
         Field,
+        PrivateAttr,
         SecretStr,
+        ValidationError,
+        create_model,
         validate_arguments,
     )
 
@@ -33,13 +33,19 @@ if PYDANTIC_V2:
 else:
     from pydantic import (  # noqa # type: ignore
         BaseSettings,
+        BaseModel,
+        create_model,
         Field,
         SecretStr,
         validate_arguments,
         validator as field_validator,
+        ValidationError,
+        PrivateAttr,
     )
 
     SettingsConfigDict = BaseSettings.Config
+
+_ModelT = TypeVar("_ModelT", bound=BaseModel)
 
 
 def model_dump(model: _ModelT, **kwargs: Any) -> dict[str, Any]:

--- a/src/marvin/_compat.py
+++ b/src/marvin/_compat.py
@@ -17,7 +17,6 @@ PYDANTIC_V2 = PYDANTIC_VERSION.startswith("2.")
 if PYDANTIC_V2:
     from pydantic.v1 import (
         BaseSettings,
-        Field,
         PrivateAttr,
         SecretStr,
         ValidationError,
@@ -27,7 +26,7 @@ if PYDANTIC_V2:
 
     SettingsConfigDict = BaseSettings.Config
 
-    from pydantic import BaseModel, field_validator  # noqa # type: ignore
+    from pydantic import BaseModel, Field, field_validator  # noqa # type: ignore
 
 else:
     from pydantic import (  # noqa # type: ignore

--- a/src/marvin/_compat.py
+++ b/src/marvin/_compat.py
@@ -16,7 +16,6 @@ PYDANTIC_V2 = PYDANTIC_VERSION.startswith("2.")
 
 if PYDANTIC_V2:
     from pydantic.v1 import (
-        BaseModel,
         BaseSettings,
         Field,
         PrivateAttr,
@@ -28,7 +27,7 @@ if PYDANTIC_V2:
 
     SettingsConfigDict = BaseSettings.Config
 
-    from pydantic import field_validator  # noqa # type: ignore
+    from pydantic import BaseModel, field_validator  # noqa # type: ignore
 
 else:
     from pydantic import (  # noqa # type: ignore

--- a/src/marvin/_compat.py
+++ b/src/marvin/_compat.py
@@ -10,7 +10,7 @@ from typing import (
     get_origin,
 )
 
-from pydantic import BaseModel, create_model
+from pydantic import create_model
 from pydantic.version import VERSION as PYDANTIC_VERSION
 
 _ModelT = TypeVar("_ModelT", bound="BaseModel")
@@ -19,6 +19,7 @@ PYDANTIC_V2 = PYDANTIC_VERSION.startswith("2.")
 
 if PYDANTIC_V2:
     from pydantic.v1 import (
+        BaseModel,
         BaseSettings,
         Field,
         SecretStr,

--- a/src/marvin/_compat.py
+++ b/src/marvin/_compat.py
@@ -20,13 +20,17 @@ if PYDANTIC_V2:
         PrivateAttr,
         SecretStr,
         ValidationError,
-        create_model,
         validate_arguments,
     )
 
     SettingsConfigDict = BaseSettings.Config
 
-    from pydantic import BaseModel, Field, field_validator  # noqa # type: ignore
+    from pydantic import (
+        BaseModel,
+        Field,
+        create_model,
+        field_validator,
+    )
 
 else:
     from pydantic import (  # noqa # type: ignore

--- a/src/marvin/components/ai_classifier.py
+++ b/src/marvin/components/ai_classifier.py
@@ -4,9 +4,9 @@ from enum import Enum, EnumMeta  # noqa
 from functools import partial
 from typing import Any, Callable, Literal, Optional, TypeVar
 
-from pydantic import BaseModel, Field
 from typing_extensions import ParamSpec, Self
 
+from marvin._compat import BaseModel, Field
 from marvin.core.ChatCompletion import ChatCompletion
 from marvin.core.ChatCompletion.abstract import AbstractChatCompletion
 from marvin.prompts import Prompt, prompt_fn

--- a/src/marvin/components/ai_function.py
+++ b/src/marvin/components/ai_function.py
@@ -118,10 +118,14 @@ class AIFunction(BaseModel, Generic[P, T]):
         *args: P.args,
         **kwargs: P.kwargs,
     ) -> Any:
-        return getattr(
-            self.as_chat_completion(*args, **kwargs).create().to_model(),
-            self.response_model_field_name or "output",
-        )
+        model_instance = self.as_chat_completion(*args, **kwargs).create().to_model()
+
+        response_model_field_name = self.response_model_field_name or "output"
+
+        if not (output := getattr(model_instance, response_model_field_name, None)):
+            return model_instance
+
+        return output
 
     async def acall(
         self,

--- a/src/marvin/components/ai_model.py
+++ b/src/marvin/components/ai_model.py
@@ -3,9 +3,9 @@ import inspect
 from functools import partial
 from typing import Any, Callable, Optional, TypeVar
 
-from pydantic import BaseModel
 from typing_extensions import ParamSpec, Self
 
+from marvin._compat import BaseModel
 from marvin.core.ChatCompletion import ChatCompletion
 from marvin.core.ChatCompletion.abstract import AbstractChatCompletion
 from marvin.prompts import Prompt, prompt_fn

--- a/src/marvin/components/ai_model_factory.py
+++ b/src/marvin/components/ai_model_factory.py
@@ -1,7 +1,6 @@
 from typing import Optional
 
-from pydantic import BaseModel
-
+from marvin._compat import BaseModel
 from marvin.components.ai_model import ai_model
 
 

--- a/src/marvin/components/library/ai_models.py
+++ b/src/marvin/components/library/ai_models.py
@@ -2,11 +2,10 @@ import json
 from typing import Optional
 
 import httpx
-from pydantic import BaseModel
 from typing_extensions import Self
 
 from marvin import ai_model
-from marvin._compat import Field, SecretStr, field_validator
+from marvin._compat import BaseModel, Field, SecretStr, field_validator
 from marvin.settings import MarvinBaseSettings
 
 

--- a/src/marvin/core/ChatCompletion/__init__.py
+++ b/src/marvin/core/ChatCompletion/__init__.py
@@ -1,6 +1,7 @@
 from typing import Optional, Any, TypeVar
-from pydantic import BaseModel
 from .abstract import AbstractChatCompletion
+
+from marvin._compat import BaseModel
 from marvin.settings import settings
 
 T = TypeVar(

--- a/src/marvin/core/ChatCompletion/abstract.py
+++ b/src/marvin/core/ChatCompletion/abstract.py
@@ -1,9 +1,8 @@
 from abc import ABC, abstractmethod
 from typing import Any, Generic, Optional, TypeVar
 
-from marvin._compat import model_copy, model_dump
+from marvin._compat import BaseModel, Field, model_copy, model_dump
 from marvin.utilities.messages import Message
-from pydantic import BaseModel, Field
 from typing_extensions import Self
 
 from .handlers import Request, Response, Turn

--- a/src/marvin/core/ChatCompletion/handlers.py
+++ b/src/marvin/core/ChatCompletion/handlers.py
@@ -12,11 +12,10 @@ from typing import (
     overload,
 )
 
-from marvin._compat import cast_to_json, model_dump
+from marvin._compat import BaseModel, Field, cast_to_json, model_dump
 from marvin.utilities.async_utils import run_sync
 from marvin.utilities.logging import get_logger
 from marvin.utilities.messages import Message, Role
-from pydantic import BaseModel, Field
 from typing_extensions import ParamSpec
 
 from .utils import parse_raw
@@ -83,6 +82,9 @@ class Choice(BaseModel):
     message: Message
     index: int
     finish_reason: str
+
+    class Config:
+        arbitrary_types_allowed = True
 
 
 class Usage(BaseModel):

--- a/src/marvin/core/ChatCompletion/providers/openai.py
+++ b/src/marvin/core/ChatCompletion/providers/openai.py
@@ -1,14 +1,13 @@
 import inspect
 from typing import Any, AsyncGenerator, Callable, Optional, TypeVar, Union
 
-from marvin._compat import cast_to_json, model_dump
+from marvin._compat import BaseModel, cast_to_json, model_dump
 from marvin.settings import settings
 from marvin.types import Function
 from marvin.utilities.async_utils import create_task
 from marvin.utilities.messages import Message
 from marvin.utilities.streaming import StreamHandler
 from openai.openai_object import OpenAIObject
-from pydantic import BaseModel
 
 from ..abstract import AbstractChatCompletion
 from ..handlers import Request, Response, Usage

--- a/src/marvin/openai/ChatCompletion/__init__.py
+++ b/src/marvin/openai/ChatCompletion/__init__.py
@@ -1,13 +1,10 @@
-from pydantic import BaseModel, Field, validator, Extra, BaseSettings, root_validator
 from pydantic.main import ModelMetaclass
 
-from typing import Any, Callable, List, Optional, Type, Union, Literal
-from marvin import settings
-from marvin.types import Function
+from typing import Any, Callable, Optional
 from operator import itemgetter
-from marvin.utilities.module_loading import import_string
-import warnings
-import copy
+
+from marvin import settings
+from marvin._compat import BaseModel, Extra, Field
 from marvin.types.request import Request as BaseRequest
 from marvin.engine import ChatCompletionBase
 

--- a/src/marvin/openai/Function/Registry/__init__.py
+++ b/src/marvin/openai/Function/Registry/__init__.py
@@ -1,8 +1,4 @@
-from typing import Any, Callable, Dict, List, Optional, Set, Type, Union
-from fastapi.routing import APIRouter
-from pydantic import BaseModel, validate_arguments
-from marvin.utilities.types import function_to_model
-from marvin.utilities.messages import Message
+from typing import Any
 from marvin.openai.Function import openai_fn
 from openai.openai_object import OpenAIObject
 from marvin.functions import FunctionRegistry

--- a/src/marvin/settings.py
+++ b/src/marvin/settings.py
@@ -5,7 +5,6 @@ from typing import Any, Literal, Optional, Union
 
 from ._compat import (
     BaseSettings,
-    Field,
     SecretStr,
     model_dump,
 )
@@ -155,22 +154,19 @@ class Settings(MarvinBaseSettings):
     azure_openai: AzureOpenAI = AzureOpenAI()
 
     # SLACK
-    slack_api_token: Optional[SecretStr] = Field(
-        default=None,
-        description="The Slack API token to use for the Slack client",
-    )
+    slack_api_token: Optional[SecretStr] = None
 
     # TOOLS
 
     # chroma
-    chroma_server_host: Optional[str] = Field(default=None)
-    chroma_server_http_port: Optional[int] = Field(default=None)
+    chroma_server_host: Optional[str] = None
+    chroma_server_http_port: Optional[int] = None
 
     # github
-    github_token: Optional[SecretStr] = Field(default=None)
+    github_token: Optional[SecretStr] = None
 
     # wolfram
-    wolfram_app_id: Optional[SecretStr] = Field(default=None)
+    wolfram_app_id: Optional[SecretStr] = None
 
     def get_defaults(self, provider: Optional[str] = None) -> dict[str, Any]:
         response: dict[str, Any] = {}

--- a/src/marvin/types/function.py
+++ b/src/marvin/types/function.py
@@ -3,9 +3,7 @@ import inspect
 import re
 from typing import Callable, Optional, Type
 
-from pydantic import BaseModel
-
-from marvin._compat import validate_arguments
+from marvin._compat import BaseModel, validate_arguments
 
 extraneous_fields = [
     "args",

--- a/src/marvin/utilities/messages.py
+++ b/src/marvin/utilities/messages.py
@@ -33,6 +33,10 @@ class FunctionCall(BaseModel):
     arguments: str
 
 
+def utcnow():
+    return datetime.now(ZoneInfo("UTC"))
+
+
 class Message(MarvinBaseModel):
     role: Role
     content: Optional[str] = Field(default=None, description="The message content")
@@ -48,7 +52,7 @@ class Message(MarvinBaseModel):
     id: uuid.UUID = Field(default_factory=uuid.uuid4, exclude=True)
     data: Optional[dict[str, Any]] = Field(default_factory=dict, exclude=True)
     timestamp: datetime = Field(
-        default_factory=lambda: datetime.now(ZoneInfo("UTC")),
+        default_factory=utcnow,
         exclude=True,
     )
 

--- a/src/marvin/utilities/messages.py
+++ b/src/marvin/utilities/messages.py
@@ -5,10 +5,9 @@ from enum import Enum
 from typing import Any, Optional
 from zoneinfo import ZoneInfo
 
-from pydantic import BaseModel, Field
 from typing_extensions import Self
 
-from marvin._compat import field_validator
+from marvin._compat import BaseModel, Field, field_validator
 from marvin.utilities.strings import split_text_by_tokens
 from marvin.utilities.types import MarvinBaseModel
 

--- a/src/marvin/utilities/types.py
+++ b/src/marvin/utilities/types.py
@@ -3,9 +3,7 @@ import logging
 from types import GenericAlias
 from typing import Any, Callable, _SpecialForm
 
-import pydantic
-from pydantic import BaseModel, PrivateAttr
-
+from marvin._compat import BaseModel, PrivateAttr, create_model
 from marvin.utilities.logging import get_logger
 
 
@@ -54,7 +52,7 @@ def function_to_model(
 
     # Create Pydantic model
     try:
-        Model = pydantic.create_model(name or function.__name__, **fields)
+        Model = create_model(name or function.__name__, **fields)
     except RuntimeError as exc:
         if "see `arbitrary_types_allowed` " in str(exc):
             raise ValueError(
@@ -85,7 +83,7 @@ def safe_issubclass(type_, classes):
 
 
 def type_to_schema(type_, set_root_type: bool = True) -> dict:
-    if safe_issubclass(type_, pydantic.BaseModel):
+    if safe_issubclass(type_, BaseModel):
         schema = type_.schema()
         # if the docstring was updated at runtime, make it the description
         if type_.__doc__ and type_.__doc__ != schema.get("description"):
@@ -94,13 +92,13 @@ def type_to_schema(type_, set_root_type: bool = True) -> dict:
 
     elif set_root_type:
 
-        class Model(pydantic.BaseModel):
+        class Model(BaseModel):
             __root__: type_
 
         return Model.schema()
     else:
 
-        class Model(pydantic.BaseModel):
+        class Model(BaseModel):
             data: type_
 
         return Model.schema()

--- a/tests/test_components/test_ai_functions.py
+++ b/tests/test_components/test_ai_functions.py
@@ -1,6 +1,7 @@
 import inspect
 
 import pytest
+from marvin._compat import BaseModel
 from marvin.components.ai_function import ai_fn
 
 from tests.utils.mark import pytest_mark_class
@@ -43,6 +44,21 @@ class TestAIFunctions:
 
         result = list_fruit(3)
         assert len(result) == 3
+
+    def test_basemodel_response(self):
+        class Fruit(BaseModel):
+            name: str
+            color: str
+
+        @ai_fn
+        def get_fruit(description: str) -> Fruit:
+            """Returns a fruit with the provided description"""
+
+        fruit = get_fruit("loved by monkeys")
+
+        assert isinstance(fruit, Fruit)
+        assert fruit.name.lower() == "banana"
+        assert fruit.color.lower() == "yellow"
 
 
 @pytest_mark_class("llm")

--- a/tests/test_components/test_ai_functions.py
+++ b/tests/test_components/test_ai_functions.py
@@ -1,8 +1,8 @@
 import inspect
 
 import pytest
-from marvin._compat import BaseModel
-from marvin.components.ai_function import ai_fn
+from marvin import ai_fn
+from pydantic import BaseModel
 
 from tests.utils.mark import pytest_mark_class
 
@@ -55,8 +55,6 @@ class TestAIFunctions:
             """Returns a fruit with the provided description"""
 
         fruit = get_fruit("loved by monkeys")
-
-        assert isinstance(fruit, Fruit)
         assert fruit.name.lower() == "banana"
         assert fruit.color.lower() == "yellow"
 


### PR DESCRIPTION
there were numerous places in the `core.ChatCompletion` and `components` modules where we imported `BaseModel` `Field` and the like from `pydantic` instead of the `_compat` module, and the CI tests were only running pydantic v2 - there was code that only worked on v2 / broke things for people with v1 installed. Further, since `pydantic-settings` was a introduced as a main dep, that likely caused conflicts for anyone with v1 pinned who tried to install marvin. i think we need to be more careful about this going forward and make sure that if we claim compatibility, that this is the case.

this PR:
- standardizes on importing pydantic objects from `_compat`
- fixes another pydantic 2 related bug which broke when an `ai_fn` specified a `BaseModel` subclass return type
- adds a not llm / llm test in CI for pydantic v1