### PR TITLE
Improve EndRun handling

### DIFF
--- a/docs/docs/interactive/assistants.md
+++ b/docs/docs/interactive/assistants.md
@@ -228,6 +228,41 @@ Marvin makes it easy to give your assistants custom tools. To do so, pass one or
     !!! success "Result"
         ![](/assets/images/docs/assistants/custom_tools.png)
 
+#### Ending a run early
+
+Normally, the assistant will continue to run until it decides to stop, which usually happens after generating a response. Sometimes it may be useful to end a run early, for example if the assistant uses a tool that indicates the conversation is over. To do this, you can raise an `EndRun` exception from within a tool. This will cause the assistant to cancel the current run and return control. EndRun exceptions can contain data.
+
+There are three ways to raise an `EndRun` exception:
+
+1. Raise the exception directly from the tool function:
+```python
+from marvin.beta.assistants import Assistant, EndRun
+
+def my_tool():
+    raise EndRun(data="The final result")
+
+ai = Assistant(tools=[my_tool])
+```
+1. Return the exception from the tool function. This is useful if e.g. your tools are wrapped in custom exception handlers:
+```python
+from marvin.beta.assistants import Assistant, EndRun
+
+def my_tool():
+    return EndRun(data="The final result")
+
+ai = Assistant(tools=[my_tool])
+```
+1. Return a special string value from the tool function. This is useful if you don't have full control over the tool itself, or need to ensure the tool output is JSON-compatible. Note that this approach does not allow you to attach any data to the exception:
+```python
+from marvin.beta.assistants import Assistant, ENDRUN_TOKEN
+
+def my_tool():
+    return ENDRUN_TOKEN
+
+ai = Assistant(tools=[my_tool])
+```
+
+
 ### Lifecycle management
 
 Assistants are Marvin objects that correspond to remote objects in the OpenAI API. You can not communicate with an assistant unless it has been registered with the API. 
@@ -387,7 +422,7 @@ This will return a `Run` object that represents the OpenAI run. You can use this
     When threads are `run` with an assistant, the same lifecycle management rules apply as when you use the assistant's `say` method. In the above example, lazy lifecycle management is used for conveneince. See [lifecycle management](#lifecycle-management) for more information.
 
 !!! warning "Threads are locked while running"
-    When an assistant is running a thread, the thread is locked and no other messages can be added to it. This applies to both user and assistant messages.
+    When an assistant is running a thread, the thread is locked and no other messages can be added to it. This applies to both user and assistant messages. To end a run early, you must [use a custom tool](#ending-a-run-early).
 
 ### Reading messages
 

--- a/src/marvin/beta/ai_flow/ai_task.py
+++ b/src/marvin/beta/ai_flow/ai_task.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel, Field
 from typing_extensions import ParamSpec
 
 from marvin.beta.assistants import Assistant, Run, Thread
-from marvin.beta.assistants.runs import CancelRun
+from marvin.beta.assistants.runs import EndRun
 from marvin.tools.assistants import AssistantTool
 from marvin.utilities.context import ScopedContext
 from marvin.utilities.jinja import Environment as JinjaEnvironment
@@ -238,7 +238,7 @@ class AITask(BaseModel, Generic[P, T]):
 
             def task_completed():
                 self.status = Status.COMPLETED
-                raise CancelRun()
+                raise EndRun()
 
             return task_completed
 
@@ -249,7 +249,7 @@ class AITask(BaseModel, Generic[P, T]):
         def task_completed_with_result(result: T):
             self.status = Status.COMPLETED
             self.result = result
-            raise CancelRun()
+            raise EndRun()
 
         tool.function._python_fn = task_completed_with_result
 
@@ -261,7 +261,7 @@ class AITask(BaseModel, Generic[P, T]):
             """Indicate that the task failed for the provided `reason`."""
             self.status = Status.FAILED
             self.result = reason
-            raise CancelRun()
+            raise EndRun()
 
         return tool_from_function(task_failed)
 

--- a/src/marvin/beta/assistants/__init__.py
+++ b/src/marvin/beta/assistants/__init__.py
@@ -1,4 +1,4 @@
-from .runs import Run
+from .runs import Run, EndRun, ENDRUN_TOKEN
 from .threads import Thread
 from .assistants import Assistant
 from .handlers import PrintHandler

--- a/src/marvin/beta/assistants/runs.py
+++ b/src/marvin/beta/assistants/runs.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel, Field, PrivateAttr, field_validator
 
 import marvin.utilities.openai
 import marvin.utilities.tools
-from marvin.tools.assistants import AssistantTool, EndRun
+from marvin.tools.assistants import ENDRUN_TOKEN, AssistantTool, EndRun
 from marvin.types import Tool
 from marvin.utilities.asyncio import ExposeSyncMethodsMixin, expose_sync_method
 from marvin.utilities.logging import get_logger
@@ -156,9 +156,7 @@ class Run(BaseModel, ExposeSyncMethodsMixin):
 
         return run_kwargs
 
-    async def get_tool_outputs(
-        self, run: OpenAIRun, as_strings: bool = True
-    ) -> list[dict[str, str]]:
+    async def get_tool_outputs(self, run: OpenAIRun) -> list[Any]:
         if run.status != "requires_action":
             return None, None
         if run.required_action.type == "submit_tool_outputs":
@@ -172,8 +170,13 @@ class Run(BaseModel, ExposeSyncMethodsMixin):
                         tools=tools,
                         function_name=tool_call.function.name,
                         function_arguments_json=tool_call.function.arguments,
-                        return_string=True,
                     )
+                    # functions can raise EndRun, return an EndRun, or return the endrun token
+                    # to end the run
+                    if isinstance(output, EndRun):
+                        raise output
+                    elif output == ENDRUN_TOKEN:
+                        raise EndRun()
                 except EndRun as exc:
                     logger.debug(f"Ending run with data: {exc.data}")
                     raise
@@ -184,9 +187,6 @@ class Run(BaseModel, ExposeSyncMethodsMixin):
                     dict(tool_call_id=tool_call.id, output=output or "")
                 )
                 tool_calls.append(tool_call)
-
-            if as_strings:
-                tool_outputs = marvin.utilities.tools.get_string_outputs(tool_outputs)
 
             return tool_outputs
 
@@ -221,16 +221,18 @@ class Run(BaseModel, ExposeSyncMethodsMixin):
                     await self._update_run_from_handler(handler)
 
                 while handler.current_run.status in ["requires_action"]:
-                    tool_outputs = await self.get_tool_outputs(
-                        run=handler.current_run, as_strings=True
-                    )
+                    tool_outputs = await self.get_tool_outputs(run=handler.current_run)
+
+                    string_outputs = [
+                        marvin.utilities.tools.output_to_string(o) for o in tool_outputs
+                    ]
 
                     handler = event_handler_class(**self.event_handler_kwargs)
 
                     async with client.beta.threads.runs.submit_tool_outputs_stream(
                         thread_id=self.thread.id,
                         run_id=self.run.id,
-                        tool_outputs=tool_outputs,
+                        tool_outputs=string_outputs,
                         event_handler=handler,
                     ) as stream:
                         await stream.until_done()

--- a/src/marvin/beta/assistants/runs.py
+++ b/src/marvin/beta/assistants/runs.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel, Field, PrivateAttr, field_validator
 
 import marvin.utilities.openai
 import marvin.utilities.tools
-from marvin.tools.assistants import AssistantTool, CancelRun
+from marvin.tools.assistants import AssistantTool, EndRun
 from marvin.types import Tool
 from marvin.utilities.asyncio import ExposeSyncMethodsMixin, expose_sync_method
 from marvin.utilities.logging import get_logger
@@ -172,7 +172,7 @@ class Run(BaseModel, ExposeSyncMethodsMixin):
                         function_arguments_json=tool_call.function.arguments,
                         return_string=True,
                     )
-                except CancelRun as exc:
+                except EndRun as exc:
                     logger.debug(f"Ending run with data: {exc.data}")
                     raise
                 except Exception as exc:
@@ -229,8 +229,8 @@ class Run(BaseModel, ExposeSyncMethodsMixin):
                         await stream.until_done()
                         await self._update_run_from_handler(handler)
 
-            except CancelRun as exc:
-                logger.debug(f"`CancelRun` raised; ending run with data: {exc.data}")
+            except EndRun as exc:
+                logger.debug(f"`EndRun` raised; ending run with data: {exc.data}")
                 await self.cancel_async()
                 self.data = exc.data
 

--- a/src/marvin/tools/assistants.py
+++ b/src/marvin/tools/assistants.py
@@ -7,6 +7,8 @@ CodeInterpreter = CodeInterpreterTool()
 
 AssistantTool = Union[RetrievalTool, CodeInterpreterTool, Tool]
 
+ENDRUN_TOKEN = "<|ENDRUN|>"
+
 
 class EndRun(Exception):
     """

--- a/src/marvin/tools/assistants.py
+++ b/src/marvin/tools/assistants.py
@@ -8,7 +8,7 @@ CodeInterpreter = CodeInterpreterTool()
 AssistantTool = Union[RetrievalTool, CodeInterpreterTool, Tool]
 
 
-class CancelRun(Exception):
+class EndRun(Exception):
     """
     A special exception that can be raised in a tool to end the run immediately.
     """

--- a/src/marvin/utilities/tools.py
+++ b/src/marvin/utilities/tools.py
@@ -180,6 +180,24 @@ def call_function_tool(
     if len(truncated_output) < len(str(output)):
         truncated_output += "..."
     logger.debug_kv(f"{tool.function.name}", f"returned: {truncated_output}", "green")
-    if return_string and not isinstance(output, str):
-        output = json.dumps(output)
     return output
+
+
+def get_string_outputs(tool_outputs: list[Any]) -> list[str]:
+    """
+    Function outputs must be provided as strings
+    """
+    string_outputs = []
+    for o in tool_outputs:
+        if isinstance(o, None):
+            o = ""
+        elif not isinstance(o, str):
+            if isinstance(o, BaseModel):
+                o = o.model_dump_json()
+            else:
+                try:
+                    o = json.dumps(o)
+                except json.JSONDecodeError:
+                    o = str(o)
+        string_outputs.append(o)
+    return string_outputs

--- a/src/marvin/utilities/tools.py
+++ b/src/marvin/utilities/tools.py
@@ -186,14 +186,11 @@ def output_to_string(output: Any) -> str:
     """
     Function outputs must be provided as strings
     """
-    if isinstance(output, None):
+    if output is None:
         output = ""
     elif not isinstance(output, str):
-        if isinstance(output, BaseModel):
-            output = output.model_dump_json()
-        else:
-            try:
-                output = json.dumps(output)
-            except json.JSONDecodeError:
-                output = str(output)
+        try:
+            output = TypeAdapter(type(output)).dump_json(output)
+        except Exception:
+            output = str(output)
     return output

--- a/src/marvin/utilities/tools.py
+++ b/src/marvin/utilities/tools.py
@@ -145,7 +145,6 @@ def call_function_tool(
     tools: list[FunctionTool],
     function_name: str,
     function_arguments_json: str,
-    return_string: bool = False,
 ) -> str:
     """
     Helper function for calling a function tool from a list of tools, using the arguments
@@ -183,21 +182,18 @@ def call_function_tool(
     return output
 
 
-def get_string_outputs(tool_outputs: list[Any]) -> list[str]:
+def output_to_string(output: Any) -> str:
     """
     Function outputs must be provided as strings
     """
-    string_outputs = []
-    for o in tool_outputs:
-        if isinstance(o, None):
-            o = ""
-        elif not isinstance(o, str):
-            if isinstance(o, BaseModel):
-                o = o.model_dump_json()
-            else:
-                try:
-                    o = json.dumps(o)
-                except json.JSONDecodeError:
-                    o = str(o)
-        string_outputs.append(o)
-    return string_outputs
+    if isinstance(output, None):
+        output = ""
+    elif not isinstance(output, str):
+        if isinstance(output, BaseModel):
+            output = output.model_dump_json()
+        else:
+            try:
+                output = json.dumps(output)
+            except json.JSONDecodeError:
+                output = str(output)
+    return output

--- a/src/marvin/utilities/tools.py
+++ b/src/marvin/utilities/tools.py
@@ -190,7 +190,7 @@ def output_to_string(output: Any) -> str:
         output = ""
     elif not isinstance(output, str):
         try:
-            output = TypeAdapter(type(output)).dump_json(output)
+            output = TypeAdapter(type(output)).dump_json(output).decode()
         except Exception:
             output = str(output)
     return output


### PR DESCRIPTION
It is sometimes useful to end a run early after a tool call is made. Historically this could be done by raising a `CancelRun` error but this was a bit arcane and defeated by any custom exception handling users might put in place (or, say, Prefect). This expands and documents the functionality.

- renames CancelRun → EndRun 
- adds ENDRUN_TOKEN for functions that must return strings
- documents how to end a run early