### PR TITLE
pass stuff to pre-run-hook

### DIFF
--- a/src/marvin/beta/assistants/assistants.py
+++ b/src/marvin/beta/assistants/assistants.py
@@ -237,7 +237,7 @@ class Assistant(BaseModel, ExposeSyncMethodsMixin):
             except KeyboardInterrupt:
                 break
 
-    def pre_run_hook(self):
+    def pre_run_hook(self, *args, **kwargs):
         pass
 
     def post_run_hook(self, run: "Run"):

--- a/src/marvin/beta/assistants/runs.py
+++ b/src/marvin/beta/assistants/runs.py
@@ -200,7 +200,9 @@ class Run(BaseModel, ExposeSyncMethodsMixin):
             handler = event_handler_class(**self.event_handler_kwargs)
 
             try:
-                self.assistant.pre_run_hook()
+                self.assistant.pre_run_hook(
+                    assistant=self.assistant, run=self, run_kwargs=run_kwargs
+                )
 
                 for msg in self.messages:
                     await handler.on_message_done(msg)


### PR DESCRIPTION
```python
In [1]: from marvin.beta.assistants import Assistant


In [2]:

In [2]: class MyAssistant(Assistant):
   ...:     def pre_run_hook(self, assistant, run, run_kwargs):
   ...:         print(assistant.instructions)
   ...:         print(getattr(assistant, "state", None)) # none for normal assistant
   ...:         print(run_kwargs)
   ...:

In [3]: def add(a: int, b: int) -> int:
   ...:     return a + b
   ...:

In [4]: with MyAssistant(name="mathbot", tools=[add], instructions="add numbers") as ai:
   ...:     ai.say("whats a million + 2312341324?")
   ...:
add numbers
None
{'instructions': 'add numbers', 'tools': [{'type': 'function', 'function': {'name': 'add', 'description': None, 'parameters': {'additionalProperties': False, 'properties': {'a': {'title':
'A', 'type': 'integer'}, 'b': {'title': 'B', 'type': 'integer'}}, 'required': ['a', 'b'], 'type': 'object'}}}], 'model': 'gpt-4-1106-preview'}
```