### PR TITLE
Access to tool calls and tool outputs in post_run_hook

### DIFF
--- a/src/marvin/beta/assistants/assistants.py
+++ b/src/marvin/beta/assistants/assistants.py
@@ -1,6 +1,7 @@
 from typing import TYPE_CHECKING, Callable, Optional, Union
 
 from pydantic import BaseModel, Field, PrivateAttr
+from openai.types.beta.threads.required_action_function_tool_call import RequiredActionFunctionToolCall
 
 import marvin.utilities.tools
 from marvin.tools.assistants import AssistantTool
@@ -168,5 +169,10 @@ class Assistant(BaseModel, ExposeSyncMethodsMixin):
     def pre_run_hook(self, run: "Run"):
         pass
 
-    def post_run_hook(self, run: "Run"):
+    def post_run_hook(
+            self,
+            run: "Run",
+            tool_calls: Optional[list[RequiredActionFunctionToolCall]] = None,
+            tool_outputs: Optional[list[dict[str, str]]] = None
+        ):
         pass

--- a/src/marvin/beta/assistants/assistants.py
+++ b/src/marvin/beta/assistants/assistants.py
@@ -1,7 +1,9 @@
 from typing import TYPE_CHECKING, Callable, Optional, Union
 
+from openai.types.beta.threads.required_action_function_tool_call import (
+    RequiredActionFunctionToolCall,
+)
 from pydantic import BaseModel, Field, PrivateAttr
-from openai.types.beta.threads.required_action_function_tool_call import RequiredActionFunctionToolCall
 
 import marvin.utilities.tools
 from marvin.tools.assistants import AssistantTool
@@ -170,9 +172,9 @@ class Assistant(BaseModel, ExposeSyncMethodsMixin):
         pass
 
     def post_run_hook(
-            self,
-            run: "Run",
-            tool_calls: Optional[list[RequiredActionFunctionToolCall]] = None,
-            tool_outputs: Optional[list[dict[str, str]]] = None
-        ):
+        self,
+        run: "Run",
+        tool_calls: Optional[list[RequiredActionFunctionToolCall]] = None,
+        tool_outputs: Optional[list[dict[str, str]]] = None,
+    ):
         pass


### PR DESCRIPTION
Usage example:
```
class CustomAssistant(Assistant):
    def post_run_hook(self, run: "Run", tool_calls, tool_outputs):
        print(f"\n\nPost run hook")
        print(f"tool_calls: {tool_calls}")
        print(f"tool_outputs: {tool_outputs}")

ai = CustomAssistant(
    name="CustomAssistant",
    instructions="You are a helpful assistant."
)

```