### PR TITLE
add ruff formatter and run it

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -7,7 +7,7 @@ env:
 
 on:
   push:
-    branches: ["main", "marvin-old"]
+    branches: ["main"]
   pull_request:
   workflow_dispatch:
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,13 +1,7 @@
 repos:
-  - repo: https://github.com/charliermarsh/ruff-pre-commit
-    # Ruff version.
-    rev: 'v0.0.277'
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.1.8
     hooks:
+      - id: ruff-format
       - id: ruff
-        args: [--fix]
-
-  - repo: https://github.com/psf/black
-    rev: 23.3.0
-    hooks:
-      - id: black-jupyter
-        args: ["--preview", "--target-version=py310"]
+        args: [--fix, --exit-non-zero-on-fix]

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![PyPI version](https://badge.fury.io/py/marvin.svg)](https://badge.fury.io/py/marvin)
 [![Twitter Follow](https://img.shields.io/twitter/follow/AskMarvinAI?style=social)](https://twitter.com/AskMarvinAI)
 [![Docs](https://img.shields.io/badge/docs-askmarvin.ai-blue)](https://www.askmarvin.ai)
-### An engineering framework
+### An AI engineering framework
 ... made with 💙 by the team at [Prefect](https://www.prefect.io/).
 
 ```bash

--- a/cookbook/flows/github_digest.py
+++ b/cookbook/flows/github_digest.py
@@ -9,7 +9,9 @@ from prefect import flow, task
 from prefect.artifacts import create_markdown_artifact
 from prefect.blocks.system import Secret
 
-DAILY_DIGEST_TEMPLATE = jinja_env.from_string(inspect.cleandoc("""
+DAILY_DIGEST_TEMPLATE = jinja_env.from_string(
+    inspect.cleandoc(
+        """
         # GitHub Digest: {{ today }}
         
         Hi {{ username }}! Here's what you've been up to on GitHub today:
@@ -40,7 +42,9 @@ DAILY_DIGEST_TEMPLATE = jinja_env.from_string(inspect.cleandoc("""
         {% for repo in committed_repos %}
         - {{ repo.commits|length }} commits to [{{ repo.name }}](github.com/{{ repo.name }})
         {% endfor %}
-        """))  # noqa: E501
+        """
+    )
+)  # noqa: E501
 
 
 @ai_fn

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,6 +103,12 @@ preview = true
 # ruff configuration
 [tool.ruff]
 extend-select = ["I"]
+target-version = "py39"
+dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$" # default, but here in case we want to change it
+
+[tool.ruff.format]
+quote-style = "double"
+skip-magic-trailing-comma = false
 
 [tool.ruff.per-file-ignores]
 "__init__.py" = ['I', 'F401', 'E402']

--- a/src/marvin/client/openai.py
+++ b/src/marvin/client/openai.py
@@ -49,7 +49,14 @@ def with_response_model(
                 cast(type[pydantic.BaseModel], response_model)
             )
             kwargs.update({"tools": [tool.model_dump()]})
-            kwargs.update({"tool_choice": {"type": "function", "function": {"name": tool.function.name}}})  # type: ignore # noqa: E501
+            kwargs.update(
+                {
+                    "tool_choice": {
+                        "type": "function",
+                        "function": {"name": tool.function.name},
+                    }
+                }
+            )  # type: ignore # noqa: E501
         response = create(*args, **kwargs)
         if isinstance(response, ChatCompletion) and parse_response:
             return handle_response_model(

--- a/src/marvin/components/ai_function.py
+++ b/src/marvin/components/ai_function.py
@@ -39,7 +39,9 @@ P = ParamSpec("P")
 class AIFunction(BaseModel, Generic[P, T], ExposeSyncMethodsMixin):
     fn: Optional[Callable[P, T]] = None
     environment: Optional[BaseEnvironment] = None
-    prompt: Optional[str] = Field(default=inspect.cleandoc("""
+    prompt: Optional[str] = Field(
+        default=inspect.cleandoc(
+            """
         Your job is to generate likely outputs for a Python function with the
         following signature and docstring:
 
@@ -54,7 +56,9 @@ class AIFunction(BaseModel, Generic[P, T], ExposeSyncMethodsMixin):
         {% endfor %}
 
         What is its output?
-    """))
+    """
+        )
+    )
     name: str = "FormatResponse"
     description: str = "Formats the response."
     field_name: str = "data"

--- a/src/marvin/components/ai_model.py
+++ b/src/marvin/components/ai_model.py
@@ -58,7 +58,10 @@ def ai_model(
     field_name: str = "data",
     field_description: str = "The data to format.",
     **render_kwargs: Any,
-) -> Union[Callable[[T], Callable[[str], T]], Callable[[str], T],]:
+) -> Union[
+    Callable[[T], Callable[[str], T]],
+    Callable[[str], T],
+]:
     def wrapper(_type_: T, text: str) -> T:
         def extract(text: str) -> T:  # type: ignore
             pass

--- a/src/marvin/components/prompt.py
+++ b/src/marvin/components/prompt.py
@@ -76,7 +76,10 @@ class PromptFunction(Prompt[U]):
         encoder: Callable[[str], list[int]] = settings.openai.chat.completions.encoder,
         max_tokens: Optional[int] = 1,
         **kwargs: Any,
-    ) -> Union[Callable[[Callable[P, Any]], Callable[P, Self]], Callable[P, Self],]:
+    ) -> Union[
+        Callable[[Callable[P, Any]], Callable[P, Self]],
+        Callable[P, Self],
+    ]:
         def wrapper(func: Callable[P, Any], *args: P.args, **kwargs: P.kwargs) -> Self:
             # Get the signature of the function
             signature = inspect.signature(func)
@@ -160,7 +163,10 @@ class PromptFunction(Prompt[U]):
         field_name: str = "data",
         field_description: str = "The data to format.",
         **kwargs: Any,
-    ) -> Union[Callable[[Callable[P, Any]], Callable[P, Self]], Callable[P, Self],]:
+    ) -> Union[
+        Callable[[Callable[P, Any]], Callable[P, Self]],
+        Callable[P, Self],
+    ]:
         def wrapper(func: Callable[P, Any], *args: P.args, **kwargs: P.kwargs) -> Self:
             # Get the signature of the function
             signature = inspect.signature(func)

--- a/src/marvin/tools/filesystem.py
+++ b/src/marvin/tools/filesystem.py
@@ -49,9 +49,9 @@ def write_lines(
         if mode == "insert":
             lines[insert_line:insert_line] = contents.splitlines(True)
         elif mode == "overwrite":
-            lines[insert_line : insert_line + len(contents.splitlines())] = (
-                contents.splitlines(True)
-            )
+            lines[
+                insert_line : insert_line + len(contents.splitlines())
+            ] = contents.splitlines(True)
         else:
             raise ValueError(f"Invalid mode: {mode}")
     with open(path, "w") as f:

--- a/src/marvin/utilities/asyncio.py
+++ b/src/marvin/utilities/asyncio.py
@@ -119,7 +119,7 @@ def expose_sync_method(name: str) -> Callable[..., Any]:
     """
 
     def decorator(
-        async_method: Callable[..., Coroutine[Any, Any, T]]
+        async_method: Callable[..., Coroutine[Any, Any, T]],
     ) -> Callable[..., T]:
         @functools.wraps(async_method)
         def sync_wrapper(*args: Any, **kwargs: Any) -> T:

--- a/src/marvin/utilities/pydantic.py
+++ b/src/marvin/utilities/pydantic.py
@@ -80,24 +80,24 @@ def cast_to_model(
         annotated_field_name: Optional[str] = field_name
 
         if hasattr(metadata, "extra") and isinstance(metadata.extra, dict):
-            annotated_field_name: Optional[str] = metadata.extra.get("name", "")  # noqa
+            annotated_field_name: Optional[str] = metadata.extra.get("name", "")
         elif hasattr(metadata, "json_schema_extra") and isinstance(
             metadata.json_schema_extra, dict
-        ):  # noqa
+        ):
             annotated_field_name: Optional[str] = metadata.json_schema_extra.get(
                 "name", ""
-            )  # noqa
+            )
         elif isinstance(metadata, dict):
-            annotated_field_name: Optional[str] = metadata.get("name", "")  # noqa
+            annotated_field_name: Optional[str] = metadata.get("name", "")
         elif isinstance(metadata, str):
             annotated_field_name: Optional[str] = metadata
         else:
             pass
         annotated_field_description: Optional[str] = description or ""
         if hasattr(metadata, "description") and isinstance(metadata.description, str):
-            annotated_field_description: Optional[str] = metadata.description  # noqa
+            annotated_field_description: Optional[str] = metadata.description
         elif isinstance(metadata, dict):
-            annotated_field_description: Optional[str] = metadata.get("description", "")  # noqa
+            annotated_field_description: Optional[str] = metadata.get("description", "")
         else:
             pass
 

--- a/src/marvin/utilities/pydantic.py
+++ b/src/marvin/utilities/pydantic.py
@@ -97,9 +97,7 @@ def cast_to_model(
         if hasattr(metadata, "description") and isinstance(metadata.description, str):
             annotated_field_description: Optional[str] = metadata.description  # noqa
         elif isinstance(metadata, dict):
-            annotated_field_description: Optional[str] = metadata.get(
-                "description", ""
-            )  # noqa
+            annotated_field_description: Optional[str] = metadata.get("description", "")  # noqa
         else:
             pass
 

--- a/tests/components/test_ai_model.py
+++ b/tests/components/test_ai_model.py
@@ -57,9 +57,11 @@ class TestAIModels:
         class RentalHistory(BaseModel):
             neighborhood: List[Neighborhood]
 
-        assert RentalHistory("""\
+        assert RentalHistory(
+            """\
             I lived in Palms, then Mar Vista, then Pico Robertson.
-        """)
+        """
+        )
 
     @pytest.mark.flaky(max_runs=3)
     def test_resume(self):
@@ -76,12 +78,14 @@ class TestAIModels:
             greater_than_ten_years_management_experience: bool
             technologies: List[Experience]
 
-        x = Resume("""\
+        x = Resume(
+            """\
             Data Engineering Manager, 2017-2022
             • Managed team of three engineers and data scientists
             • Deployed and maintained internal Apache Kafka pipeline
             • Built tree-based classifier to predict customer churn (xgboost)\
-        """)
+        """
+        )
 
         assert x.greater_than_three_years_management_experience
         assert not x.greater_than_ten_years_management_experience
@@ -92,10 +96,12 @@ class TestAIModels:
         class LLMConference(BaseModel):
             speakers: list[Literal["Adam", "Nate", "Jeremiah"]]
 
-        x = LLMConference("""
+        x = LLMConference(
+            """
             The conference for best LLM framework will feature talks by
             Adam, Nate, Jeremiah, Marvin, and Billy Bob Thornton.
-        """)
+        """
+        )
         assert len(set(x.speakers)) == 3
         assert set(x.speakers) == set(["Adam", "Nate", "Jeremiah"])
 


### PR DESCRIPTION
ruff does formatting now so we don't need black anymore 🙂

this updates the pre-commit (in ci as well) to use `ruff format .` 

I'm thinking it might be nice to have this go in before we merge [this branch](https://github.com/PrefectHQ/marvin/tree/service-layer), if possible