### PR TITLE
Add mapping for automatic parallelization over inputs

### DIFF
--- a/docs/docs/text/classification.md
+++ b/docs/docs/text/classification.md
@@ -188,3 +188,20 @@ result = await marvin.classify_async(
 
 assert result == "bug"
 ```
+
+## Mapping
+
+To classify a list of inputs at once, use `.map`:
+
+```python
+inputs = [
+    "The app crashes when I try to upload a file.",
+    "How do change my password?"
+]
+result = marvin.classify.map(inputs, ["bug", "feature request", "inquiry"])
+assert result == ["bug", "inquiry"]
+```
+
+(`marvin.classify_async.map` is also available for async environments.)
+
+Mapping automatically issues parallel requests to the API, making it a highly efficient way to classify multiple inputs at once. The result is a list of classifications in the same order as the inputs.

--- a/docs/docs/text/extraction.md
+++ b/docs/docs/text/extraction.md
@@ -168,3 +168,20 @@ result = await marvin.extract_async(
 
 assert result == ["NY", "CA"]
 ```
+
+## Mapping
+
+To extract from a list of inputs at once, use `.map`:
+
+```python
+inputs = [
+    "I drove from New York to California.",
+    "I took a flight from NYC to BOS."
+]
+result = marvin.extract.map(inputs, target=str, instructions="2-letter state codes")
+assert result  == [["NY", "CA"], ["NY", "MA"]]
+```
+
+(`marvin.extract_async.map` is also available for async environments.)
+
+Mapping automatically issues parallel requests to the API, making it a highly efficient way to work with multiple inputs at once. The result is a list of outputs in the same order as the inputs.

--- a/docs/docs/text/transformation.md
+++ b/docs/docs/text/transformation.md
@@ -124,3 +124,20 @@ result = await marvin.cast_async("one", int)
 
 assert result == 1
 ```
+
+## Mapping
+
+To transform a list of inputs at once, use `.map`:
+
+```python
+inputs = [
+    "I bought two donuts.",
+    "I bought six hot dogs."
+]
+result = marvin.cast.map(inputs, int)
+assert result  == [2, 6]
+```
+
+(`marvin.cast_async.map` is also available for async environments.)
+
+Mapping automatically issues parallel requests to the API, making it a highly efficient way to work with multiple inputs at once. The result is a list of outputs in the same order as the inputs.

--- a/docs/docs/vision/classification.md
+++ b/docs/docs/vision/classification.md
@@ -75,3 +75,20 @@ result = await marvin.beta.classify_async(
 
 assert result == "bug"
 ```
+
+## Mapping
+
+To classify a list of inputs at once, use `.map`:
+
+```python
+inputs = [
+    "The app crashes when I try to upload a file.",
+    "How do change my password?"
+]
+result = marvin.beta.classify.map(inputs, ["bug", "feature request", "inquiry"])
+assert result == ["bug", "inquiry"]
+```
+
+(`marvin.beta.classify_async.map` is also available for async environments.)
+
+Mapping automatically issues parallel requests to the API, making it a highly efficient way to classify multiple inputs at once. The result is a list of classifications in the same order as the inputs.

--- a/docs/docs/vision/extraction.md
+++ b/docs/docs/vision/extraction.md
@@ -65,3 +65,20 @@ result = await marvin.beta.extract_async(
 
 assert result == ["NY", "CA"]
 ```
+
+## Mapping
+
+To extract from a list of inputs at once, use `.map`:
+
+```python
+inputs = [
+    "I drove from New York to California.",
+    "I took a flight from NYC to BOS."
+]
+result = marvin.beta.extract.map(inputs, target=str, instructions="2-letter state codes")
+assert result  == [["NY", "CA"], ["NY", "MA"]]
+```
+
+(`marvin.beta.extract_async.map` is also available for async environments.)
+
+Mapping automatically issues parallel requests to the API, making it a highly efficient way to work with multiple inputs at once. The result is a list of outputs in the same order as the inputs.

--- a/docs/docs/vision/transformation.md
+++ b/docs/docs/vision/transformation.md
@@ -125,3 +125,20 @@ result = await marvin.beta.cast_async("one", int)
 
 assert result == 1
 ```
+
+## Mapping
+
+To transform a list of inputs at once, use `.map`:
+
+```python
+inputs = [
+    "I bought two donuts.",
+    "I bought six hot dogs."
+]
+result = marvin.beta.cast.map(inputs, int)
+assert result  == [2, 6]
+```
+
+(`marvin.beta.cast_async.map` is also available for async environments.)
+
+Mapping automatically issues parallel requests to the API, making it a highly efficient way to work with multiple inputs at once. The result is a list of outputs in the same order as the inputs.

--- a/src/marvin/ai/text.py
+++ b/src/marvin/ai/text.py
@@ -40,6 +40,7 @@ from marvin.utilities.asyncio import run_sync
 from marvin.utilities.context import ctx
 from marvin.utilities.jinja import Transcript
 from marvin.utilities.logging import get_logger
+from marvin.utilities.mapping import map_async
 from marvin.utilities.python import PythonFunction
 from marvin.utilities.strings import count_tokens
 
@@ -680,7 +681,7 @@ def model(
     return decorator
 
 
-### Sync versions of the above functions
+# --- Sync versions of the above functions
 
 
 def cast(
@@ -839,3 +840,123 @@ def generate(
             client=client,
         )
     )
+
+
+# --- Mapping
+async def classify_async_map(
+    data: list[str],
+    labels: Union[Enum, list[T], type],
+    instructions: Optional[str] = None,
+    model_kwargs: Optional[dict] = None,
+    client: Optional[AsyncMarvinClient] = None,
+) -> list[T]:
+    return await map_async(
+        fn=classify_async,
+        map_kwargs=dict(data=data),
+        unmapped_kwargs=dict(
+            labels=labels,
+            instructions=instructions,
+            model_kwargs=model_kwargs,
+            client=client,
+        ),
+    )
+
+
+def classify_map(
+    data: list[str],
+    labels: Union[Enum, list[T], type],
+    instructions: Optional[str] = None,
+    model_kwargs: Optional[dict] = None,
+    client: Optional[AsyncMarvinClient] = None,
+) -> list[T]:
+    return run_sync(
+        classify_async_map(
+            data=data,
+            labels=labels,
+            instructions=instructions,
+            model_kwargs=model_kwargs,
+            client=client,
+        )
+    )
+
+
+async def cast_async_map(
+    data: list[str],
+    target: type[T],
+    instructions: Optional[str] = None,
+    model_kwargs: Optional[dict] = None,
+    client: Optional[AsyncMarvinClient] = None,
+) -> list[T]:
+    return await map_async(
+        fn=cast_async,
+        map_kwargs=dict(data=data),
+        unmapped_kwargs=dict(
+            target=target,
+            instructions=instructions,
+            model_kwargs=model_kwargs,
+            client=client,
+        ),
+    )
+
+
+def cast_map(
+    data: list[str],
+    target: type[T],
+    instructions: Optional[str] = None,
+    model_kwargs: Optional[dict] = None,
+    client: Optional[AsyncMarvinClient] = None,
+) -> list[T]:
+    return run_sync(
+        cast_async_map(
+            data=data,
+            target=target,
+            instructions=instructions,
+            model_kwargs=model_kwargs,
+            client=client,
+        )
+    )
+
+
+async def extract_async_map(
+    data: list[str],
+    target: Optional[type[T]] = None,
+    instructions: Optional[str] = None,
+    model_kwargs: Optional[dict] = None,
+    client: Optional[AsyncMarvinClient] = None,
+) -> list[list[T]]:
+    return await map_async(
+        fn=extract_async,
+        map_kwargs=dict(data=data),
+        unmapped_kwargs=dict(
+            target=target,
+            instructions=instructions,
+            model_kwargs=model_kwargs,
+            client=client,
+        ),
+    )
+
+
+def extract_map(
+    data: list[str],
+    target: Optional[type[T]] = None,
+    instructions: Optional[str] = None,
+    model_kwargs: Optional[dict] = None,
+    client: Optional[AsyncMarvinClient] = None,
+) -> list[list[T]]:
+    return run_sync(
+        extract_async_map(
+            data=data,
+            target=target,
+            instructions=instructions,
+            model_kwargs=model_kwargs,
+            client=client,
+        )
+    )
+
+
+cast_async.map = cast_async_map
+cast.map = cast_map
+classify_async.map = classify_async_map
+classify.map = classify_map
+extract_async.map = extract_async_map
+extract.map = extract_map

--- a/src/marvin/beta/vision.py
+++ b/src/marvin/beta/vision.py
@@ -6,7 +6,7 @@ vision-enhanced versions of `cast`, `extract`, and `classify`.
 import inspect
 from enum import Enum
 from pathlib import Path
-from typing import Callable, Coroutine, TypeVar, Union
+from typing import Callable, Coroutine, Optional, TypeVar, Union
 
 from pydantic import BaseModel
 
@@ -26,6 +26,7 @@ from marvin.utilities.context import ctx
 from marvin.utilities.images import image_to_base64
 from marvin.utilities.jinja import Transcript
 from marvin.utilities.logging import get_logger
+from marvin.utilities.mapping import map_async
 
 T = TypeVar("T")
 M = TypeVar("M", bound=BaseModel)
@@ -217,7 +218,7 @@ async def cast_async(
     instructions. The function also supports additional arguments for both models.
 
     Args:
-        images (list[Union[str, Path]]): The images to be processed.
+        images (list[Image]): The images to be processed.
         data (str): The data to be converted.
         target (type): The type to convert the data into.
         instructions (str, optional): Specific instructions for the conversion.
@@ -251,7 +252,7 @@ async def extract_async(
     data: Union[str, Image],
     target: type[T],
     instructions: str = None,
-    images: list[Union[str, Path]] = None,
+    images: list[Image] = None,
     vision_model_kwargs: dict = None,
     model_kwargs: dict = None,
 ) -> T:
@@ -390,7 +391,7 @@ def extract(
     data: Union[str, Image],
     target: type[T],
     instructions: str = None,
-    images: list[Union[str, Path]] = None,
+    images: list[Image] = None,
     vision_model_kwargs: dict = None,
     model_kwargs: dict = None,
 ) -> T:
@@ -401,7 +402,7 @@ def extract(
         data (Union[str, Image]): Data or an image for information extraction.
         target (type[T]): The type to extract the data into.
         instructions (str, optional): Instructions for extraction.
-        images (list[Union[str, Path]], optional): Additional images for extraction.
+        images (list[Image], optional): Additional images for extraction.
         vision_model_kwargs (dict, optional): Arguments for the vision model.
         model_kwargs (dict, optional): Arguments for the language model.
 
@@ -423,7 +424,7 @@ def extract(
 def classify(
     data: Union[str, Image],
     labels: Union[Enum, list[T], type],
-    images: Union[Union[str, Path], list[Union[str, Path]]] = None,
+    images: Union[Image, list[Image]] = None,
     instructions: str = None,
     vision_model_kwargs: dict = None,
     model_kwargs: dict = None,
@@ -434,7 +435,7 @@ def classify(
     Args:
         data (Union[str, Image]): Data or an image for classification.
         labels (Union[Enum, list[T], type]): Labels to classify into.
-        images (Union[Union[str, Path], list[Union[str, Path]]], optional): Additional images for classification.
+        images (Union[Image, list[Image]], optional): Additional images for classification.
         instructions (str, optional): Instructions for the classification.
         vision_model_kwargs (dict, optional): Arguments for the vision model.
         model_kwargs (dict, optional): Arguments for the language model.
@@ -452,3 +453,114 @@ def classify(
             model_kwargs=model_kwargs,
         )
     )
+
+
+# --- Mapping
+async def classify_async_map(
+    data: list[Union[str, Image]],
+    labels: Union[Enum, list[T], type],
+    instructions: Optional[str] = None,
+    model_kwargs: Optional[dict] = None,
+) -> list[T]:
+    return await map_async(
+        fn=classify_async,
+        map_kwargs=dict(data=data),
+        unmapped_kwargs=dict(
+            labels=labels,
+            instructions=instructions,
+            model_kwargs=model_kwargs,
+        ),
+    )
+
+
+def classify_map(
+    data: list[Union[str, Image]],
+    labels: Union[Enum, list[T], type],
+    instructions: Optional[str] = None,
+    model_kwargs: Optional[dict] = None,
+) -> list[T]:
+    return run_sync(
+        classify_async_map(
+            data=data,
+            labels=labels,
+            instructions=instructions,
+            model_kwargs=model_kwargs,
+        )
+    )
+
+
+async def cast_async_map(
+    data: list[Union[str, Image]],
+    target: type[T],
+    instructions: Optional[str] = None,
+    images: list[list[Image]] = None,
+    model_kwargs: Optional[dict] = None,
+) -> list[T]:
+    return await map_async(
+        fn=cast_async,
+        map_kwargs=dict(data=data, images=images or []),
+        unmapped_kwargs=dict(
+            target=target,
+            instructions=instructions,
+            model_kwargs=model_kwargs,
+        ),
+    )
+
+
+def cast_map(
+    data: list[Union[str, Image]],
+    target: type[T],
+    instructions: Optional[str] = None,
+    images: list[list[Image]] = None,
+    model_kwargs: Optional[dict] = None,
+) -> list[T]:
+    return run_sync(
+        cast_async_map(
+            data=data,
+            images=images,
+            target=target,
+            instructions=instructions,
+            model_kwargs=model_kwargs,
+        )
+    )
+
+
+async def extract_async_map(
+    data: list[Union[str, Image]],
+    target: Optional[type[T]] = None,
+    instructions: Optional[str] = None,
+    model_kwargs: Optional[dict] = None,
+) -> list[list[T]]:
+    return await map_async(
+        fn=extract_async,
+        map_kwargs=dict(data=data),
+        unmapped_kwargs=dict(
+            target=target,
+            instructions=instructions,
+            model_kwargs=model_kwargs,
+        ),
+    )
+
+
+def extract_map(
+    data: list[Union[str, Image]],
+    target: Optional[type[T]] = None,
+    instructions: Optional[str] = None,
+    model_kwargs: Optional[dict] = None,
+) -> list[list[T]]:
+    return run_sync(
+        extract_async_map(
+            data=data,
+            target=target,
+            instructions=instructions,
+            model_kwargs=model_kwargs,
+        )
+    )
+
+
+cast_async.map = cast_async_map
+cast.map = cast_map
+classify_async.map = classify_async_map
+classify.map = classify_map
+extract_async.map = extract_async_map
+extract.map = extract_map

--- a/src/marvin/beta/vision.py
+++ b/src/marvin/beta/vision.py
@@ -118,7 +118,10 @@ async def _two_step_vision_response(
         images = [images]
 
     if not images and not isinstance(data, Image):
-        return marvin_call(data)
+        if inspect.iscoroutinefunction(marvin_call):
+            return await marvin_call(data)
+        else:
+            return marvin_call(data)
 
     if isinstance(data, Image):
         images.append(data)

--- a/src/marvin/utilities/mapping.py
+++ b/src/marvin/utilities/mapping.py
@@ -1,0 +1,65 @@
+"""Utilities for mapping."""
+
+import asyncio
+from typing import Any, Callable, Coroutine, TypeVar
+
+T = TypeVar("T")
+
+
+async def map_async(
+    fn: Callable[..., Coroutine[Any, Any, T]],
+    map_args: tuple = None,
+    map_kwargs: dict = None,
+    unmapped_kwargs: dict = None,
+):
+    """
+    Asynchronously maps a function over a list of arguments.
+
+    This function takes a function and multiple lists of arguments, and applies
+    the function to each combination of arguments. The function is applied
+    concurrently to each combination of arguments using asyncio's gather
+    function.
+
+    Args:
+        fn (Callable[..., Coroutine[Any, Any, T]]): The async function to map.
+        map_args (list, optional): A list of lists, where each inner list
+            contains positional arguments to map over.
+        unmapped_kwargs (dict, optional): A dictionary of arguments to pass to
+            the function as is.
+        map_kwargs (dict, optional): A dictionary where each key-value pair
+            represents the keyword arguments to map over.
+
+    Returns:
+        A list of return values from the function, gathered using asyncio.gather.
+
+    Example:
+        Basic usage:
+        async def add(x, y):
+            return x + y
+
+        result = await map_async(add, map_args=[[1, 2, 3], [4, 5, 6]])
+        # result is [5, 7, 9]
+    """
+    if map_args is None:
+        map_args = []
+    if map_kwargs is None:
+        map_kwargs = {}
+    if unmapped_kwargs is None:
+        unmapped_kwargs = {}
+
+    tasks = []
+    if map_args:
+        max_length = max(len(arg) for arg in map_args)
+    else:
+        max_length = max(len(v) for v in map_kwargs.values())
+
+    for i in range(max_length):
+        call_args = [arg[i] if i < len(arg) else None for arg in map_args]
+        call_kwargs = (
+            {k: v[i] if i < len(v) else None for k, v in map_kwargs.items()}
+            if map_kwargs
+            else {}
+        )
+        tasks.append(fn(*call_args, **call_kwargs, **unmapped_kwargs))
+
+    return await asyncio.gather(*tasks)

--- a/tests/ai/beta/vision/test_cast.py
+++ b/tests/ai/beta/vision/test_cast.py
@@ -20,6 +20,16 @@ class TestVisionCast:
             Location(city="New York City", state="NY"),
         )
 
+    def test_cast_dc(self):
+        img = marvin.beta.Image(
+            "https://images.unsplash.com/photo-1617581629397-a72507c3de9e"
+        )
+        result = marvin.beta.cast(img, target=Location)
+        assert result in (
+            Location(city="Washington", state="DC"),
+            Location(city="Washington", state="D.C."),
+        )
+
     def test_cast_ny_images_input(self):
         img = marvin.beta.Image(
             "https://images.unsplash.com/photo-1568515387631-8b650bbcdb90"
@@ -92,4 +102,42 @@ class TestAsync:
         assert result in (
             Location(city="New York", state="NY"),
             Location(city="New York City", state="NY"),
+        )
+
+
+class TestMapping:
+    def test_map(self):
+        ny = marvin.beta.Image(
+            "https://images.unsplash.com/photo-1568515387631-8b650bbcdb90"
+        )
+        dc = marvin.beta.Image(
+            "https://images.unsplash.com/photo-1617581629397-a72507c3de9e"
+        )
+        result = marvin.beta.cast.map([ny, dc], target=Location)
+        assert isinstance(result, list)
+        assert result[0] in (
+            Location(city="New York", state="NY"),
+            Location(city="New York City", state="NY"),
+        )
+        assert result[1] in (
+            Location(city="Washington", state="DC"),
+            Location(city="Washington", state="D.C."),
+        )
+
+    async def test_async_map(self):
+        ny = marvin.beta.Image(
+            "https://images.unsplash.com/photo-1568515387631-8b650bbcdb90"
+        )
+        dc = marvin.beta.Image(
+            "https://images.unsplash.com/photo-1617581629397-a72507c3de9e"
+        )
+        result = await marvin.beta.cast_async.map([ny, dc], target=Location)
+        assert isinstance(result, list)
+        assert result[0] in (
+            Location(city="New York", state="NY"),
+            Location(city="New York City", state="NY"),
+        )
+        assert result[1] in (
+            Location(city="Washington", state="DC"),
+            Location(city="Washington", state="D.C."),
         )

--- a/tests/ai/beta/vision/test_classify.py
+++ b/tests/ai/beta/vision/test_classify.py
@@ -93,3 +93,29 @@ class TestAsync:
         )
         result = await marvin.beta.classify_async(img, labels=["urban", "rural"])
         assert result == "urban"
+
+
+class TestMapping:
+    def test_map(self):
+        ny = marvin.beta.Image(
+            "https://images.unsplash.com/photo-1568515387631-8b650bbcdb90"
+        )
+        dc = marvin.beta.Image(
+            "https://images.unsplash.com/photo-1617581629397-a72507c3de9e"
+        )
+        result = marvin.beta.classify.map([ny, dc], labels=["urban", "rural"])
+        assert isinstance(result, list)
+        assert result == ["urban", "urban"]
+
+    async def test_map_async(self):
+        ny = marvin.beta.Image(
+            "https://images.unsplash.com/photo-1568515387631-8b650bbcdb90"
+        )
+        dc = marvin.beta.Image(
+            "https://images.unsplash.com/photo-1617581629397-a72507c3de9e"
+        )
+        result = await marvin.beta.classify_async.map(
+            [ny, dc], labels=["urban", "rural"]
+        )
+        assert isinstance(result, list)
+        assert result == ["urban", "urban"]

--- a/tests/ai/beta/vision/test_extract.py
+++ b/tests/ai/beta/vision/test_extract.py
@@ -94,3 +94,41 @@ class TestAsync:
             [Location(city="New York", state="NY")],
             [Location(city="New York City", state="NY")],
         )
+
+
+class TestMapping:
+    def test_map(self):
+        ny = marvin.beta.Image(
+            "https://images.unsplash.com/photo-1568515387631-8b650bbcdb90"
+        )
+        dc = marvin.beta.Image(
+            "https://images.unsplash.com/photo-1617581629397-a72507c3de9e"
+        )
+        result = marvin.beta.extract.map([ny, dc], target=Location)
+        assert isinstance(result, list)
+        assert result[0][0] in (
+            Location(city="New York", state="NY"),
+            Location(city="New York City", state="NY"),
+        )
+        assert result[1][0] in (
+            Location(city="Washington", state="DC"),
+            Location(city="Washington", state="D.C."),
+        )
+
+    async def test_async_map(self):
+        ny = marvin.beta.Image(
+            "https://images.unsplash.com/photo-1568515387631-8b650bbcdb90"
+        )
+        dc = marvin.beta.Image(
+            "https://images.unsplash.com/photo-1617581629397-a72507c3de9e"
+        )
+        result = await marvin.beta.extract_async.map([ny, dc], target=Location)
+        assert isinstance(result, list)
+        assert result[0][0] in (
+            Location(city="New York", state="NY"),
+            Location(city="New York City", state="NY"),
+        )
+        assert result[1][0] in (
+            Location(city="Washington", state="DC"),
+            Location(city="Washington", state="D.C."),
+        )

--- a/tests/ai/test_cast.py
+++ b/tests/ai/test_cast.py
@@ -118,3 +118,24 @@ class TestCast:
         async def test_cast_text_to_int(self):
             result = await marvin.cast_async("one", int)
             assert result == 1
+
+
+class TestMapping:
+    def test_cast_map(self):
+        result = marvin.cast.map(["one", "two"], int)
+        assert isinstance(result, list)
+        assert result == [1, 2]
+
+    def test_cast_map_with_instructions(self):
+        result = marvin.cast.map(
+            ["one", "two"],
+            int,
+            instructions="add one to each number",
+        )
+        assert isinstance(result, list)
+        assert result == [2, 3]
+
+    async def test_async_cast_map(self):
+        result = await marvin.cast_async.map(["one", "two"], int)
+        assert isinstance(result, list)
+        assert result == [1, 2]

--- a/tests/ai/test_cast.py
+++ b/tests/ai/test_cast.py
@@ -121,12 +121,12 @@ class TestCast:
 
 
 class TestMapping:
-    def test_cast_map(self):
+    def test_map(self):
         result = marvin.cast.map(["one", "two"], int)
         assert isinstance(result, list)
         assert result == [1, 2]
 
-    def test_cast_map_with_instructions(self):
+    def test_map_with_instructions(self):
         result = marvin.cast.map(
             ["one", "two"],
             int,
@@ -135,7 +135,7 @@ class TestMapping:
         assert isinstance(result, list)
         assert result == [2, 3]
 
-    async def test_async_cast_map(self):
+    async def test_async_map(self):
         result = await marvin.cast_async.map(["one", "two"], int)
         assert isinstance(result, list)
         assert result == [1, 2]

--- a/tests/ai/test_classify.py
+++ b/tests/ai/test_classify.py
@@ -106,3 +106,26 @@ class TestClassify:
                 )
 
             assert router(user_input).value == expected_selection
+
+
+class TestMapping:
+    def test_classify_map(self):
+        result = marvin.classify.map(["This is great!", "This is terrible!"], Sentiment)
+        assert isinstance(result, list)
+        assert result == ["Positive", "Negative"]
+
+    def test_classify_map_with_instructions(self):
+        result = marvin.classify.map(
+            ["This is great!", "This is terrible!"],
+            Sentiment,
+            instructions="Always choose the positive label!",
+        )
+        assert isinstance(result, list)
+        assert result == ["Positive", "Positive"]
+
+    async def test_async_classify_map(self):
+        result = await marvin.classify_async.map(
+            ["This is great!", "This is terrible!"], Sentiment
+        )
+        assert isinstance(result, list)
+        assert result == ["Positive", "Negative"]

--- a/tests/ai/test_extract.py
+++ b/tests/ai/test_extract.py
@@ -92,3 +92,28 @@ class TestExtract:
         async def test_extract_numbers(self):
             result = await marvin.extract_async("one, two, three", int)
             assert result == [1, 2, 3]
+
+
+class TestMapping:
+    def test_map(self):
+        result = marvin.extract.map(
+            ["I have one donut", "I bought two donuts and ate one"], int
+        )
+        assert isinstance(result, list)
+        assert result == [[1], [2, 1]]
+
+    def test_map_with_instructions(self):
+        result = marvin.extract.map(
+            ["I have one donut", "I bought two donuts and ate one"],
+            int,
+            instructions="ignore the number two",
+        )
+        assert isinstance(result, list)
+        assert result == [[1], [1]]
+
+    async def test_async_map(self):
+        result = await marvin.extract_async.map(
+            ["I have one donut", "I bought two donuts and ate one"], int
+        )
+        assert isinstance(result, list)
+        assert result == [[1], [2, 1]]


### PR DESCRIPTION
This exposes a `map` utility as an attribute of the major Marvin functions cast, extract, and classify.

Mapping is performed by calling each function's "map" attribute, e.g. `marvin.cast.map()`

```python
inputs = [
    "I drove from New York to California.",
    "I took a flight from NYC to BOS."
]
outputs = marvin.extract.map(inputs, target=str, instructions="2-letter state codes")
assert outputs  == [
	["NY", "CA"], 
	["NY", "MA"]
]
```