### PR TITLE
Add latest Azure support to openai.py

### DIFF
--- a/src/marvin/core/ChatCompletion/providers/openai.py
+++ b/src/marvin/core/ChatCompletion/providers/openai.py
@@ -208,10 +208,11 @@ class OpenAIChatCompletion(AbstractChatCompletion[T]):
         # Azure OpenAI Compatibility
         api_type = serialized_request.get("api_type", None)
         if isinstance(api_type, str) and api_type.startswith("azure"):
-            if model := serialized_request.pop("model", None):
-                serialized_request["engine"] = model
             if deployment_name := serialized_request.pop("deployment_name", None):
                 serialized_request["deployment_id"] = deployment_name
+            else:
+                if model := serialized_request.pop("model", None):
+                    serialized_request["engine"] = model
 
         if handler_fn := serialized_request.pop("stream_handler", {}):
             serialized_request["stream"] = True

--- a/src/marvin/core/ChatCompletion/providers/openai.py
+++ b/src/marvin/core/ChatCompletion/providers/openai.py
@@ -204,6 +204,14 @@ class OpenAIChatCompletion(AbstractChatCompletion[T]):
         Send the serialized request to OpenAI's endpoint asynchronously.
         """
         import openai
+        
+        # Azure OpenAI Compatibility
+        api_type = serialized_request.get("api_type", None)
+        if isinstance(api_type, str) and api_type.startswith("azure"):
+            if model := serialized_request.pop("model", None):
+                serialized_request["engine"] = model
+            if deployment_name := serialized_request.pop("deployment_name", None):
+                serialized_request["deployment_id"] = deployment_name
 
         if handler_fn := serialized_request.pop("stream_handler", {}):
             serialized_request["stream"] = True


### PR DESCRIPTION
Support recent changes to Azure OpenAI API.

Note: I'm not familiar with the `marvin` repo, I only just loaded up the documentation 30 minutes ago and ran into an issue with Azure on the first example. Maybe this fix is all marvin needs or maybe not. I can say I was able to complete the first example using:
- Azure - with `marvin.settings.azure_openai.deployment_name` set
- Azure - without `marvin.settings.azure_openai.deployment_name` set (my deployment is named the same as the model/engine)
- OpenAI

Let me know if you need me to test any other areas.