### PR TITLE
rm asserts but keep syntax highlighting

### DIFF
--- a/docs/ai/text/extraction.md
+++ b/docs/ai/text/extraction.md
@@ -27,7 +27,7 @@ Marvin's `extract` function is a robust tool for pulling lists of structured ent
         !!! success "Result"
             
             ```python
-            assert features == ['camera', 'battery life']
+            features == ['camera', 'battery life']
             ```
 
     === "Structured entities"

--- a/docs/ai/text/function.md
+++ b/docs/ai/text/function.md
@@ -192,7 +192,7 @@ attractions = sightseeing('NYC', 'museums')
 
 !!! success "Result"
     ```python
-    assert attractions == [
+    attractions == [
         Attraction(
             name="Metropolitan Museum of Art",
             category="Art Museum",

--- a/docs/ai/text/generation.md
+++ b/docs/ai/text/generation.md
@@ -35,14 +35,11 @@ Marvin can generate synthetic data according to a schema and instructions. Gener
         !!! success "Result"
             
             ```python
-            print(names)
-            ['John', 'Emma', 'Michael', 'Sophia']
+            names == ['John', 'Emma', 'Michael', 'Sophia']
 
-            print(french_names)
-            ['Jean', 'Claire', 'Lucas', 'Emma']
+            french_names == ['Jean', 'Claire', 'Lucas', 'Emma']
 
-            print(star_wars_names)
-            ['Luke', 'Leia', 'Han', 'Anakin']
+            star_wars_names == ['Luke', 'Leia', 'Han', 'Anakin']
             ```
 
     === "Populations (`dict[str, int]`)"
@@ -62,7 +59,7 @@ Marvin can generate synthetic data according to a schema and instructions. Gener
         !!! success "Result"
             
             ```python
-            assert populations == [
+            populations == [
                 {'China': 1444216107},
                 {'India': 1380004385},
                 {'United States': 331893745},
@@ -90,8 +87,7 @@ Marvin can generate synthetic data according to a schema and instructions. Gener
         !!! success "Result"
             
             ```python
-            print(locations)
-            [
+            locations == [
                 Location(city='Washington', state='District of Columbia'),
                 Location(city='Jackson', state='Mississippi'),
                 Location(city='Cleveland', state='Ohio'),
@@ -149,7 +145,7 @@ The first and second tabs both show high-quality, varied results. The third tab 
 
     !!! success "Result"
         ```python
-        assert cities == [
+        cities == [
             'New York',
             'Los Angeles',
             'Chicago',
@@ -172,7 +168,7 @@ The first and second tabs both show high-quality, varied results. The third tab 
     ```
     !!! success "Result"
         ```python
-        assert cities == [
+        cities == [
             'Chicago',
             'San Francisco',
             'Seattle',
@@ -199,7 +195,7 @@ The first and second tabs both show high-quality, varied results. The third tab 
     ```
     !!! failure "Result"
         ```python
-        assert cities == [
+        cities == [
             'Houston',
             'Seattle',
             'Chicago',

--- a/docs/ai/vision/extraction.md
+++ b/docs/ai/vision/extraction.md
@@ -44,5 +44,5 @@ The `marvin.beta.extract` function is an enhanced version of `marvin.extract` th
 
     !!! success "Result"
         ```python
-        assert result == ['Pembroke Welsh Corgi', 'Yorkshire Terrier']
+        result == ['Pembroke Welsh Corgi', 'Yorkshire Terrier']
         ```    

--- a/docs/welcome/what_is_marvin.md
+++ b/docs/welcome/what_is_marvin.md
@@ -48,7 +48,7 @@ Marvin is open-source, free to use, and made with 💙 by the team at [Prefect](
         !!! success "Result"
             
             ```python
-            assert features == ['camera', 'battery life']
+            features == ['camera', 'battery life']
             ```
 
     === "Standardize inputs"
@@ -95,7 +95,7 @@ Marvin is open-source, free to use, and made with 💙 by the team at [Prefect](
     
         !!! success "Result"
             ```python
-            assert result == [
+            result == [
                 Location(city="Washington", state="DC"),
                 Location(city="Jefferson City", state="MO"),
                 Location(city="Lincoln", state="NE"),
@@ -120,7 +120,7 @@ Marvin is open-source, free to use, and made with 💙 by the team at [Prefect](
         !!! success "Result"
             
             ```python
-            assert fruits == ["apple", "cherry", "strawberry"]
+            fruits == ["apple", "cherry", "strawberry"]
             ```
 
         Note that `list_fruits` has no source code. Marvin's components turn your function into a prompt, ask AI for its most likely output, and parses its response.


### PR DESCRIPTION
we want good highlighting, so no comments but assert isnt great on non-deterministic examples bc it suggests the user _ought_ to get that `Result`

keeps `assert` for deterministic examples