### PR TITLE
allow use of `OPENAI_API_KEY` env var

### DIFF
--- a/docs/configuration/settings.md
+++ b/docs/configuration/settings.md
@@ -5,12 +5,13 @@ Marvin makes use of Pydantic's `BaseSettings` to configure, load, and change beh
 ## Environment Variables
 All settings are configurable via environment variables like `MARVIN_<setting name>`.
 
+Please set Marvin specific settings in `~/.marvin/.env`. One exception being `OPENAI_API_KEY`, which may be as a global env var on your system and it will be picked up by Marvin.
+
 !!! example "Setting Environment Variables"
-    For example, in an `.env` file or in your shell config file you might have:
+    For example, in your `~/.marvin/.env` file or in your shell config file you might have:
     ```shell
-    MARVIN_LOG_LEVEL=DEBUG
-    MARVIN_LLM_MODEL=gpt-4
-    MARVIN_LLM_TEMPERATURE=0
+    MARVIN_LOG_LEVEL=INFO
+    MARVIN_OPENAI_CHAT_COMPLETIONS_MODEL=gpt-4
     MARVIN_OPENAI_API_KEY='sk-my-api-key'
     ```
     Settings these values will let you avoid setting an API key every time. 
@@ -23,10 +24,6 @@ A runtime settings object is accessible via `marvin.settings` and can be used to
     ```python
     import marvin
 
-    marvin.settings.llm_model # 'gpt-4'
-
-    marvin.settings.llm_model = 'gpt-3.5-turbo'
-
-    marvin.settings.llm_model # 'gpt-3.5-turbo'
+    marvin.settings.openai_chat_completions_model = 'gpt-4'
     ```
 

--- a/docs/configuration/settings.md
+++ b/docs/configuration/settings.md
@@ -8,7 +8,7 @@ All settings are configurable via environment variables like `MARVIN_<setting na
 Please set Marvin specific settings in `~/.marvin/.env`. One exception being `OPENAI_API_KEY`, which may be as a global env var on your system and it will be picked up by Marvin.
 
 !!! example "Setting Environment Variables"
-    For example, in your `~/.marvin/.env` file or in your shell config file you might have:
+    For example, in your `~/.marvin/.env` file you could have:
     ```shell
     MARVIN_LOG_LEVEL=INFO
     MARVIN_OPENAI_CHAT_COMPLETIONS_MODEL=gpt-4

--- a/docs/static/css/tailwind.css
+++ b/docs/static/css/tailwind.css
@@ -1,5 +1,5 @@
 /*
-! tailwindcss v3.3.6 | MIT License | https://tailwindcss.com
+! tailwindcss v3.4.0 | MIT License | https://tailwindcss.com
 */
 
 /*
@@ -32,9 +32,11 @@
 4. Use the user's configured `sans` font-family by default.
 5. Use the user's configured `sans` font-feature-settings by default.
 6. Use the user's configured `sans` font-variation-settings by default.
+7. Disable tap highlights on iOS
 */
 
-html {
+html,
+:host {
   line-height: 1.5;
   /* 1 */
   -webkit-text-size-adjust: 100%;
@@ -44,12 +46,14 @@ html {
   -o-tab-size: 4;
      tab-size: 4;
   /* 3 */
-  font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+  font-family: ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
   /* 4 */
   font-feature-settings: normal;
   /* 5 */
   font-variation-settings: normal;
   /* 6 */
+  -webkit-tap-highlight-color: transparent;
+  /* 7 */
 }
 
 /*

--- a/docs/welcome/quickstart.md
+++ b/docs/welcome/quickstart.md
@@ -5,6 +5,18 @@ After [installing Marvin](../installation), the fastest way to get started is by
 !!! info "Initializing a Client"
     To use Marvin you must have an API Key configured for an external model provider, like OpenAI. 
     
+    You can pass your API Key to Marvin in one of two ways:
+
+    - Set the environment variable `MARVIN_OPENAI_API_KEY` in `~/.marvin/.env` or as `OPENAI_API_KEY` in your shell config file.
+
+    ```shell
+    » cat ~/.marvin/.env | rg OPENAI
+    MARVIN_OPENAI_API_KEY=sk-xxx
+    MARVIN_OPENAI_ORGANIZATION=org-xxx
+    ```
+
+    - Pass your API Key to Marvin's `OpenAI` client constructor. 
+
     ```python
     from openai import OpenAI
 
@@ -23,11 +35,8 @@ Marvin's most basic component is the AI Model, built on Pydantic's `BaseModel`. 
         ```python
         from marvin import ai_model
         from pydantic import BaseModel, Field
-        from openai import OpenAI
 
-        client = OpenAI(api_key = 'YOUR_API_KEY')
-
-        @ai_model(client = client)
+        @ai_model
         class Location(BaseModel):
             city: str
             state_abbreviation: str = Field(
@@ -120,9 +129,6 @@ Marvin's most basic component is the AI Model, built on Pydantic's `BaseModel`. 
         ```python
         from marvin import ai_model
         from pydantic import BaseModel, Field
-        from openai import OpenAI
-
-        client = OpenAI(api_key = 'YOUR_API_KEY')
 
         class Location(BaseModel):
             city: str
@@ -131,12 +137,12 @@ Marvin's most basic component is the AI Model, built on Pydantic's `BaseModel`. 
                 description="The two-letter state abbreviation"
             )
 
-        ai_model(Location, client = client)("The Big Apple")
+        ai_model(Location)("The Big Apple")
         ```
         ??? info "Generated Prompt"
             You can view and/or eject the generated prompt by simply calling 
             ```python
-            ai_model(Location, client = client)("The Big Apple").as_prompt().serialize()
+            ai_model(Location)("The Big Apple").as_prompt().serialize()
             ```
             When you do you'll see the raw payload that's sent to the LLM. All of the parameters
             below like `FormatResponse` and the prompt you send are fully customizable. 
@@ -358,11 +364,8 @@ AI Functions look like regular functions, but have no source code. Instead, an A
         `ai_fn` can decorate python functions to evlaute them using a Large Language Model.
         ```python
         from marvin import ai_fn
-        from openai import OpenAI
 
-        client = OpenAI(api_key = 'YOUR_API_KEY')
-
-        @ai_fn(client=client)
+        @ai_fn
         def sentiment_list(texts: list[str]) -> list[float]:
             """
             Given a list of `texts`, returns a list of numbers between 1 (positive) and
@@ -437,9 +440,6 @@ AI Functions look like regular functions, but have no source code. Instead, an A
         `ai_fn` can be used as a utility function to evaluate python functions using a Large Language Model.
         ```python
         from marvin import ai_fn
-        from openai import OpenAI
-
-        client = OpenAI(api_key = 'YOUR_API_KEY')
 
         def sentiment_list(texts: list[str]) -> list[float]:
             """
@@ -448,7 +448,7 @@ AI Functions look like regular functions, but have no source code. Instead, an A
             """
 
 
-        ai_fn(sentiment_list, client=client)(
+        ai_fn(sentiment_list)(
             [
                 "That was surprisingly easy!",
                 "Oh no, not again.",
@@ -458,7 +458,7 @@ AI Functions look like regular functions, but have no source code. Instead, an A
         ??? info "Generated Prompt"
             You can view and/or eject the generated prompt by simply calling 
             ```python
-            ai_fn(sentiment_list, client = client)([
+            ai_fn(sentiment_list)([
                 "That was surprisingly easy!",
                 "Oh no, not again.",
             ]).as_prompt().serialize()

--- a/docs/welcome/quickstart.md
+++ b/docs/welcome/quickstart.md
@@ -15,12 +15,19 @@ After [installing Marvin](../installation), the fastest way to get started is by
     MARVIN_OPENAI_ORGANIZATION=org-xxx
     ```
 
-    - Pass your API Key to Marvin's `OpenAI` client constructor. 
+    - Pass your API Key to Marvin's `OpenAI` client constructor and pass it to Marvin's `ai_fn`, `ai_classifier`, or `ai_model` decorators.
 
     ```python
+    from marvin import ai_fn
     from openai import OpenAI
 
     client = OpenAI(api_key = 'YOUR_API_KEY')
+
+    @ai_fn(client = client)
+    def list_fruits(n: int, color: str = 'red') -> list[str]:
+        """
+        Generates a list of {{n}} {{color}} fruits.
+        """
     ```
 
 ## Components 

--- a/src/marvin/client/openai.py
+++ b/src/marvin/client/openai.py
@@ -37,8 +37,8 @@ def _get_default_client(client_type: str) -> Union[Client, AsyncClient]:
     )
     if not api_key:
         raise ValueError(
-            "OpenAI API key not found. Set `MARVIN_OPENAI_API_KEY` in `~/.marvin/.env`"
-            " or `OPENAI_API_KEY` in environment."
+            "OpenAI API key not found. Please either set `MARVIN_OPENAI_API_KEY` in `~/.marvin/.env`"
+            " or otherwise set `OPENAI_API_KEY` in your environment."
         )
     if client_type not in ["sync", "async"]:
         raise ValueError(f"Invalid client type {client_type!r}")

--- a/src/marvin/client/openai.py
+++ b/src/marvin/client/openai.py
@@ -38,9 +38,9 @@ def _get_default_client(client_type: str) -> Union[Client, AsyncClient]:
 
     if not api_key:
         raise ValueError(
-            "OpenAI API key not set - please set `MARVIN_OPENAI_API_KEY` in `~/.marvin/.env`."
+            "OpenAI API key not found. Please either set `MARVIN_OPENAI_API_KEY` in `~/.marvin/.env`"
+            " or otherwise set `OPENAI_API_KEY` in your environment."
         )
-
     if client_type == "sync":
         return Client(
             **settings.openai.model_dump(

--- a/src/marvin/client/openai.py
+++ b/src/marvin/client/openai.py
@@ -35,28 +35,21 @@ def _get_default_client(client_type: str) -> Union[Client, AsyncClient]:
     api_key = (
         settings.openai.api_key.get_secret_value() if settings.openai.api_key else None
     )
-
     if not api_key:
         raise ValueError(
-            "OpenAI API key not found. Please either set `MARVIN_OPENAI_API_KEY` in `~/.marvin/.env`"
-            " or otherwise set `OPENAI_API_KEY` in your environment."
+            "OpenAI API key not found. Set `MARVIN_OPENAI_API_KEY` in `~/.marvin/.env`"
+            " or `OPENAI_API_KEY` in environment."
         )
-    if client_type == "sync":
-        return Client(
-            **settings.openai.model_dump(
-                exclude={"chat", "images", "audio", "assistants", "api_key"}
-            )
-            | dict(api_key=api_key)
-        )
-    elif client_type == "async":
-        return AsyncClient(
-            **settings.openai.model_dump(
-                exclude={"chat", "images", "audio", "assistants", "api_key"}
-            )
-            | dict(api_key=api_key)
-        )
-    else:
+    if client_type not in ["sync", "async"]:
         raise ValueError(f"Invalid client type {client_type!r}")
+
+    client_class = Client if client_type == "sync" else AsyncClient
+    return client_class(
+        **settings.openai.model_dump(
+            exclude={"chat", "images", "audio", "assistants", "api_key"}
+        )
+        | {"api_key": api_key}
+    )
 
 
 def with_response_model(

--- a/src/marvin/settings.py
+++ b/src/marvin/settings.py
@@ -15,7 +15,7 @@ from contextlib import contextmanager
 from copy import deepcopy
 from typing import Any, Optional, Union
 
-from pydantic import Field, SecretStr
+from pydantic import Field, SecretStr, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from typing_extensions import Literal
 
@@ -186,6 +186,17 @@ class OpenAISettings(MarvinSettings):
     images: ImageSettings = Field(default_factory=ImageSettings)
     audio: AudioSettings = Field(default_factory=AudioSettings)
     assistants: AssistantSettings = Field(default_factory=AssistantSettings)
+
+    @field_validator("api_key")
+    def discover_api_key(cls, v):
+        if v is None:
+            v = SecretStr(os.environ.get("OPENAI_API_KEY"))
+            if v.get_secret_value() is None:
+                raise ValueError(
+                    "OpenAI API key not found. Please either set `MARVIN_OPENAI_API_KEY` in `~/.marvin/.env`"
+                    " or otherwise set `OPENAI_API_KEY` in your environment."
+                )
+        return v
 
 
 class Settings(MarvinSettings):


### PR DESCRIPTION
```python
AttributeError: 'NoneType' object has no attribute 'get_secret_value'
```
we fail if the api key:
- is not explicitly passed into a new client instance
- is not set as `MARVIN_OPENAI_API_KEY` in `~/.marvin/.env`

most users will likely just have `OPENAI_API_KEY` set somewhere on their machine, so we should use that for `marvin.settings.openai.api_key` if they haven't done one of the above

this PR also updates the quickstart to recommend setting the env var instead of passing the client around everywhere