### PR TITLE
support local dotenv

### DIFF
--- a/src/marvin/settings.py
+++ b/src/marvin/settings.py
@@ -11,7 +11,7 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 
 class MarvinSettings(BaseSettings):
     model_config = SettingsConfigDict(
-        env_file="" if os.getenv("MARVIN_TEST_MODE") else "~/.marvin/.env",
+        env_file="" if os.getenv("MARVIN_TEST_MODE") else ("~/.marvin/.env", ".env"),
         extra="allow",
         arbitrary_types_allowed=True,
         validate_assignment=True,


### PR DESCRIPTION
closes #766

per pydantic docs
> If you need to load multiple dotenv files, you can pass multiple file paths as a tuple or list. The files will be loaded in order, with each file overriding the previous one.
```
from pydantic_settings import BaseSettings, SettingsConfigDict


class Settings(BaseSettings):
    model_config = SettingsConfigDict(
        # `.env.prod` takes priority over `.env`
        env_file=('.env', '.env.prod')
    )
```