### PR TITLE
Assume `str` return annotation if none provided

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,6 @@ dev = [
     "ipython",
     "mkdocs-autolinks-plugin~=0.7",
     "mkdocs-awesome-pages-plugin~=2.8",
-    "mkdocs-livereload",
     "mkdocs-markdownextradata-plugin~=0.2",
     "mkdocs-jupyter>=0.24.1",
     "mkdocs-material>=9.1.17",

--- a/src/marvin/_mappings/types.py
+++ b/src/marvin/_mappings/types.py
@@ -25,6 +25,9 @@ def cast_type_to_model(
     else:
         metadata = FieldInfo(description=field_description)
 
+    if _type is None:
+        raise ValueError("No type provided; unable to create model for casting.")
+
     return create_model(
         model_name,
         __doc__=model_description,

--- a/src/marvin/components/prompt/fn.py
+++ b/src/marvin/components/prompt/fn.py
@@ -192,9 +192,12 @@ class PromptFunction(Prompt[U]):
             signature = inspect.signature(func)
             params = signature.bind(*args, **kwargs_)
             params.apply_defaults()
+            _type = inspect.signature(func).return_annotation
+            if _type is inspect._empty:
+                _type = str
 
             toolset = cast_type_to_toolset(
-                _type=inspect.signature(func).return_annotation,
+                _type=_type,
                 model_name=model_name,
                 model_description=model_description,
                 field_name=field_name,

--- a/tests/components/test_ai_functions.py
+++ b/tests/components/test_ai_functions.py
@@ -41,6 +41,30 @@ class TestAIFunctions:
             assert len(result) == 3
 
     class TestAnnotations:
+        def test_no_annotations(self):
+            @ai_fn
+            def f(x):
+                """returns x + 1"""
+
+            result = f(3)
+            assert result == "4"
+
+        def test_arg_annotations(self):
+            @ai_fn
+            def f(x: int):
+                """returns x + 1"""
+
+            result = f(3)
+            assert result == "4"
+
+        def test_return_annotations(self):
+            @ai_fn
+            def f(x) -> int:
+                """returns x + 1"""
+
+            result = f("3")
+            assert result == 4
+
         def test_list_fruit_with_generic_type_hints(self):
             @ai_fn
             def list_fruit(n: int) -> List[str]:


### PR DESCRIPTION
AI functions without return annotations currently raise a cryptic pydantic error. This PR:
- raises a more explicit and clear error if an empty annotation is provided
- makes ai functions return string values by default, to avoid the error entirely