### PR TITLE
allow kwargs on `Application` post run hook

### DIFF
--- a/src/marvin/beta/applications/applications.py
+++ b/src/marvin/beta/applications/applications.py
@@ -78,6 +78,6 @@ class Application(Assistant):
 
         return tools
 
-    def post_run_hook(self, run: Run):
+    def post_run_hook(self, run: Run, *args, **kwargs):
         self.state.flush_changes()
-        return super().post_run_hook(run)
+        return super().post_run_hook(run, *args, **kwargs)


### PR DESCRIPTION
2.1.4 started allowing tracking tool calls and outputs via the `Assistant.post_run_hook` but the `Application` did not allow arbitrary kwargs to go through