### PR TITLE
bug: azure settings no longer respected due to `pydantic-settings==2.2.0`

### DIFF
--- a/src/marvin/utilities/openai.py
+++ b/src/marvin/utilities/openai.py
@@ -63,13 +63,9 @@ def get_openai_client(
 
     # --- Azure OpenAI
     elif marvin.settings.provider == "azure_openai":
-        api_key = getattr(marvin.settings.openai, "marvin_azure_openai_api_key", None)
-        api_version = getattr(
-            marvin.settings.openai, "marvin_azure_openai_api_version", None
-        )
-        azure_endpoint = getattr(
-            marvin.settings.openai, "marvin_azure_openai_endpoint", None
-        )
+        api_key = getattr(marvin.settings, "marvin_azure_openai_api_key", None)
+        api_version = getattr(marvin.settings, "marvin_azure_openai_api_version", None)
+        azure_endpoint = getattr(marvin.settings, "marvin_azure_openai_endpoint", None)
 
         if any(k is None for k in [api_key, api_version, azure_endpoint]):
             raise ValueError(

--- a/src/marvin/utilities/openai.py
+++ b/src/marvin/utilities/openai.py
@@ -63,9 +63,9 @@ def get_openai_client(
 
     # --- Azure OpenAI
     elif marvin.settings.provider == "azure_openai":
-        api_key = getattr(marvin.settings, "azure_openai_api_key", None)
-        api_version = getattr(marvin.settings, "azure_openai_api_version", None)
-        azure_endpoint = getattr(marvin.settings, "azure_openai_endpoint", None)
+        api_key = getattr(marvin.settings.openai, "marvin_azure_openai_api_key", None)
+        api_version = getattr(marvin.settings.openai, "marvin_azure_openai_api_version", None)
+        azure_endpoint = getattr(marvin.settings.openai, "marvin_azure_openai_endpoint", None)
 
         if any(k is None for k in [api_key, api_version, azure_endpoint]):
             raise ValueError(

--- a/src/marvin/utilities/openai.py
+++ b/src/marvin/utilities/openai.py
@@ -64,8 +64,12 @@ def get_openai_client(
     # --- Azure OpenAI
     elif marvin.settings.provider == "azure_openai":
         api_key = getattr(marvin.settings.openai, "marvin_azure_openai_api_key", None)
-        api_version = getattr(marvin.settings.openai, "marvin_azure_openai_api_version", None)
-        azure_endpoint = getattr(marvin.settings.openai, "marvin_azure_openai_endpoint", None)
+        api_version = getattr(
+            marvin.settings.openai, "marvin_azure_openai_api_version", None
+        )
+        azure_endpoint = getattr(
+            marvin.settings.openai, "marvin_azure_openai_endpoint", None
+        )
 
         if any(k is None for k in [api_key, api_version, azure_endpoint]):
             raise ValueError(


### PR DESCRIPTION
I am beyond confused and would appreciate any insights here. This bug shows up in one project I have, but not another, on the same computer. Others using Marivn have had a similar experience, where it works just fine in one environment but fails in another. I'm not sure what is going on.

I managed to fix it by inspecting the `marvin.settings` object and changing a few lines in the OpenAI provider, shown in the PR

this code doesn't seem to have changed in the last month. downgrading to older versions of Marvin does not fix this bug in the one project it's present in. I'm testing Marvin 2.1.2 - Marvin 2.1.5. I really can't figure it out
