### PR TITLE
Assistant lifecycle tests

### DIFF
--- a/src/marvin/beta/assistants/assistants.py
+++ b/src/marvin/beta/assistants/assistants.py
@@ -92,10 +92,9 @@ class Assistant(BaseModel, ExposeSyncMethodsMixin):
         # post the message
         user_message = await thread.add_async(message, file_paths=file_paths)
 
-        # enter assistant context, run the thread, and decrement context level
-        await self.__aenter__()
-        await thread.run_async(assistant=self, **run_kwargs)
-        self._context_level -= 1
+        # run the thread
+        async with self:
+            await thread.run_async(assistant=self, **run_kwargs)
 
         # load all messages, including the user message
         response_messages = await thread.get_messages_async(

--- a/src/marvin/beta/assistants/assistants.py
+++ b/src/marvin/beta/assistants/assistants.py
@@ -5,6 +5,7 @@ from openai.types.beta.threads.required_action_function_tool_call import (
 )
 from pydantic import BaseModel, Field, PrivateAttr
 
+import marvin.utilities.openai
 import marvin.utilities.tools
 from marvin.tools.assistants import AssistantTool
 from marvin.types import Tool
@@ -14,7 +15,6 @@ from marvin.utilities.asyncio import (
     run_sync,
 )
 from marvin.utilities.logging import get_logger
-from marvin.utilities.openai import get_openai_client
 
 from .threads import Thread, ThreadMessage
 
@@ -114,7 +114,7 @@ class Assistant(BaseModel, ExposeSyncMethodsMixin):
     async def __aenter__(self):
         # if this is the outermost context and no ID is set, create the assistant
         if self.id is None and self._context_level == 0:
-            await self.create_async()
+            await self.create_async(_auto_delete=True)
 
         self._context_level += 1
         return self
@@ -130,12 +130,12 @@ class Assistant(BaseModel, ExposeSyncMethodsMixin):
         return False
 
     @expose_sync_method("create")
-    async def create_async(self):
+    async def create_async(self, _auto_delete: bool = False):
         if self.id is not None:
             raise ValueError(
                 "Assistant has an ID and has already been created in the OpenAI API."
             )
-        client = get_openai_client()
+        client = marvin.utilities.openai.get_openai_client()
         response = await client.beta.assistants.create(
             **self.model_dump(
                 include={"name", "model", "metadata", "file_ids", "metadata"}
@@ -145,11 +145,16 @@ class Assistant(BaseModel, ExposeSyncMethodsMixin):
         )
         self.id = response.id
 
+        # assistants are auto deleted if their context level reaches 0,
+        # so we disable that behavior by initializing the context level to 1
+        if not _auto_delete:
+            self._context_level = 1
+
     @expose_sync_method("delete")
     async def delete_async(self):
         if not self.id:
             raise ValueError("Assistant has no ID and doesn't exist in the OpenAI API.")
-        client = get_openai_client()
+        client = marvin.utilities.openai.get_openai_client()
         await client.beta.assistants.delete(assistant_id=self.id)
         self.id = None
 
@@ -159,9 +164,12 @@ class Assistant(BaseModel, ExposeSyncMethodsMixin):
 
     @classmethod
     async def load_async(cls, assistant_id: str, **kwargs):
-        client = get_openai_client()
+        client = marvin.utilities.openai.get_openai_client()
         response = await client.beta.assistants.retrieve(assistant_id=assistant_id)
-        return cls(**(response.model_dump() | kwargs))
+        assistant = cls(**(response.model_dump() | kwargs))
+        # set context level to 1 so the assistant is never auto-deleted
+        assistant._context_level = 1
+        return assistant
 
     def chat(self, thread: Thread = None):
         if thread is None:

--- a/src/marvin/utilities/openai.py
+++ b/src/marvin/utilities/openai.py
@@ -85,7 +85,9 @@ def get_openai_client(
             )
         client_class = AsyncAzureOpenAI if is_async else AzureOpenAI
         kwargs.update(
-            api_key=api_key, api_version=api_version, azure_endpoint=azure_endpoint
+            api_key=api_key,
+            api_version=api_version,
+            azure_endpoint=azure_endpoint,
         )
 
     # --- N/A

--- a/tests/beta/assistants/test_assistants.py
+++ b/tests/beta/assistants/test_assistants.py
@@ -1,0 +1,98 @@
+from unittest.mock import patch
+
+import openai
+import pytest
+from marvin.beta.assistants import Assistant
+
+client = openai.AsyncClient()
+
+
+def mocked_client():
+    return client
+
+
+@pytest.fixture(autouse=True)
+def mock_get_client(monkeypatch):
+    # Use monkeypatch to replace get_client with special_get_client
+    monkeypatch.setattr("marvin.utilities.openai.get_openai_client", mocked_client)
+
+
+class TestLifeCycle:
+    @patch.object(client.beta.assistants, "delete", wraps=client.beta.assistants.delete)
+    @patch.object(client.beta.assistants, "create", wraps=client.beta.assistants.create)
+    def test_interactive(self, mock_create, mock_delete):
+        """auto-create and auto-delete on interaction"""
+        ai = Assistant()
+        mock_create.assert_not_called()
+        assert not ai.id
+        response = ai.say("repeat the word hi")
+        assert response
+        assert not ai.id
+        mock_create.assert_called()
+        mock_delete.assert_called()
+
+    @patch.object(client.beta.assistants, "delete", wraps=client.beta.assistants.delete)
+    @patch.object(client.beta.assistants, "create", wraps=client.beta.assistants.create)
+    def test_context_manager(self, mock_create, mock_delete):
+        """auto-create and auto-delete on context only"""
+        ai = Assistant()
+        with ai:
+            mock_create.assert_called()
+            assert ai.id
+            ai.say("repeat the word hi")
+            mock_delete.assert_not_called()
+            ai.say("repeat the word hi")
+            mock_delete.assert_not_called()
+            assert ai.id
+        assert not ai.id
+        mock_delete.assert_called_once()
+        mock_create.assert_called_once()
+
+    @patch.object(client.beta.assistants, "delete", wraps=client.beta.assistants.delete)
+    @patch.object(client.beta.assistants, "create", wraps=client.beta.assistants.create)
+    def test_manual_lifecycle(self, mock_create, mock_delete):
+        """manual create and delete"""
+        ai = Assistant()
+        mock_create.assert_not_called()
+        ai.create()
+        mock_create.assert_called()
+        assert ai.id
+        ai.say("repeat the word hi")
+        mock_delete.assert_not_called()
+        ai.say("repeat the word hi")
+        mock_delete.assert_not_called()
+        assert ai.id
+        ai.delete()
+        assert not ai.id
+        mock_delete.assert_called_once()
+        mock_create.assert_called_once()
+
+    def test_load_from_api(self):
+        """fully manual delete"""
+
+        api_ai = Assistant()
+        api_ai.create()
+        api_id = api_ai.id
+
+        # create mocks late to avoid calling above
+        with (
+            patch.object(
+                client.beta.assistants, "delete", wraps=client.beta.assistants.delete
+            ) as mock_delete,
+            patch.object(
+                client.beta.assistants, "create", wraps=client.beta.assistants.create
+            ) as mock_create,
+        ):
+            ai = Assistant.load(api_id)
+            mock_create.assert_not_called()
+
+            assert ai.id
+            ai.say("repeat the word hi")
+            mock_delete.assert_not_called()
+            ai.say("repeat the word hi")
+            mock_delete.assert_not_called()
+            assert ai.id
+            ai.delete()
+            assert not ai.id
+            mock_delete.assert_called_once()
+            mock_create.assert_not_called()

--- a/tests/beta/assistants/test_assistants.py
+++ b/tests/beta/assistants/test_assistants.py
@@ -1,10 +1,11 @@
 from unittest.mock import patch
 
+import marvin
 import openai
 import pytest
 from marvin.beta.assistants import Assistant
 
-client = openai.AsyncClient()
+client = openai.AsyncClient(api_key=marvin.settings.openai.api_key.get_secret_value())
 
 
 def mocked_client():


### PR DESCRIPTION
Closes a bug where manual assistant lifecycles were still calling `delete` automatically. Now lifecycles should work as described in docs:

- full interactive use (e.g. instantiate a Python assistant and call `say`) will auto create / delete as necessary
- context managers can force creation/ deletion to only happen once, at the open/close of the context
- manual calls to create and delete will disable automatic behavior
- loading from the API will disable automatic behavior