### PR TITLE
make `acall` consistent with `__call__`, add tests, fix a bug

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dev = [
     "mkdocstrings[python]~=0.22",
     "pdbpp~=0.10",
     "pre-commit>=2.21,<4.0",
-    "pydantic",
+    "pydantic[dotenv]",
     "ruff",
 ]
 tests = [

--- a/src/marvin/components/ai_classifier.py
+++ b/src/marvin/components/ai_classifier.py
@@ -11,6 +11,7 @@ from marvin.core.ChatCompletion import ChatCompletion
 from marvin.core.ChatCompletion.abstract import AbstractChatCompletion
 from marvin.prompts import Prompt, prompt_fn
 from marvin.utilities.async_utils import run_sync
+from marvin.utilities.logging import get_logger
 
 T = TypeVar("T", bound=BaseModel)
 
@@ -238,6 +239,10 @@ class AIEnum(Enum, metaclass=AIEnumMeta):
         instructions: Optional[str] = None,
         mode: Optional[Literal["function", "logit_bias"]] = None,
     ) -> Any:
+        get_logger("marvin.AIClassifier").debug_kv(
+            f"Calling `AIEnum` {cls.__name__!r}", f" with value {value!r}."
+        )
+
         ctx = ctx or cls.__metadata__.ctx or {}
         instructions = instructions or cls.__metadata__.instructions
         ctx["instructions"] = instructions or ctx.get("instructions", None)
@@ -257,6 +262,9 @@ class AIEnum(Enum, metaclass=AIEnumMeta):
         instructions: Optional[str] = None,
         mode: Optional[Literal["function", "logit_bias"]] = None,
     ) -> Any:
+        get_logger("marvin.AIClassifier").debug_kv(
+            f"Calling `AIEnum` {cls.__name__!r}", f" with value {value!r}."
+        )
         ctx = ctx or cls.__metadata__.ctx or {}
         instructions = instructions or cls.__metadata__.instructions
         ctx["instructions"] = instructions or ctx.get("instructions", None)

--- a/src/marvin/components/ai_model.py
+++ b/src/marvin/components/ai_model.py
@@ -10,6 +10,7 @@ from marvin.core.ChatCompletion import ChatCompletion
 from marvin.core.ChatCompletion.abstract import AbstractChatCompletion
 from marvin.prompts import Prompt, prompt_fn
 from marvin.utilities.async_utils import run_sync
+from marvin.utilities.logging import get_logger
 
 T = TypeVar("T", bound=BaseModel)
 
@@ -246,6 +247,11 @@ class AIModel(BaseModel):
     ) -> Self:
         metadata = getattr(cls, "__metadata__", {})
 
+        get_logger("marvin.AIModel").debug_kv(
+            f"Calling `ai_model` {cls.__name__!r}",
+            f"with {text!r}",
+        )
+
         # Set default values using a loop to reduce repetition
         default_keys = [
             "ctx",
@@ -273,7 +279,7 @@ class AIModel(BaseModel):
                 **model_kwargs,
             )
             .create()
-            .to_model()
+            .to_model(cls)
         )
         return _model  # type: ignore
 
@@ -291,6 +297,11 @@ class AIModel(BaseModel):
         **model_kwargs: Any,
     ) -> Self:
         metadata = getattr(cls, "__metadata__", {})
+
+        get_logger("marvin.AIModel").debug_kv(
+            f"Calling `ai_model` {cls.__name__!r}",
+            f"with {text!r}",
+        )
 
         # Set default values using a loop to reduce repetition
         default_keys = [
@@ -318,7 +329,7 @@ class AIModel(BaseModel):
                 model=model,
                 **model_kwargs,
             ).acreate()  # type: ignore
-        ).to_model()
+        ).to_model(cls)
         return _model  # type: ignore
 
     @classmethod

--- a/src/marvin/core/ChatCompletion/abstract.py
+++ b/src/marvin/core/ChatCompletion/abstract.py
@@ -140,7 +140,9 @@ class AbstractChatCompletion(
         """
         pass
 
-    def create(self, response_model: Optional[type] = None, **kwargs: Any) -> Turn[T]:
+    def create(
+        self, response_model: Optional[type[T]] = None, **kwargs: Any
+    ) -> Turn[T]:
         """
         Create a completion synchronously.
         Derived classes can override this if they need to change the core logic.

--- a/src/marvin/core/ChatCompletion/handlers.py
+++ b/src/marvin/core/ChatCompletion/handlers.py
@@ -195,10 +195,12 @@ class Turn(BaseModel, Generic[T], extra="allow", arbitrary_types_allowed=True):
                 function_call=None,
             )
 
-    def to_model(self) -> T:
-        if not self.request.response_model:
-            raise ValueError("No response model found.")
-        model = self.request.response_model
+    def to_model(self, model_cls: Optional[type[T]] = None) -> T:
+        model = model_cls or self.request.response_model
+
+        if not model:
+            raise ValueError("No model found.")
+
         pairs = self.get_function_call()
         try:
             return model(**pairs[0][1])

--- a/tests/test_components/test_ai_model.py
+++ b/tests/test_components/test_ai_model.py
@@ -2,6 +2,7 @@ from typing import List, Literal, Optional
 
 import pytest
 from marvin import ai_model
+from marvin.utilities.messages import Message, Role
 from pydantic import BaseModel, Field
 
 from tests.utils.mark import pytest_mark_class
@@ -142,9 +143,30 @@ class TestAIModels:
             )
         )
 
+    def test_correct_class_is_returned(self):
+        @ai_model
+        class Fruit(BaseModel):
+            color: str
+            name: str
+
+        fruit = Fruit("loved by monkeys")
+
+        assert isinstance(fruit, Fruit)
+
+    async def test_correct_class_is_returned_via_acall(self):
+        @ai_model
+        class Fruit(BaseModel):
+            color: str
+            name: str
+
+        fruit = await Fruit.acall("loved by monkeys")
+
+        assert isinstance(fruit, Fruit)
+
 
 @pytest_mark_class("llm")
 class TestAIModelsMessage:
+    @pytest.mark.skip(reason="old behavior, may revisit")
     def test_arithmetic_message(self):
         @ai_model
         class Arithmetic(BaseModel):
@@ -154,23 +176,24 @@ class TestAIModelsMessage:
 
         x = Arithmetic("One plus six")
         assert x.sum == 7
-        # assert isinstance(x._message, Message)
-        # assert x._message.role == Role.FUNCTION_RESPONSE
+        assert isinstance(x._message, Message)
+        assert x._message.role == Role.FUNCTION_RESPONSE
 
 
 @pytest_mark_class("llm")
 class TestInstructions:
-    # def test_instructions_error(self):
-    #     @ai_model
-    #     class Test(BaseModel):
-    #         text: str
+    @pytest.mark.skip(reason="old behavior, may revisit")
+    def test_instructions_error(self):
+        @ai_model
+        class Test(BaseModel):
+            text: str
 
-    #     with pytest.raises(
-    #         ValueError, match="(Received `instructions` but this model)"
-    #     ):
-    #         Test("Hello!", instructions="Translate to French")
-    #     with pytest.raises(ValueError, match="(Received `model` but this model)"):
-    #         Test("Hello!", model=None)
+        with pytest.raises(
+            ValueError, match="(Received `instructions` but this model)"
+        ):
+            Test("Hello!", instructions="Translate to French")
+        with pytest.raises(ValueError, match="(Received `model` but this model)"):
+            Test("Hello!", model=None)
 
     def test_instructions(self):
         @ai_model
@@ -247,15 +270,15 @@ class TestInstructions:
 
 @pytest_mark_class("llm")
 class TestAIModelMapping:
-    # def test_arithmetic(self):
-    #     @ai_model
-    #     class Arithmetic(BaseModel):
-    #         sum: float
+    def test_arithmetic(self):
+        @ai_model
+        class Arithmetic(BaseModel):
+            sum: float
 
-    #     x = Arithmetic.map(["One plus six", "Two plus 100 minus one"])
-    #     assert len(x) == 2
-    #     assert x[0].sum == 7
-    #     assert x[1].sum == 101
+        x = Arithmetic.map(["One plus six", "Two plus 100 minus one"])
+        assert len(x) == 2
+        assert x[0].sum == 7
+        assert x[1].sum == 101
 
     def test_location(self):
         @ai_model


### PR DESCRIPTION
- makes sure v1 pydantic installs get dotenv extra
- adds nice debug logs like ai application / ai_fn for ai_model / ai_classifier
- fixes bug with ai_model where `acall` returns a hydrated `FormatResponse` object instead of the user-defined class