### PR TITLE
Fix application tool setup

### DIFF
--- a/src/marvin/beta/applications/applications.py
+++ b/src/marvin/beta/applications/applications.py
@@ -69,13 +69,10 @@ class Application(Assistant):
             if not isinstance(tool, Tool):
                 kwargs = None
                 signature = inspect.signature(tool)
-                parameter = None
                 for parameter in signature.parameters.values():
                     if parameter.annotation == Application:
+                        kwargs = {parameter.name: self}
                         break
-                if parameter is not None:
-                    kwargs = {parameter.name: self}
-
                 tool = tool_from_function(tool, kwargs=kwargs)
             tools.append(tool)
 


### PR DESCRIPTION
The previous logic had a bug that would set the last parameter to receive the application even if the type annotation didn't match. That ultimately breaks the tool usage by omitting required parameters from the spec