### PR TITLE
fix case where `ai_fn` returns a literal False

### DIFF
--- a/src/marvin/components/ai_function.py
+++ b/src/marvin/components/ai_function.py
@@ -121,7 +121,7 @@ class AIFunction(BaseModel, Generic[P, T]):
         model_instance = self.as_chat_completion(*args, **kwargs).create().to_model()
         response_model_field_name = self.response_model_field_name or "output"
 
-        if not (output := getattr(model_instance, response_model_field_name, None)):
+        if (output := getattr(model_instance, response_model_field_name, None)) is None:
             return model_instance
 
         return output
@@ -137,7 +137,7 @@ class AIFunction(BaseModel, Generic[P, T]):
 
         response_model_field_name = self.response_model_field_name or "output"
 
-        if not (output := getattr(model_instance, response_model_field_name, None)):
+        if (output := getattr(model_instance, response_model_field_name, None)) is None:
             return model_instance
 
         return output

--- a/tests/test_components/test_ai_functions.py
+++ b/tests/test_components/test_ai_functions.py
@@ -45,7 +45,7 @@ class TestAIFunctions:
         result = list_fruit(3)
         assert len(result) == 3
 
-    def test_basemodel_response(self):
+    def test_basemodel_return_annotation(self):
         class Fruit(BaseModel):
             name: str
             color: str
@@ -57,6 +57,14 @@ class TestAIFunctions:
         fruit = get_fruit("loved by monkeys")
         assert fruit.name.lower() == "banana"
         assert fruit.color.lower() == "yellow"
+
+    @pytest.mark.parametrize("name,expected", [("banana", True), ("car", False)])
+    def test_bool_return_annotation(self, name, expected):
+        @ai_fn
+        def is_fruit(name: str) -> bool:
+            """Returns True if the provided name is a fruit"""
+
+        assert is_fruit(name) == expected
 
 
 @pytest_mark_class("llm")


### PR DESCRIPTION
closes #621

the `if not` evaluated to `True` if the literal return from the `ai_fn` is `False`, which means we would actually return the generic response model instead of the annotated return type.

this pr moves to a stricter check `if output is None`