### PR TITLE
Support chat web services in beta Assistant API by modifying threads

### DIFF
--- a/src/marvin/beta/assistants/README.md
+++ b/src/marvin/beta/assistants/README.md
@@ -101,8 +101,8 @@ def roll_dice(n_dice: int) -> list[int]:
 # otherwise call ai.create() and ai.delete()
 with Assistant(name="Marvin", tools=[roll_dice]) as ai:
 
-    # create a new thread
-    thread = Thread()
+    # create a new thread with or without an ID
+    thread = Thread() # or: thread=Thread("123")
     thread.create()
 
     # OR: get a thread by ID

--- a/src/marvin/beta/assistants/README.md
+++ b/src/marvin/beta/assistants/README.md
@@ -101,8 +101,13 @@ def roll_dice(n_dice: int) -> list[int]:
 # otherwise call ai.create() and ai.delete()
 with Assistant(name="Marvin", tools=[roll_dice]) as ai:
 
-    # create a new thread to track history
+    # create a new thread
     thread = Thread()
+    thread.create()
+
+    # OR: get a thread by ID
+    thread = Thread("123")
+    thread.get()
 
     # add any number of user messages to the thread
     thread.add("Hello")

--- a/src/marvin/beta/assistants/threads.py
+++ b/src/marvin/beta/assistants/threads.py
@@ -26,16 +26,6 @@ class Thread(BaseModel, ExposeSyncMethodsMixin):
     metadata: dict = {}
     messages: list[ThreadMessage] = Field([], repr=False)
 
-    def __enter__(self):
-        self.create()
-        return self
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        self.delete()
-        # If an exception has occurred, you might want to handle it or pass it through
-        # Returning False here will re-raise any exception that occurred in the context
-        return False
-
     @expose_sync_method("create")
     async def create_async(self, messages: list[str] = None):
         """

--- a/src/marvin/beta/assistants/threads.py
+++ b/src/marvin/beta/assistants/threads.py
@@ -26,6 +26,16 @@ class Thread(BaseModel, ExposeSyncMethodsMixin):
     metadata: dict = {}
     messages: list[ThreadMessage] = Field([], repr=False)
 
+    @expose_sync_method("get")
+    async def get_async(self):
+        """
+        Gets a thread.
+        """
+        client = get_client()
+        response = await client.beta.threads.retrieve(thread_id=self.id)
+        self.id = response.id
+        return self
+
     @expose_sync_method("create")
     async def create_async(self, messages: list[str] = None):
         """

--- a/src/marvin/beta/assistants/threads.py
+++ b/src/marvin/beta/assistants/threads.py
@@ -31,8 +31,6 @@ class Thread(BaseModel, ExposeSyncMethodsMixin):
         """
         Creates a thread.
         """
-        if self.id is not None:
-            raise ValueError("Thread has already been created.")
         if messages is not None:
             messages = [{"role": "user", "content": message} for message in messages]
         client = get_client()


### PR DESCRIPTION
This PR allows threads for the beta Assistant API to be created with a unique ID, persisted, and retrieved. This is a requirement for chat based web services.