### PR TITLE
Add streaming support for chatcompletions

### DIFF
--- a/src/marvin/client/openai.py
+++ b/src/marvin/client/openai.py
@@ -9,16 +9,26 @@ from typing import (
     Union,
 )
 
+import openai
+import openai.types.chat.chat_completion
+import openai.types.chat.chat_completion_chunk
 import pydantic
 from openai import AsyncClient, Client, NotFoundError
-from openai.types.chat import (
-    ChatCompletion,
-)
+from openai.types.chat import ChatCompletion
+from pydantic import BaseModel
 from typing_extensions import ParamSpec
 
 import marvin
 from marvin import settings
-from marvin.types import ChatRequest, ImageRequest, VisionRequest
+from marvin.types import (
+    BaseMessage as Message,
+)
+from marvin.types import (
+    ChatRequest,
+    ImageRequest,
+    StreamingChatResponse,
+    VisionRequest,
+)
 from marvin.utilities.logging import get_logger
 
 if TYPE_CHECKING:
@@ -30,6 +40,86 @@ P = ParamSpec("P")
 T = TypeVar("T", bound=pydantic.BaseModel)
 
 FALLBACK_CHAT_COMPLETIONS_MODEL = "gpt-3.5-turbo"
+
+
+def process_streaming_chat_response(
+    completion: Optional[ChatCompletion], chunk: openai.types.chat.ChatCompletionChunk
+) -> StreamingChatResponse:
+    # if no completion is provided, create the initial completion from the chunk
+    if completion is None:
+        completion = ChatCompletion(
+            id=chunk.id,
+            model=chunk.model,
+            choices=[
+                openai.types.chat.chat_completion.Choice(
+                    finish_reason=c.finish_reason or "stop",
+                    index=c.index,
+                    logprobs=c.logprobs,
+                    message=openai.types.chat.ChatCompletionMessage(
+                        content=c.delta.content or "",
+                        role=c.delta.role or "assistant",
+                        tool_calls=c.delta.tool_calls,
+                    ),
+                )
+                for c in chunk.choices
+            ],
+            created=chunk.created,
+            object="chat.completion",
+        )
+
+    # update the completion choices from the chunk, overwriting or append as necessary
+
+    completion = completion.model_copy()
+    choices = []
+    for c, chunk_c in zip(completion.choices, chunk.choices):
+        c = c.model_copy()
+        if chunk_c.finish_reason:
+            c.finish_reason = chunk_c.finish_reason
+        if chunk_c.index is not None:
+            c.index = chunk_c.index
+        if chunk_c.logprobs:
+            c.logprobs = chunk_c.logprobs
+        c.message = openai.types.chat.ChatCompletionMessage(
+            content=c.message.content + (chunk_c.delta.content or ""),
+            role=chunk_c.delta.role or c.message.role,
+            tool_calls=chunk_c.delta.tool_calls or c.message.tool_calls,
+        )
+        choices.append(c)
+    completion.choices = choices
+    return completion
+
+
+class OpenAIStreamHandler(BaseModel):
+    callback: Optional[Callable[[Message], None]] = None
+
+    def handle_streaming_chat(self, api_response: openai.Stream) -> Message:
+        """
+        Accumulate chunk deltas into a full ChatCompletion. Returns the full
+        ChatCompletion. Passes a StreamingChatResponse to the callback.
+        """
+        completion = None
+        for chunk in api_response:
+            completion = process_streaming_chat_response(
+                completion=completion, chunk=chunk
+            )
+            if self.callback:
+                self.callback(StreamingChatResponse(chunk=chunk, completion=completion))
+        return completion
+
+    async def handle_streaming_chat_async(self, api_response: openai.Stream) -> Message:
+        """
+        Accumulate chunk deltas into a full ChatCompletion. Returns the full
+        ChatCompletion. Passes a dict of partial ChatCompletions and chunks to
+        the callback, if provided.
+        """
+        completion = None
+        async for chunk in api_response:
+            completion = process_streaming_chat_response(
+                completion=completion, chunk=chunk
+            )
+            if self.callback:
+                self.callback(StreamingChatResponse(chunk=chunk, completion=completion))
+        return completion
 
 
 async def should_fallback(e: NotFoundError, request: ChatRequest) -> bool:
@@ -111,11 +201,17 @@ class MarvinClient(pydantic.BaseModel):
         self,
         *,
         completion: Optional[Callable[..., "ChatCompletion"]] = None,
+        stream_callback: Optional[Callable[[Message], None]] = None,
         **kwargs: Any,
     ) -> Union["ChatCompletion", T]:
         create: Callable[..., "ChatCompletion"] = (
             completion or self.client.chat.completions.create
         )
+
+        # setup streaming
+        if stream_callback is not None:
+            kwargs.setdefault("stream", True)
+
         # validate request
         request = ChatRequest(**kwargs)
         try:
@@ -128,6 +224,11 @@ class MarvinClient(pydantic.BaseModel):
                 )
             else:
                 raise e
+
+        if request.stream:
+            return OpenAIStreamHandler(callback=stream_callback).handle_streaming_chat(
+                response
+            )
         return response
 
     def generate_vision(
@@ -185,9 +286,15 @@ class AsyncMarvinClient(pydantic.BaseModel):
 
     async def generate_chat(
         self,
+        stream_callback: Optional[Callable[[Message], None]] = None,
         **kwargs: Any,
     ) -> Union["ChatCompletion", T]:
         create = self.client.chat.completions.create
+
+        # setup streaming
+        if stream_callback is not None:
+            kwargs.setdefault("stream", True)
+
         # validate request
         request = ChatRequest(**kwargs)
         try:
@@ -202,6 +309,10 @@ class AsyncMarvinClient(pydantic.BaseModel):
                 )
             else:
                 raise e
+        if request.stream:
+            return await OpenAIStreamHandler(
+                callback=stream_callback
+            ).handle_streaming_chat_async(response)
         return response
 
     async def generate_vision(

--- a/src/marvin/utilities/asyncio.py
+++ b/src/marvin/utilities/asyncio.py
@@ -8,6 +8,30 @@ from typing import Any, Callable, Coroutine, TypeVar, cast
 
 T = TypeVar("T")
 
+BACKGROUND_TASKS = set()
+
+
+def create_task(coro):
+    """
+    Creates async background tasks in a way that is safe from garbage
+    collection.
+
+    See
+    https://textual.textualize.io/blog/2023/02/11/the-heisenbug-lurking-in-your-async-code/
+
+    Example:
+
+    async def my_coro(x: int) -> int:
+        return x + 1
+
+    # safely submits my_coro for background execution
+    create_task(my_coro(1))
+    """  # noqa: E501
+    task = asyncio.create_task(coro)
+    BACKGROUND_TASKS.add(task)
+    task.add_done_callback(BACKGROUND_TASKS.discard)
+    return task
+
 
 async def run_async(fn: Callable[..., T], *args: Any, **kwargs: Any) -> T:
     """

--- a/tests/client/openai.py
+++ b/tests/client/openai.py
@@ -1,0 +1,75 @@
+from marvin.client.openai import AsyncMarvinClient, MarvinClient
+from marvin.types import BaseMessage, StreamingChatResponse
+from openai.types.chat import ChatCompletion
+
+
+class TestStreaming:
+    def test_chat(self):
+        buffer = []
+        client = MarvinClient()
+        response = client.generate_chat(
+            messages=[BaseMessage(role="user", content="Hello!")],
+            stream=True,
+            stream_callback=lambda response: buffer.append(response),
+        )
+        assert isinstance(response, ChatCompletion)
+        assert len(buffer) > 1
+        assert all(isinstance(c, StreamingChatResponse) for c in buffer)
+        assert buffer[-1].completion is response
+
+    def test_providing_callback_turns_on_streaming(self):
+        buffer = []
+        client = MarvinClient()
+        response = client.generate_chat(
+            messages=[BaseMessage(role="user", content="Hello!")],
+            stream_callback=lambda response: buffer.append(response),
+        )
+        assert isinstance(response, ChatCompletion)
+        assert len(buffer) > 1
+
+    def test_can_turn_off_streaming_even_if_callback_provided(self):
+        buffer = []
+        client = MarvinClient()
+        response = client.generate_chat(
+            messages=[BaseMessage(role="user", content="Hello!")],
+            stream=False,
+            stream_callback=lambda response: buffer.append(response),
+        )
+        assert isinstance(response, ChatCompletion)
+        assert len(buffer) == 0
+
+
+class TestStreamingAsync:
+    async def test_chat(self):
+        buffer = []
+        client = AsyncMarvinClient()
+        response = await client.generate_chat(
+            messages=[BaseMessage(role="user", content="Hello!")],
+            stream=True,
+            stream_callback=lambda response: buffer.append(response),
+        )
+        assert isinstance(response, ChatCompletion)
+        assert len(buffer) > 1
+        assert all(isinstance(c, StreamingChatResponse) for c in buffer)
+        assert buffer[-1].completion is response
+
+    async def test_providing_callback_turns_on_streaming(self):
+        buffer = []
+        client = AsyncMarvinClient()
+        response = await client.generate_chat(
+            messages=[BaseMessage(role="user", content="Hello!")],
+            stream_callback=lambda response: buffer.append(response),
+        )
+        assert isinstance(response, ChatCompletion)
+        assert len(buffer) > 1
+
+    async def test_can_turn_off_streaming_even_if_callback_provided(self):
+        buffer = []
+        client = AsyncMarvinClient()
+        response = await client.generate_chat(
+            messages=[BaseMessage(role="user", content="Hello!")],
+            stream=False,
+            stream_callback=lambda response: buffer.append(response),
+        )
+        assert isinstance(response, ChatCompletion)
+        assert len(buffer) == 0


### PR DESCRIPTION
This PR allows you to pass a `stream_callback` to `generate_chat` in order to handle streaming responses from chat completion endpoints.

stream_callback receives a `StreamingChatResponse` object which has:
- `chunk`, the most recently received chatcompletion delta
- `completion`, the reconstructed chatcompletion (up through the provided chunk)
- `messages`, for easy access to the messages received in the completion (a list in case n > 1)

Note this is not used in Marvin features yet.