### PR TITLE
Wrong parameter name for cast() in docs

### DIFF
--- a/docs/docs/text/extraction.md
+++ b/docs/docs/text/extraction.md
@@ -142,13 +142,13 @@ Sometimes the cast operation is obvious, as in the "big apple" example above. Ot
 In a simple case, instructions can be used independent of any type-casting. Here, we want to keep the output a string, but get the 2-letter abbreviation of the state.
 
 ```python
-marvin.cast('California', to=str, instruction="The state's abbreviation")
+marvin.cast('California', to=str, instructions="The state's abbreviation")
 # "CA"
 
-marvin.cast('The sunshine state', to=str, instruction="The state's abbreviation")
+marvin.cast('The sunshine state', to=str, instructions="The state's abbreviation")
 # "FL"
 
-marvin.cast('Mass.', to=str, instruction="The state's abbreviation")
+marvin.cast('Mass.', to=str, instructions="The state's abbreviation")
 # MA
 ```
 

--- a/docs/docs/text/transformation.md
+++ b/docs/docs/text/transformation.md
@@ -56,13 +56,13 @@ Sometimes the cast operation is obvious, as in the "big apple" example above. Ot
 In a simple case, instructions can be used independent of any type-casting. Here, we want to keep the output a string, but get the 2-letter abbreviation of the state.
 
 ```python
-marvin.cast('California', target=str, instruction="The state's abbreviation")
+marvin.cast('California', target=str, instructions="The state's abbreviation")
 # "CA"
 
-marvin.cast('The sunshine state', target=str, instruction="The state's abbreviation")
+marvin.cast('The sunshine state', target=str, instructions="The state's abbreviation")
 # "FL"
 
-marvin.cast('Mass.', target=str, instruction="The state's abbreviation")
+marvin.cast('Mass.', target=str, instructions="The state's abbreviation")
 # MA
 ```
 


### PR DESCRIPTION
The parameter name for cast() is listed as "instruction" in the docs when it should be "instructions".