### PR TITLE
Update classify prompt to avoid label bug with integers

### DIFF
--- a/src/marvin/ai/prompts/text_prompts.py
+++ b/src/marvin/ai/prompts/text_prompts.py
@@ -158,9 +158,9 @@ CLASSIFY_PROMPT = inspect.cleandoc(
     
     ## Labels
     
-    You must classify the data as one of the following labels:
+    You must classify the data as one of the following labels, which are numbered (starting from 0) and provide a brief description. Output the label number only.
     {% for label in labels %}
-    - Label {{ loop.index0 }} (value: {{ label }})
+    - Label #{{ loop.index0 }}: {{ label }}
     {% endfor %}
     
     

--- a/tests/ai/test_classify.py
+++ b/tests/ai/test_classify.py
@@ -48,6 +48,12 @@ class TestClassify:
             )
             assert result == "bug"
 
+        def test_classify_number(self):
+            # a version of the prompt would choose the label *number* that
+            # matched the data, rather than the label *description*
+            result = marvin.classify(0, ["letter", "number"])
+            assert result == "number"
+
     class TestBool:
         def test_classify_positive_sentiment(self):
             result = marvin.classify("This is a great feature!", bool)


### PR DESCRIPTION
If the data to classify was the number 0, the classifier was selecting the label with the "0" index instead of the correct description. This updates the prompt for clarity.