### PR TITLE
Add support for setting the client

### DIFF
--- a/cookbook/azure/README.md
+++ b/cookbook/azure/README.md
@@ -26,7 +26,7 @@ As an alternative to setting environment variables, you can pass the `AzureOpenA
 
 ```python
 import marvin
-from marvin.client import MarvinClient
+from marvin.client import AsyncMarvinClient
 
 from openai import AzureOpenAI
 
@@ -37,7 +37,7 @@ azure_openai_client = AzureOpenAI(
 )
 
 @marvin.fn(
-    client=MarvinClient(client=azure_openai_client),
+    client=AsyncMarvinClient(client=azure_openai_client),
     model_kwargs={"model": "your_deployment_name"}
 )
 def list_fruits(n: int) -> list[str]:

--- a/docs/docs/images/generation.md
+++ b/docs/docs/images/generation.md
@@ -50,6 +50,7 @@ Marvin can generate images from text.
   </p>
 </div>
 
+
 ## Generating images from functions
 
 In addition to passing prompts directly to the DALLE-3 API via the `paint` function, you can also use the `@image` decorator to generate images from the output of a function. This is useful for adding more complex logic to your image generation process or capturing aesthetic preferences programmatically.
@@ -279,3 +280,13 @@ marvin.utilities.images.base64_to_image(
 ```
 
 To change this behavior globally set `MARVIN_IMAGE_RESPONSE_FORMAT=b64_json` in your environment, or equivalently change `marvin.settings.images.response_format = "b64_json"` in your code.
+
+## Async support
+
+If you are using Marvin in an async environment, you can use `paint_async`:
+  
+```python
+image = await marvin.paint_async(
+    "A cup of coffee, still warm"
+)
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "httpx>=0.24.1",
     "jinja2>=3.1.2",
     "jsonpatch>=1.33",
-    "openai>=1.4.0",
+    "openai>=1.16.0",
     "prompt-toolkit>=3.0.33",
     "pydantic>=2.4.2",
     "pydantic_settings",

--- a/src/marvin/__init__.py
+++ b/src/marvin/__init__.py
@@ -14,7 +14,7 @@ from .ai.text import (
     model,
     Model,
 )
-from .ai.images import paint, image
+from .ai.images import paint, paint_async, image
 from .ai.audio import speak_async, speak, speech, transcribe, transcribe_async
 
 if settings.auto_import_beta_modules:

--- a/src/marvin/ai/text.py
+++ b/src/marvin/ai/text.py
@@ -34,7 +34,11 @@ from marvin.ai.prompts.text_prompts import (
     FUNCTION_PROMPT,
     GENERATE_PROMPT,
 )
-from marvin.client.openai import AsyncMarvinClient, ChatCompletion, MarvinClient
+from marvin.client.openai import (
+    AsyncMarvinClient,
+    ChatCompletion,
+    get_default_async_client,
+)
 from marvin.types import ChatRequest, ChatResponse
 from marvin.utilities.asyncio import run_sync
 from marvin.utilities.context import ctx
@@ -78,7 +82,7 @@ async def generate_llm_response(
     Returns:
         ChatResponse: The generated response from the language model.
     """
-    client = client or AsyncMarvinClient()
+    client = client or get_default_async_client()
     model_kwargs = model_kwargs or {}
     prompt_kwargs = prompt_kwargs or {}
     messages = Transcript(content=prompt_template).render_to_messages(**prompt_kwargs)
@@ -448,7 +452,7 @@ async def generate_async(
 def fn(
     func: Optional[Callable] = None,
     model_kwargs: Optional[dict] = None,
-    client: Optional[MarvinClient] = None,
+    client: Optional[AsyncMarvinClient] = None,
 ) -> Callable:
     """
     Converts a Python function into an AI function using a decorator.
@@ -460,7 +464,7 @@ def fn(
         func (Callable, optional): The function to be converted. Defaults to None.
         model_kwargs (dict, optional): Additional keyword arguments for the
             language model. Defaults to None.
-        client (MarvinClient, optional): The client to use for the AI function.
+        client (AsyncMarvinClient, optional): The client to use for the AI function.
 
     Returns:
         Callable: The converted AI function.
@@ -582,7 +586,7 @@ class Model(BaseModel):
         *,
         instructions: Optional[str] = None,
         model_kwargs: Optional[dict] = None,
-        client: Optional[MarvinClient] = None,
+        client: Optional[AsyncMarvinClient] = None,
         **kwargs,
     ):
         """
@@ -662,7 +666,7 @@ def model(
     type_: Union[Type[M], None] = None,
     instructions: Optional[str] = None,
     model_kwargs: Optional[dict] = None,
-    client: Optional[MarvinClient] = None,
+    client: Optional[AsyncMarvinClient] = None,
 ) -> Union[Type[M], Callable[[Type[M]], Type[M]]]:
     """
     Class decorator for instantiating a Pydantic model from a string.

--- a/src/marvin/beta/assistants/runs.py
+++ b/src/marvin/beta/assistants/runs.py
@@ -206,7 +206,7 @@ class Run(BaseModel, ExposeSyncMethodsMixin):
                 for msg in self.messages:
                     await handler.on_message_done(msg)
 
-                async with client.beta.threads.runs.create_and_stream(
+                async with client.beta.threads.runs.stream(
                     thread_id=self.thread.id,
                     assistant_id=self.assistant.id,
                     event_handler=handler,

--- a/src/marvin/beta/vision.py
+++ b/src/marvin/beta/vision.py
@@ -14,7 +14,7 @@ import marvin
 import marvin.utilities.tools
 from marvin.ai.prompts.vision_prompts import CAPTION_PROMPT
 from marvin.ai.text import EjectRequest
-from marvin.client.openai import AsyncMarvinClient
+from marvin.client.openai import get_default_async_client
 from marvin.types import (
     BaseMessage,
     ChatResponse,
@@ -53,6 +53,7 @@ async def generate_vision_response(
     """
     model_kwargs = model_kwargs or {}
     prompt_kwargs = prompt_kwargs or {}
+    client = get_default_async_client()
     messages = Transcript(content=prompt_template).render_to_messages(**prompt_kwargs)
 
     if images is not None:
@@ -66,7 +67,7 @@ async def generate_vision_response(
     request = VisionRequest(messages=messages, **model_kwargs)
     if marvin.settings.log_verbose:
         logger.debug_kv("Request", request.model_dump_json(indent=2))
-    response = await AsyncMarvinClient().generate_vision(
+    response = await client.generate_vision(
         **request.model_dump(exclude_none=True, exclude_unset=True)
     )
     if marvin.settings.log_verbose:

--- a/src/marvin/client/openai.py
+++ b/src/marvin/client/openai.py
@@ -361,3 +361,13 @@ class AsyncMarvinClient(pydantic.BaseModel):
                 file=file, **validated_kwargs
             )
         return response
+
+
+def get_default_client(**client_kwargs) -> MarvinClient:
+    client_cls = marvin.settings.default_client or MarvinClient
+    return client_cls(**client_kwargs)
+
+
+def get_default_async_client(**client_kwargs) -> AsyncMarvinClient:
+    client_cls = marvin.settings.default_async_client or AsyncMarvinClient
+    return client_cls(**client_kwargs)

--- a/src/marvin/client/openai.py
+++ b/src/marvin/client/openai.py
@@ -364,10 +364,10 @@ class AsyncMarvinClient(pydantic.BaseModel):
 
 
 def get_default_client(**client_kwargs) -> MarvinClient:
-    client_cls = marvin.settings.default_client or MarvinClient
+    client_cls = marvin.settings.default_client_cls or MarvinClient
     return client_cls(**client_kwargs)
 
 
 def get_default_async_client(**client_kwargs) -> AsyncMarvinClient:
-    client_cls = marvin.settings.default_async_client or AsyncMarvinClient
+    client_cls = marvin.settings.default_async_client_cls or AsyncMarvinClient
     return client_cls(**client_kwargs)

--- a/src/marvin/settings.py
+++ b/src/marvin/settings.py
@@ -263,10 +263,10 @@ class Settings(MarvinSettings):
     )
     openai: OpenAISettings = Field(default_factory=OpenAISettings)
 
-    default_client: ImportString = Field(
+    default_client_cls: ImportString = Field(
         None, description="The qualified import path of the default client to use."
     )
-    default_async_client: ImportString = Field(
+    default_async_client_cls: ImportString = Field(
         None,
         description="The qualified import path of the default async client to use.",
     )

--- a/src/marvin/settings.py
+++ b/src/marvin/settings.py
@@ -5,7 +5,7 @@ from contextlib import contextmanager
 from copy import deepcopy
 from typing import Any, Callable, Literal, Optional, Union
 
-from pydantic import Field, SecretStr, field_validator
+from pydantic import Field, ImportString, SecretStr, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -262,6 +262,14 @@ class Settings(MarvinSettings):
         ),
     )
     openai: OpenAISettings = Field(default_factory=OpenAISettings)
+
+    default_client: ImportString = Field(
+        None, description="The qualified import path of the default client to use."
+    )
+    default_async_client: ImportString = Field(
+        None,
+        description="The qualified import path of the default async client to use.",
+    )
 
     # ai settings
     ai: AISettings = Field(default_factory=AISettings)

--- a/tests/client/test_openai.py
+++ b/tests/client/test_openai.py
@@ -1,4 +1,7 @@
+import marvin
+import pytest
 from marvin.client.openai import AsyncMarvinClient, MarvinClient
+from marvin.settings import temporary_settings
 from marvin.types import BaseMessage, StreamingChatResponse
 from openai.types.chat import ChatCompletion
 
@@ -73,3 +76,22 @@ class TestStreamingAsync:
         )
         assert isinstance(response, ChatCompletion)
         assert len(buffer) == 0
+
+
+class TempTestClient(AsyncMarvinClient):
+    def generate_chat(self, *args, **kwargs):
+        raise NotImplementedError()
+
+
+class TestChangeClient:
+    def test_change_client_class(self):
+        with temporary_settings(default_async_client=TempTestClient):
+            with pytest.raises(NotImplementedError):
+                marvin.classify("book", ["thing you read", "thing you sing"])
+
+    def test_change_client_path(self):
+        with temporary_settings(
+            default_async_client="tests.client.test_openai.TempTestClient"
+        ):
+            with pytest.raises(NotImplementedError):
+                marvin.classify("book", ["thing you read", "thing you sing"])

--- a/tests/client/test_openai.py
+++ b/tests/client/test_openai.py
@@ -85,13 +85,13 @@ class TempTestClient(AsyncMarvinClient):
 
 class TestChangeClient:
     def test_change_client_class(self):
-        with temporary_settings(default_async_client=TempTestClient):
+        with temporary_settings(default_async_client_cls=TempTestClient):
             with pytest.raises(NotImplementedError):
                 marvin.classify("book", ["thing you read", "thing you sing"])
 
     def test_change_client_path(self):
         with temporary_settings(
-            default_async_client="tests.client.test_openai.TempTestClient"
+            default_async_client_cls="tests.client.test_openai.TempTestClient"
         ):
             with pytest.raises(NotImplementedError):
                 marvin.classify("book", ["thing you read", "thing you sing"])


### PR DESCRIPTION
Allows the marvin client to be configured globally in settings

Also bumps openai version to 1.16, it was lower bound at 1.4 which doesn't actually include assistants streaming (intro'd in 1.14)