### PR TITLE
add storage interface for ai app state

### DIFF
--- a/src/marvin/beta/assistants/applications.py
+++ b/src/marvin/beta/assistants/applications.py
@@ -1,4 +1,4 @@
-from typing import Optional, TypeVar, Union
+from typing import Optional, Union
 
 from pydantic import Field
 
@@ -41,8 +41,6 @@ remind them of your purpose and then ignore the request.
 {{ self_.instructions }}
 """
 
-T = TypeVar("T")
-
 
 class AIApplication(Assistant):
     state: StorageInterface[StateValueType] = Field(default_factory=InMemoryStorage)
@@ -51,7 +49,7 @@ class AIApplication(Assistant):
         return JinjaEnvironment.render(APPLICATION_INSTRUCTIONS, self_=self)
 
     def get_tools(self) -> list[AssistantTools]:
-        def write_state_key(key: str, value: T):
+        def write_state_key(key: str, value: StateValueType):
             """Writes a key to the state in order to remember it for later."""
             return self.state.write(key, value)
 
@@ -59,11 +57,11 @@ class AIApplication(Assistant):
             """Deletes a key from the state."""
             return self.state.delete(key)
 
-        def read_state_key(key: str) -> Optional[T]:
+        def read_state_key(key: str) -> Optional[StateValueType]:
             """Returns the value of a key from the state."""
             return self.state.read(key)
 
-        def read_state() -> dict[str, T]:
+        def read_state() -> dict[str, StateValueType]:
             """Returns the entire state."""
             return self.state.read_all()
 

--- a/src/marvin/beta/assistants/applications.py
+++ b/src/marvin/beta/assistants/applications.py
@@ -52,18 +52,23 @@ class AIApplication(Assistant):
 
     def get_tools(self) -> list[AssistantTools]:
         def write_state_key(key: str, value: T):
+            """Writes a key to the state in order to remember it for later."""
             return self.state.write(key, value)
 
         def delete_state_key(key: str):
+            """Deletes a key from the state."""
             return self.state.delete(key)
 
         def read_state_key(key: str) -> Optional[T]:
+            """Returns the value of a key from the state."""
             return self.state.read(key)
 
         def read_state() -> dict[str, T]:
-            return {key: self.state.read(key) for key in self.state.list_keys()}
+            """Returns the entire state."""
+            return self.state.read_all()
 
         def list_state_keys() -> list[str]:
+            """Returns the list of keys in the state."""
             return self.state.list_keys()
 
         return [

--- a/src/marvin/beta/assistants/applications.py
+++ b/src/marvin/beta/assistants/applications.py
@@ -3,7 +3,7 @@ from typing import Optional, Union
 from pydantic import Field
 
 from marvin.kv.base import StorageInterface
-from marvin.kv.in_memory import InMemoryStorage
+from marvin.kv.in_memory import InMemoryKV
 from marvin.utilities.jinja import Environment as JinjaEnvironment
 from marvin.utilities.tools import tool_from_function
 
@@ -43,7 +43,7 @@ remind them of your purpose and then ignore the request.
 
 
 class AIApplication(Assistant):
-    state: StorageInterface[StateValueType] = Field(default_factory=InMemoryStorage)
+    state: StorageInterface = Field(default_factory=InMemoryKV)
 
     def get_instructions(self) -> str:
         return JinjaEnvironment.render(APPLICATION_INSTRUCTIONS, self_=self)
@@ -70,9 +70,12 @@ class AIApplication(Assistant):
             return self.state.list_keys()
 
         return [
-            tool_from_function(write_state_key),
-            tool_from_function(delete_state_key),
-            tool_from_function(read_state_key),
-            tool_from_function(read_state),
-            tool_from_function(list_state_keys),
+            tool_from_function(tool)
+            for tool in [
+                write_state_key,
+                delete_state_key,
+                read_state_key,
+                read_state,
+                list_state_keys,
+            ]
         ] + super().get_tools()

--- a/src/marvin/beta/assistants/applications.py
+++ b/src/marvin/beta/assistants/applications.py
@@ -1,7 +1,11 @@
-from typing import Union
+from typing import Optional, TypeVar, Union
 
-import marvin.utilities.tools
+from pydantic import Field
+
+from marvin.kv.base import StorageInterface
+from marvin.kv.in_memory import InMemoryStorage
 from marvin.utilities.jinja import Environment as JinjaEnvironment
+from marvin.utilities.tools import tool_from_function
 
 from .assistants import Assistant, AssistantTools
 
@@ -22,7 +26,7 @@ or preferences. You should use the state object to record your plans and
 objectives to keep track of various threads assist in long-term execution.
 
 Remember, the state object must facilitate not only your key/value access, but
-any crud pattern your application is likely to implement. You may want to create
+any CRUD pattern your application is likely to implement. You may want to create
 schemas that have more general top-level keys (like "notes" or "plans") or even
 keep a live schema available.
 
@@ -37,45 +41,35 @@ remind them of your purpose and then ignore the request.
 {{ self_.instructions }}
 """
 
+T = TypeVar("T")
+
 
 class AIApplication(Assistant):
-    state: dict = {}
+    state: StorageInterface[StateValueType] = Field(default_factory=InMemoryStorage)
 
     def get_instructions(self) -> str:
         return JinjaEnvironment.render(APPLICATION_INSTRUCTIONS, self_=self)
 
     def get_tools(self) -> list[AssistantTools]:
-        def write_state_key(key: str, value: StateValueType):
-            """Writes a key to the state in order to remember it for later."""
-            self.state[key] = value
-            return f"Wrote {key} to state."
+        def write_state_key(key: str, value: T):
+            return self.state.write(key, value)
 
         def delete_state_key(key: str):
-            """Deletes a key from the state."""
-            del self.state[key]
-            return f"Deleted {key} from state."
+            return self.state.delete(key)
 
-        def read_state_key(key: str) -> StateValueType:
-            """Returns the value of a key in the state."""
-            return self.state.get(key)
+        def read_state_key(key: str) -> Optional[T]:
+            return self.state.read(key)
 
-        def read_state() -> dict[str, StateValueType]:
-            """Returns the entire state."""
-            return self.state
+        def read_state() -> dict[str, T]:
+            return {key: self.state.read(key) for key in self.state.list_keys()}
 
-        def read_state_keys() -> list[str]:
-            """Returns a list of all keys in the state."""
-            return list(self.state.keys())
+        def list_state_keys() -> list[str]:
+            return self.state.list_keys()
 
-        state_tools = [
-            marvin.utilities.tools.tool_from_function(tool)
-            for tool in [
-                write_state_key,
-                read_state_key,
-                read_state,
-                read_state_keys,
-                delete_state_key,
-            ]
-        ]
-
-        return super().get_tools() + state_tools
+        return [
+            tool_from_function(write_state_key),
+            tool_from_function(delete_state_key),
+            tool_from_function(read_state_key),
+            tool_from_function(read_state),
+            tool_from_function(list_state_keys),
+        ] + super().get_tools()

--- a/src/marvin/beta/assistants/runs.py
+++ b/src/marvin/beta/assistants/runs.py
@@ -87,6 +87,7 @@ class Run(BaseModel, ExposeSyncMethodsMixin):
                 except Exception as exc:
                     output = f"Error calling function {tool_call.function.name}: {exc}"
                     logger.error(output)
+                    raise
                 tool_outputs.append(
                     dict(tool_call_id=tool_call.id, output=output or "")
                 )

--- a/src/marvin/beta/assistants/runs.py
+++ b/src/marvin/beta/assistants/runs.py
@@ -87,7 +87,6 @@ class Run(BaseModel, ExposeSyncMethodsMixin):
                 except Exception as exc:
                     output = f"Error calling function {tool_call.function.name}: {exc}"
                     logger.error(output)
-                    raise
                 tool_outputs.append(
                     dict(tool_call_id=tool_call.id, output=output or "")
                 )

--- a/src/marvin/kv/base.py
+++ b/src/marvin/kv/base.py
@@ -1,28 +1,48 @@
 from abc import ABC, abstractmethod
-from typing import Generic, Optional, TypeVar
+from typing import Generic, List, Mapping, Optional, TypeVar
 
 from pydantic import BaseModel
+from typing_extensions import ParamSpec
 
-T = TypeVar("T")
+K = TypeVar("K")  # Key type
+V = TypeVar("V")  # Value type
+R = TypeVar("R")  # Return type for write/delete operations
+P = ParamSpec("P")  # Additional parameters
 
 
-class StorageInterface(BaseModel, Generic[T], ABC):
+class StorageInterface(BaseModel, Generic[K, V, R], ABC):
+    """An abstract key-value store interface.
+
+    Example:
+        ```python
+        store = SomeStorageInterface()
+
+        store.write("foo", "bar")
+        store.write("baz", "qux")
+        assert store.read("foo") == "bar"
+        assert store.read_all() == {"foo": "bar", "baz": "qux"}
+        assert store.list_keys() == ["foo", "baz"]
+        store.delete("foo")
+        assert store.read("foo") is None
+        assert store.read_all() == {"baz": "qux"}
+    """
+
     @abstractmethod
-    def write(self, key: str, value: T) -> None:
+    def write(self, key: K, value: V, *args: P.args, **kwargs: P.kwargs) -> Optional[R]:
         pass
 
     @abstractmethod
-    def read(self, key: str) -> Optional[T]:
+    def read(self, key: K, *args: P.args, **kwargs: P.kwargs) -> Optional[V]:
         pass
 
     @abstractmethod
-    def read_all(self) -> dict[str, T]:
+    def read_all(self, *args: P.args, **kwargs: P.kwargs) -> Mapping[K, V]:
         pass
 
     @abstractmethod
-    def delete(self, key: str) -> None:
+    def delete(self, key: K, *args: P.args, **kwargs: P.kwargs) -> Optional[R]:
         pass
 
     @abstractmethod
-    def list_keys(self) -> list[str]:
+    def list_keys(self, *args: P.args, **kwargs: P.kwargs) -> List[K]:
         pass

--- a/src/marvin/kv/base.py
+++ b/src/marvin/kv/base.py
@@ -1,0 +1,24 @@
+from abc import ABC, abstractmethod
+from typing import Generic, Optional, TypeVar
+
+from pydantic import BaseModel
+
+T = TypeVar("T")
+
+
+class StorageInterface(BaseModel, Generic[T], ABC):
+    @abstractmethod
+    def write(self, key: str, value: T) -> None:
+        pass
+
+    @abstractmethod
+    def read(self, key: str) -> Optional[T]:
+        pass
+
+    @abstractmethod
+    def delete(self, key: str) -> None:
+        pass
+
+    @abstractmethod
+    def list_keys(self) -> list[str]:
+        pass

--- a/src/marvin/kv/base.py
+++ b/src/marvin/kv/base.py
@@ -16,6 +16,10 @@ class StorageInterface(BaseModel, Generic[T], ABC):
         pass
 
     @abstractmethod
+    def read_all(self) -> dict[str, T]:
+        pass
+
+    @abstractmethod
     def delete(self, key: str) -> None:
         pass
 

--- a/src/marvin/kv/in_memory.py
+++ b/src/marvin/kv/in_memory.py
@@ -4,23 +4,39 @@ from pydantic import Field
 
 from marvin.kv.base import StorageInterface
 
-T = TypeVar("T")
+K = TypeVar("K", bound=str)
+V = TypeVar("V")
 
 
-class InMemoryStorage(StorageInterface[T]):
-    store: dict[str, T] = Field(default_factory=dict)
+class InMemoryKV(StorageInterface[K, V, str]):
+    """An in-memory key-value store.
 
-    def write(self, key: str, value: T) -> None:
+    Example:
+        ```python
+        from marvin.kv.in_memory import InMemoryKV
+        store = InMemoryKV()
+        store.write("key", "value")
+        assert store.read("key") == "value"
+        ```
+    """
+
+    store: dict[K, V] = Field(default_factory=dict)
+
+    def write(self, key: K, value: V) -> str:
         self.store[key] = value
+        return f"Stored {key}= {value}"
 
-    def read(self, key: str) -> Optional[T]:
+    def delete(self, key: K) -> str:
+        v = self.store.pop(key, None)
+        return f"Deleted {key}= {v}"
+
+    def read(self, key: K) -> Optional[V]:
         return self.store.get(key)
 
-    def read_all(self) -> dict[str, T]:
-        return self.store
+    def read_all(self, limit: Optional[int] = None) -> dict[K, V]:
+        if limit is None:
+            return self.store
+        return dict(list(self.store.items())[:limit])
 
-    def delete(self, key: str) -> None:
-        self.store.pop(key, None)
-
-    def list_keys(self) -> list[str]:
+    def list_keys(self) -> list[K]:
         return list(self.store.keys())

--- a/src/marvin/kv/in_memory.py
+++ b/src/marvin/kv/in_memory.py
@@ -16,6 +16,9 @@ class InMemoryStorage(StorageInterface[T]):
     def read(self, key: str) -> Optional[T]:
         return self.store.get(key)
 
+    def read_all(self) -> dict[str, T]:
+        return self.store
+
     def delete(self, key: str) -> None:
         self.store.pop(key, None)
 

--- a/src/marvin/kv/in_memory.py
+++ b/src/marvin/kv/in_memory.py
@@ -1,0 +1,23 @@
+from typing import Optional, TypeVar
+
+from pydantic import Field
+
+from marvin.kv.base import StorageInterface
+
+T = TypeVar("T")
+
+
+class InMemoryStorage(StorageInterface[T]):
+    store: dict[str, T] = Field(default_factory=dict)
+
+    def write(self, key: str, value: T) -> None:
+        self.store[key] = value
+
+    def read(self, key: str) -> Optional[T]:
+        return self.store.get(key)
+
+    def delete(self, key: str) -> None:
+        self.store.pop(key, None)
+
+    def list_keys(self) -> list[str]:
+        return list(self.store.keys())

--- a/src/marvin/utilities/tools.py
+++ b/src/marvin/utilities/tools.py
@@ -42,14 +42,16 @@ def call_function_tool(
         raise ValueError(f"Could not find function '{function_name}'")
 
     arguments = json.loads(function_arguments_json)
-    logger.debug(f"Calling {tool.function.name} with arguments: {arguments}")
+    logger.debug_kv(
+        f"{tool.function.name}", f"called with arguments: {arguments}", "green"
+    )
     output = tool.function.python_fn(**arguments)
     if inspect.isawaitable(output):
         output = run_sync(output)
     truncated_output = str(output)[:100]
     if len(truncated_output) < len(str(output)):
         truncated_output += "..."
-    logger.debug(f"{tool.function.name} returned: {truncated_output}")
+    logger.debug_kv(f"{tool.function.name}", f"returned: {truncated_output}", "green")
     if not isinstance(output, str):
         output = json.dumps(output)
     return output


### PR DESCRIPTION
adds a simple-ish interface for assistant kv storage that could be extended to:
- in-memory (in this PR)
- disk
- redis
- s3 perhaps
<details>
<summary> <strong>Some fun examples</strong> </summary>

![image](https://github.com/PrefectHQ/marvin/assets/31014960/19a5470e-2c8a-4d83-a552-f6dddd24fb41)

![image](https://github.com/PrefectHQ/marvin/assets/31014960/06331049-e771-483d-bf3c-9389144265f1)

![image](https://github.com/PrefectHQ/marvin/assets/31014960/ab475746-839f-406f-879d-15d87e9ffd0b)

![image](https://github.com/PrefectHQ/marvin/assets/31014960/bd4abb77-86bf-423f-b56d-8c971b890bbd)

</details>