### PR TITLE
docs: fix environment variable in docs/warning message

### DIFF
--- a/docs/docs/configuration/settings.md
+++ b/docs/docs/configuration/settings.md
@@ -11,7 +11,7 @@ Please set Marvin specific settings in `~/.marvin/.env`. One exception being `OP
     For example, in your `~/.marvin/.env` file you could have:
     ```shell
     MARVIN_LOG_LEVEL=INFO
-    MARVIN_OPENAI_CHAT_COMPLETIONS_MODEL=gpt-4
+    MARVIN_CHAT_COMPLETIONS_MODEL=gpt-4
     MARVIN_OPENAI_API_KEY='sk-my-api-key'
     ```
     Settings these values will let you avoid setting an API key every time. 

--- a/src/marvin/client/openai.py
+++ b/src/marvin/client/openai.py
@@ -139,7 +139,7 @@ async def should_fallback(e: NotFoundError, request: ChatRequest) -> bool:
             " API key likely does not give you access to. This API call will"
             f" fall back to the {FALLBACK_CHAT_COMPLETIONS_MODEL!r} model. To"
             " avoid this warning, please set"
-            " `MARVIN_OPENAI_CHAT_COMPLETIONS_MODEL=<accessible model>` in"
+            " `MARVIN_CHAT_COMPLETIONS_MODEL=<accessible model>` in"
             f" `~/.marvin/.env` - for example, `gpt-3.5-turbo`.\n\n {e}"
         )
         return True


### PR DESCRIPTION
I believe this is correct from testing/other parts of the codebase, lmk if not
