### PR TITLE
inject app into tools

### DIFF
--- a/src/marvin/beta/ai_flow/ai_task.py
+++ b/src/marvin/beta/ai_flow/ai_task.py
@@ -260,7 +260,7 @@ class AITask(BaseModel, Generic[P, T]):
             self.result = result
             raise CancelRun()
 
-        tool.function.python_fn = task_completed_with_result
+        tool.function._python_fn = task_completed_with_result
 
         return tool
 


### PR DESCRIPTION
Uses explicit dependency injection: if any function has a parameter annotated with `AIApplication`, the calling AI Application will inject itself as the parameter at runtime. This is also used to move the state functions out of the `get_tools()` method.