### PR TITLE
Update Documentation Example to Match Feature

### DIFF
--- a/docs/components/ai_classifier.md
+++ b/docs/components/ai_classifier.md
@@ -14,6 +14,7 @@ AI Classifiers are a high-level component, or building block, of Marvin. Like al
     from marvin import ai_classifier
     from enum import Enum
 
+    @ai_classifier
     class CustomerIntent(Enum):
         """Classifies the incoming users intent"""
 
@@ -26,11 +27,7 @@ AI Classifiers are a high-level component, or building block, of Marvin. Like al
         ACCOUNT_CANCELLATION = 'ACCOUNT_CANCELLATION'
         OPERATOR_CUSTOMER_SERVICE = 'OPERATOR_CUSTOMER_SERVICE'
 
-    @ai_classifier
-    def classify_intent(text: str) -> CustomerIntent:
-        '''Classifies the most likely intent from user input'''
-
-    classify_intent("I got double charged, can you help me out?")
+    CustomerIntent("I got double charged, can you help me out?")
     ```
     !!! success "Result"
         ```python 


### PR DESCRIPTION
This commit updates the documentation to ensure that the example provided correctly matches the featured example at the bottom of the page. Specifically, the `ai_classifier` decorator has been moved to decorate the `CustomerIntent` enum instead of the `classify_intent` function. This change corrects the example to demonstrate the intended usage of the `ai_classifier` in conjunction with the `CustomerIntent` enum, enhancing the accuracy and clarity of the documentation for users.