### PR TITLE
Only support async handlers

### DIFF
--- a/docs/docs/interactive/assistants.md
+++ b/docs/docs/interactive/assistants.md
@@ -105,7 +105,7 @@ For more control over the conversation, including posting multiple user messages
 
 #### Event handlers
 
-Marvin uses the OpenAI streaming API to provide real-time updates on the assistant's actions. To customize how these updates are handled, you can provide a custom event handler class to the `event_handler_class` parameter of `Assistant.say`, `Thread.run`, or `Run.run`. This class must inherit from `openai.AssistantEventHandler` or `openai.AsyncAssistantEventHandler`. For more control, you can also provide `event_handler_kwargs` that will be provided to the event handler when it is instantiated.
+Marvin uses the OpenAI streaming API to provide real-time updates on the assistant's actions. To customize how these updates are handled, you can provide a custom event handler class to the `event_handler_class` parameter of `Assistant.say`, `Thread.run`, or `Run.run`. This class must inherit from `openai.AsyncAssistantEventHandler` (so all methods must be async). For more control, you can also provide `event_handler_kwargs` that will be provided to the event handler when it is instantiated.
 
 #### Pretty-printing
 

--- a/src/marvin/beta/assistants/assistants.py
+++ b/src/marvin/beta/assistants/assistants.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 from typing import TYPE_CHECKING, Callable, Optional, Union
 
-from openai import AssistantEventHandler, AsyncAssistantEventHandler
+from openai import AsyncAssistantEventHandler
 from prompt_toolkit import PromptSession
 from prompt_toolkit.auto_suggest import AutoSuggestFromHistory
 from prompt_toolkit.history import FileHistory
@@ -34,9 +34,7 @@ logger = get_logger("Assistants")
 NOT_PROVIDED = "__NOT_PROVIDED__"
 
 
-def default_run_handler_class() -> (
-    type[Union[AssistantEventHandler, AsyncAssistantEventHandler]]
-):
+def default_run_handler_class() -> type[AsyncAssistantEventHandler]:
     return PrintHandler
 
 
@@ -103,9 +101,7 @@ class Assistant(BaseModel, ExposeSyncMethodsMixin):
         message: str,
         file_paths: Optional[list[str]] = None,
         thread: Optional[Thread] = None,
-        event_handler_class: type[
-            Union[AssistantEventHandler, AsyncAssistantEventHandler]
-        ] = NOT_PROVIDED,
+        event_handler_class: type[AsyncAssistantEventHandler] = NOT_PROVIDED,
         **run_kwargs,
     ) -> "Run":
         thread = thread or self.default_thread

--- a/src/marvin/beta/assistants/runs.py
+++ b/src/marvin/beta/assistants/runs.py
@@ -205,7 +205,9 @@ class Run(BaseModel, ExposeSyncMethodsMixin):
                 self.assistant.pre_run_hook()
 
                 for msg in self.messages:
-                    await handler.on_message_done(msg)
+                    msg_handler = handler.on_message_done(msg)
+                    if inspect.iscoroutine(msg_handler):
+                        await msg_handler
 
                 async with client.beta.threads.runs.create_and_stream(
                     thread_id=self.thread.id,
@@ -236,7 +238,9 @@ class Run(BaseModel, ExposeSyncMethodsMixin):
                 self.data = exc.data
 
             except Exception as exc:
-                await handler.on_exception(exc)
+                exc_handler = handler.on_exception(exc)
+                if inspect.iscoroutine(exc_handler):
+                    await exc_handler
                 raise
 
             if self.run.status == "failed":

--- a/src/marvin/beta/assistants/runs.py
+++ b/src/marvin/beta/assistants/runs.py
@@ -191,6 +191,8 @@ class Run(BaseModel, ExposeSyncMethodsMixin):
             raise ValueError(
                 "This run object was provided an ID; can not create a new run."
             )
+        if not self.thread.id:
+            await self.thread.create_async()
         client = marvin.utilities.openai.get_openai_client()
         run_kwargs = self._get_run_kwargs(thread=self.thread)
 


### PR DESCRIPTION
The split in the openAI API makes it difficult to support both async and sync event handlers at this time without a number of forking paths. It's simpler to just support async event handlers. 

Note: this is technically a bugfix because today we document that we support sync handlers but they error if you try to use them.