### PR TITLE
Improve instructions/tool handling on assistant calls

### DIFF
--- a/src/marvin/beta/applications/applications.py
+++ b/src/marvin/beta/applications/applications.py
@@ -3,7 +3,7 @@ import inspect
 from pydantic import Field, field_validator
 
 from marvin.beta.applications.state import State
-from marvin.beta.assistants import Assistant
+from marvin.beta.assistants import Assistant, Thread
 from marvin.beta.assistants.runs import Run
 from marvin.tools.assistants import AssistantTool
 from marvin.types import Tool
@@ -59,7 +59,7 @@ class Application(Assistant):
             return v
         return State(value=v)
 
-    def get_instructions(self) -> str:
+    def get_instructions(self, thread: Thread = None) -> str:
         return JinjaEnvironment.render(APPLICATION_INSTRUCTIONS, self_=self)
 
     def get_tools(self) -> list[AssistantTool]:

--- a/src/marvin/beta/applications/planner.py
+++ b/src/marvin/beta/applications/planner.py
@@ -2,6 +2,7 @@ from typing import Literal, Optional
 
 from pydantic import BaseModel, Field
 
+from marvin.beta.assistants import Thread
 from marvin.tools.assistants import AssistantTool
 from marvin.utilities.jinja import Environment as JinjaEnvironment
 
@@ -48,7 +49,7 @@ class TaskList(BaseModel):
 class AIPlanner(Application):
     plan: State = Field(default_factory=lambda: State(value=TaskList()))
 
-    def get_instructions(self) -> str:
+    def get_instructions(self, thread: Thread = None) -> str:
         instructions = super().get_instructions()
         return JinjaEnvironment.render(
             instructions + "\n\n" + PLANNER_INSTRUCTIONS, self_=self

--- a/src/marvin/beta/assistants/assistants.py
+++ b/src/marvin/beta/assistants/assistants.py
@@ -39,7 +39,7 @@ class Assistant(BaseModel, ExposeSyncMethodsMixin):
         metadata (dict): Additional data about the assistant.
         file_ids (list): List of file IDs associated with the assistant.
         tools (list): List of tools used by the assistant.
-        instructions (list): List of instructions for the assistant.
+        instructions (str): Instructions for the assistant.
     """
 
     id: Optional[str] = None
@@ -78,7 +78,7 @@ class Assistant(BaseModel, ExposeSyncMethodsMixin):
             for tool in self.tools
         ]
 
-    def get_instructions(self) -> str:
+    def get_instructions(self, thread: Thread = None) -> str:
         return self.instructions or ""
 
     @expose_sync_method("say")

--- a/src/marvin/beta/assistants/assistants.py
+++ b/src/marvin/beta/assistants/assistants.py
@@ -26,6 +26,12 @@ logger = get_logger("Assistants")
 NOT_PROVIDED = "__NOT_PROVIDED__"
 
 
+def default_run_handler_class() -> (
+    type[Union[AssistantEventHandler, AsyncAssistantEventHandler]]
+):
+    return PrintHandler
+
+
 class Assistant(BaseModel, ExposeSyncMethodsMixin):
     """
     The Assistant class represents an AI assistant that can be created, deleted,
@@ -95,7 +101,7 @@ class Assistant(BaseModel, ExposeSyncMethodsMixin):
         thread = thread or self.default_thread
 
         if event_handler_class is NOT_PROVIDED:
-            event_handler_class = PrintHandler
+            event_handler_class = default_run_handler_class()
 
         # post the message
         user_message = await thread.add_async(message, file_paths=file_paths)

--- a/src/marvin/beta/assistants/runs.py
+++ b/src/marvin/beta/assistants/runs.py
@@ -43,8 +43,8 @@ class Run(BaseModel, ExposeSyncMethodsMixin):
 
     thread: Thread
     assistant: Assistant
-    event_handler_class: type[
-        Union[AssistantEventHandler, AsyncAssistantEventHandler]
+    event_handler_class: Optional[
+        type[Union[AssistantEventHandler, AsyncAssistantEventHandler]]
     ] = Field(default=None)
     event_handler_kwargs: dict[str, Any] = Field(default={})
     _messages: list[Message] = PrivateAttr({})

--- a/src/marvin/beta/assistants/runs.py
+++ b/src/marvin/beta/assistants/runs.py
@@ -117,16 +117,16 @@ class Run(BaseModel, ExposeSyncMethodsMixin):
         )
         await self.refresh_async()
 
-    def _get_instructions(self) -> str:
+    def _get_instructions(self, thread: Thread = None) -> Optional[str]:
         if self.instructions is None:
-            instructions = self.assistant.get_instructions() or ""
+            instructions = self.assistant.get_instructions(thread=thread) or ""
         else:
             instructions = self.instructions
 
         if self.additional_instructions is not None:
             instructions = "\n\n".join([instructions, self.additional_instructions])
 
-        return instructions
+        return instructions or None
 
     def _get_model(self) -> str:
         if self.model is None:
@@ -145,18 +145,16 @@ class Run(BaseModel, ExposeSyncMethodsMixin):
             tools.extend(self.additional_tools)
         return tools
 
-    def _get_run_kwargs(self, **run_kwargs) -> dict:
-        if "instructions" not in run_kwargs and (
-            self.instructions is not None or self.additional_instructions is not None
-        ):
-            run_kwargs["instructions"] = self._get_instructions()
+    def _get_run_kwargs(self, thread: Thread = None, **run_kwargs) -> dict:
+        if instructions := self._get_instructions(thread=thread):
+            run_kwargs["instructions"] = instructions
 
-        if "tools" not in run_kwargs and (
-            self.tools is not None or self.additional_tools is not None
-        ):
-            run_kwargs["tools"] = self._get_tools()
-        if "model" not in run_kwargs and self.model is not None:
-            run_kwargs["model"] = self._get_model()
+        if tools := self._get_tools():
+            run_kwargs["tools"] = [t.model_dump(mode="json") for t in tools]
+
+        if model := self._get_model():
+            run_kwargs["model"] = model
+
         return run_kwargs
 
     async def get_tool_outputs(self, run: OpenAIRun) -> list[dict[str, str]]:
@@ -194,7 +192,8 @@ class Run(BaseModel, ExposeSyncMethodsMixin):
                 "This run object was provided an ID; can not create a new run."
             )
         client = marvin.utilities.openai.get_openai_client()
-        run_kwargs = self._get_run_kwargs()
+        run_kwargs = self._get_run_kwargs(thread=self.thread)
+
         event_handler_class = self.event_handler_class or AsyncAssistantEventHandler
 
         with self.assistant:

--- a/tests/beta/assistants/test_assistants.py
+++ b/tests/beta/assistants/test_assistants.py
@@ -4,6 +4,7 @@ import marvin
 import openai
 import pytest
 from marvin.beta.assistants import Assistant
+from marvin.tools.assistants import CodeInterpreter
 
 client = openai.AsyncClient(api_key=marvin.settings.openai.api_key.get_secret_value())
 
@@ -21,6 +22,19 @@ def mock_get_client(monkeypatch):
 @pytest.fixture(autouse=True)
 def mock_say(monkeypatch):
     monkeypatch.setattr(client.beta.threads.runs, "create", AsyncMock())
+
+
+class TestTools:
+    def test_code_interpreter(self):
+        ai = Assistant(tools=[CodeInterpreter])
+        run = ai.say(
+            "use the code interpreter to compute a random number between 85 and 95"
+        )
+        assert run.steps[0].step_details.tool_calls[0].type == "code_interpreter"
+        output = int(
+            run.steps[-2].step_details.tool_calls[0].code_interpreter.outputs[0].logs
+        )
+        assert 85 <= output <= 95
 
 
 class TestLifeCycle:

--- a/tests/beta/assistants/test_assistants.py
+++ b/tests/beta/assistants/test_assistants.py
@@ -31,7 +31,7 @@ class TestTools:
             "use the code interpreter to compute a random number between 85 and 95"
         )
         assert run.steps[0].step_details.tool_calls[0].type == "code_interpreter"
-        output = int(
+        output = float(
             run.steps[-2].step_details.tool_calls[0].code_interpreter.outputs[0].logs
         )
         assert 85 <= output <= 95

--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -1,1 +1,2 @@
 from .llms import *
+from .assistants import *

--- a/tests/fixtures/assistants.py
+++ b/tests/fixtures/assistants.py
@@ -1,0 +1,13 @@
+from unittest.mock import Mock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def mock_default_run_handler_class():
+    """Return an empty default handler instead of a print handler to avoid
+    printing assistant output during tests"""
+    mock = Mock()
+    mock.return_value = None
+    with patch("marvin.beta.assistants.assistants.default_run_handler_class", new=mock):
+        yield


### PR DESCRIPTION
This fixes two small bugs that were unlikely to be encountered but present:
- if the code interpreter was passed as a tool to a run (rather than an assistant), the openai API fails to recognize and cast it, resulting in an API error
- assistant instructions were not provided with every message. This matters for `Applications`, where the instructions contain the latest state object (so they need to be constantly refreshed). In practice, this would only be experienced by users that were using manual lifecycle management; with lazy lifecycles, the assistant (and instructions) are created on every call, meaning the bug couldn't impact.