### PR TITLE
Replace deprecated validate_args with TypeAdapter

### DIFF
--- a/src/marvin/utilities/pydantic.py
+++ b/src/marvin/utilities/pydantic.py
@@ -1,4 +1,5 @@
 """Module for Pydantic utilities."""
+
 from types import FunctionType, GenericAlias
 from typing import Annotated, Any, Callable, Optional, Union, cast, get_origin
 
@@ -12,6 +13,8 @@ def cast_callable_to_model(
     name: Optional[str] = None,
     description: Optional[str] = None,
 ) -> type[BaseModel]:
+    # this relies on deprecated behavior. Use TypeAdaptor(type).json_schema() if
+    # possible!
     model = validate_arguments(function).model
     for field in ["args", "kwargs", "v__duplicate_kwargs"]:
         fields = cast(dict[str, Any], model.__fields__)

--- a/src/marvin/utilities/tools.py
+++ b/src/marvin/utilities/tools.py
@@ -5,12 +5,11 @@ import json
 from functools import update_wrapper
 from typing import Any, Callable, Optional
 
-from pydantic import PydanticInvalidForJsonSchema
+import pydantic
 
 from marvin.requests import Function, Tool
 from marvin.utilities.asyncio import run_sync
 from marvin.utilities.logging import get_logger
-from marvin.utilities.pydantic import cast_callable_to_model
 
 logger = get_logger("Tools")
 
@@ -58,24 +57,14 @@ def tool_from_function(
     if kwargs:
         fn = custom_partial(fn, **kwargs)
 
-    model = cast_callable_to_model(fn)
-    serializer: Callable[..., dict[str, Any]] = getattr(
-        model, "model_json_schema", getattr(model, "schema")
-    )
-    try:
-        parameters = serializer()
-    except PydanticInvalidForJsonSchema:
-        raise TypeError(
-            "Could not create tool from function because annotations could not be"
-            f" serialized to JSON: {fn}"
-        )
+    schema = pydantic.TypeAdapter(fn).json_schema()
 
     return Tool(
         type="function",
         function=Function.create(
             name=name or fn.__name__,
             description=description or fn.__doc__,
-            parameters=parameters,
+            parameters=schema,
             _python_fn=fn,
         ),
     )


### PR DESCRIPTION
@zzstoatzz noticed that AI Applications didn't support tools that were instance methods which turns out to be due to some deprecation conflict in how schemas are generated. `cast_callable_to_model` used to handle this explicitly (removing args and kwargs by hand) but this no longer seems to affect the generated schema, which creates problems. This PR uses a v2 TypeAdapter instead.