### PR TITLE
support streaming for `ChatCompletion.create`

### DIFF
--- a/src/marvin/core/ChatCompletion/providers/openai.py
+++ b/src/marvin/core/ChatCompletion/providers/openai.py
@@ -4,7 +4,7 @@ from typing import Any, AsyncGenerator, Callable, Optional, TypeVar, Union
 from marvin._compat import BaseModel, cast_to_json, model_dump
 from marvin.settings import settings
 from marvin.types import Function
-from marvin.utilities.async_utils import create_task
+from marvin.utilities.async_utils import create_task, run_sync
 from marvin.utilities.messages import Message
 from marvin.utilities.streaming import StreamHandler
 from openai.openai_object import OpenAIObject
@@ -195,10 +195,9 @@ class OpenAIChatCompletion(AbstractChatCompletion[T]):
         # Use openai's library functions to send the request and get a response
         # Example:
 
-        import openai
-
-        response = openai.ChatCompletion.create(**serialized_request)  # type: ignore
-        return response  # type: ignore
+        return run_sync(
+            self._send_request_async(**serialized_request),
+        )
 
     async def _send_request_async(self, **serialized_request: Any) -> Response[T]:
         """
@@ -216,4 +215,4 @@ class OpenAIChatCompletion(AbstractChatCompletion[T]):
                 callback=handler_fn,
             ).handle_streaming_response(response)
 
-        return response  # type: ignore
+        return response

--- a/tests/test_chat_completion/test_sdk.py
+++ b/tests/test_chat_completion/test_sdk.py
@@ -48,6 +48,37 @@ class TestChatCompletion:
         assert model.name == "Billy"
         assert model.age == 10
 
+    def test_streaming(self):
+        from marvin import openai
+
+        streamed_data = []
+
+        def handler(message):
+            streamed_data.append(message.content)
+
+        completion = openai.ChatCompletion(stream_handler=handler).create(
+            messages=[{"role": "user", "content": "say exactly 'hello'"}],
+        )
+
+        assert completion.response.choices[0].message.content == streamed_data[-1]
+        assert "hello" in streamed_data[-1].lower()
+        assert len(streamed_data) > 1
+
+    async def test_streaming_async(self):
+        from marvin import openai
+
+        streamed_data = []
+
+        async def handler(message):
+            streamed_data.append(message.content)
+
+        completion = await openai.ChatCompletion(stream_handler=handler).acreate(
+            messages=[{"role": "user", "content": "say only 'hello'"}],
+        )
+        assert completion.response.choices[0].message.content == streamed_data[-1]
+        assert "hello" in streamed_data[-1].lower()
+        assert len(streamed_data) > 1
+
 
 @pytest_mark_class("llm")
 class TestChatCompletionChain:


### PR DESCRIPTION
previously the stream_handler was only valid when using `acreate`, this PR allows users to pass a stream_handler to `ChatCompletion` to be used with either `create` or `acreate`