### PR TITLE
Add support for classifying objects and returning indices

### DIFF
--- a/docs/docs/text/classification.md
+++ b/docs/docs/text/classification.md
@@ -9,15 +9,14 @@ Marvin has a powerful classification tool that can be used to categorize text in
   </p>
 </div>
 
-
 !!! example "Example: categorize user feedback"
-    Categorize user feedback into labels such as "bug", "feature request", or "inquiry":
-    
+Categorize user feedback into labels such as "bug", "feature request", or "inquiry":
+
     ```python
     import marvin
 
     category = marvin.classify(
-        "The app crashes when I try to upload a file.", 
+        "The app crashes when I try to upload a file.",
         labels=["bug", "feature request", "inquiry"]
     )
     ```
@@ -28,7 +27,6 @@ Marvin has a powerful classification tool that can be used to categorize text in
         assert category == "bug"
         ```
 
-
 <div class="admonition info">
   <p class="admonition-title">How it works</p>
   <p>
@@ -36,22 +34,21 @@ Marvin has a powerful classification tool that can be used to categorize text in
   </p>
 </div>
 
-
 ## Providing labels
 
 Marvin's classification tool is designed to accommodate a variety of label formats, each suited to different use cases.
 
 ### Lists
 
-When quick, ad-hoc categorization is required, a simple list of strings is the most straightforward approach. For example:
+When quick, ad-hoc categorization is required, a simple list of values is the most straightforward approach. The result of the classifier is the matching label from the list. Marvin will attempt to convert your labels to strings if they are not already strings. If you are trying to classify complex objects that have unusual or no simple string representation, consider manually creating labels and [classifying by index](#returning-indices).
 
 !!! example "Example: sentiment analysis"
-    
+
     ```python
     import marvin
 
     sentiment = marvin.classify(
-        "Marvin is so easy to use!", 
+        "Marvin is so easy to use!",
         labels=["positive", "negative", "meh"]
     )
     ```
@@ -60,7 +57,6 @@ When quick, ad-hoc categorization is required, a simple list of strings is the m
         ```python
         assert sentiment == "positive"
         ```
-
 
 ### Enums
 
@@ -107,6 +103,18 @@ request = marvin.classify("Reset my password", RequestType)
 assert request == "account issue"
 ```
 
+## Returning indices
+
+In some cases, you may want to return the index of the selected label rather than the label itself:
+
+```python
+result = marvin.classify(
+    "Reset my password",
+    ["support request", "account issue", "general inquiry"],
+    return_index=True,
+)
+assert result == 1
+```
 
 ## Providing instructions
 
@@ -160,7 +168,6 @@ assert predicted_sentiment == "Positive"
 
 While the primary focus is on the `classify` function, Marvin also includes the `classifier` decorator. Applied to Enums, it enables them to be used as classifiers that can be instantiated with natural language. This interface is particularly handy when dealing with a fixed set of labels commonly reused in your application.
 
-
 ```python
 @marvin.classifier
 class IssueType(Enum):
@@ -175,6 +182,7 @@ assert issue == IssueType.BUG
 While convenient for certain scenarios, it's recommended to use the `classify` function for its greater flexibility and broader application range.
 
 ## Model parameters
+
 You can pass parameters to the underlying API via the `model_kwargs` argument of `classify` or `@classifier`. These parameters are passed directly to the API, so you can use any supported parameter.
 
 ## Best practices
@@ -190,9 +198,9 @@ If you are using Marvin in an async environment, you can use `classify_async`:
 
 ```python
 result = await marvin.classify_async(
-    "The app crashes when I try to upload a file.", 
+    "The app crashes when I try to upload a file.",
     labels=["bug", "feature request", "inquiry"]
-) 
+)
 
 assert result == "bug"
 ```

--- a/docs/docs/text/classification.md
+++ b/docs/docs/text/classification.md
@@ -40,7 +40,7 @@ Marvin's classification tool is designed to accommodate a variety of label forma
 
 ### Lists
 
-When quick, ad-hoc categorization is required, a simple list of values is the most straightforward approach. The result of the classifier is the matching label from the list. Marvin will attempt to convert your labels to strings if they are not already strings. If you are trying to classify complex objects that have unusual or no simple string representation, consider manually creating labels and [classifying by index](#returning-indices).
+When quick, ad-hoc categorization is required, a simple list of values is the most straightforward approach. The result of the classifier is the matching label from the list. Marvin will attempt to convert your labels to strings if they are not already strings in order to provide them to the LLM, though the original (potentially non-string) labels will be returned as your result.
 
 !!! example "Example: sentiment analysis"
 
@@ -57,6 +57,26 @@ When quick, ad-hoc categorization is required, a simple list of values is the mo
         ```python
         assert sentiment == "positive"
         ```
+
+#### Lists of objects
+
+Marvin's classification tool can also handle lists of objects, in which case it will return the object that best matches the input. For example, here we use a text prompt to select a single person from a list of people:
+
+```python
+import marvin
+from pydantic import BaseModel
+
+class Person(BaseModel):
+    name: str
+    age: int
+
+alice = Person(name="Alice", age=45)
+bob = Person(name="Bob", age=16)
+
+result = marvin.classify('who is a teenager?', [alice, bob])
+assert result is bob
+```
+
 
 ### Enums
 
@@ -97,10 +117,11 @@ In scenarios where labels are part of the function signatures or need to be infe
 from typing import Literal
 import marvin
 
-RequestType = Literal["support request", "account issue", "general inquiry"]
+RequestType = Literal["billing issue", "support request", "general inquiry"]
+
 
 request = marvin.classify("Reset my password", RequestType)
-assert request == "account issue"
+assert request == "support request"
 ```
 
 ## Returning indices
@@ -110,7 +131,7 @@ In some cases, you may want to return the index of the selected label rather tha
 ```python
 result = marvin.classify(
     "Reset my password",
-    ["support request", "account issue", "general inquiry"],
+    ["billing issue", "support request", "general inquiry"],
     return_index=True,
 )
 assert result == 1

--- a/src/marvin/_mappings/types.py
+++ b/src/marvin/_mappings/types.py
@@ -92,7 +92,10 @@ def cast_type_to_labels(type_: Union[type, GenericAlias]) -> list[str]:
         return member_values
     elif isinstance(type_, list):
         # typeadapter handles all types known to Pydantic
-        return [TypeAdapter(type(t)).dump_json(t).decode() for t in type_]
+        try:
+            return [TypeAdapter(type(t)).dump_json(t).decode() for t in type_]
+        except Exception as exc:
+            raise ValueError(f"Unable to cast type to labels: {exc}")
     elif type_ is bool:
         return ["false", "true"], [False, True]
     else:

--- a/src/marvin/ai/text.py
+++ b/src/marvin/ai/text.py
@@ -267,6 +267,9 @@ async def cast_async(
     """
     model_kwargs = model_kwargs or {}
 
+    if not isinstance(data, str):
+        data = marvin.utilities.tools.output_to_string(data)
+
     if target is None and instructions is None:
         raise ValueError("Must provide either a target type or instructions.")
     elif target is None:
@@ -327,11 +330,16 @@ async def extract_async(
     Returns:
         list: A list of extracted entities of the specified type.
     """
+    model_kwargs = model_kwargs or {}
+
     if target is None and instructions is None:
         raise ValueError("Must provide either a target type or instructions.")
     elif target is None:
         target = str
-    model_kwargs = model_kwargs or {}
+
+    if not isinstance(data, str):
+        data = marvin.utilities.tools.output_to_string(data)
+
     return await _generate_typed_llm_response_with_tool(
         prompt_template=EXTRACT_PROMPT,
         prompt_kwargs=dict(data=data, instructions=instructions),
@@ -372,6 +380,9 @@ async def classify_async(
     """
 
     model_kwargs = model_kwargs or {}
+    if not isinstance(data, str):
+        data = marvin.utilities.tools.output_to_string(data)
+
     return await _generate_typed_llm_response_with_logit_bias(
         prompt_template=CLASSIFY_PROMPT,
         prompt_kwargs=dict(data=data, labels=labels, instructions=instructions),

--- a/src/marvin/ai/text.py
+++ b/src/marvin/ai/text.py
@@ -26,6 +26,7 @@ import marvin.utilities.tools
 from marvin._mappings.types import (
     cast_labels_to_grammar,
     cast_type_to_labels,
+    cast_type_to_list,
 )
 from marvin.ai.prompts.text_prompts import (
     CAST_PROMPT,
@@ -210,6 +211,7 @@ async def _generate_typed_llm_response_with_logit_bias(
     if "labels" not in prompt_kwargs:
         raise ValueError("Labels must be provided as a kwarg to the prompt template.")
     labels = prompt_kwargs["labels"]
+    label_list = cast_type_to_list(labels)
     label_strings = cast_type_to_labels(labels)
     grammar = cast_labels_to_grammar(
         labels=label_strings, encoder=encoder, max_tokens=max_tokens
@@ -231,8 +233,7 @@ async def _generate_typed_llm_response_with_logit_bias(
     if labels is bool:
         return bool(label_index)
 
-    result = label_strings[label_index]
-    return labels(result) if isinstance(labels, type) else result
+    return label_list[label_index]
 
 
 async def cast_async(

--- a/src/marvin/beta/vision.py
+++ b/src/marvin/beta/vision.py
@@ -280,9 +280,10 @@ async def classify_async(
     labels: Union[Enum, list[T], type],
     images: Union[Union[str, Path], list[Union[str, Path]]] = None,
     instructions: str = None,
+    return_index: bool = False,
     vision_model_kwargs: dict = None,
     model_kwargs: dict = None,
-) -> T:
+) -> Union[T, int]:
     """
     Classifies provided data and/or images into one of the specified labels.
     Args:
@@ -290,11 +291,12 @@ async def classify_async(
         labels (Union[Enum, list[T], type]): Labels to classify into.
         images (Union[Union[str, Path], list[Union[str, Path]]], optional): Additional images for classification.
         instructions (str, optional): Instructions for the classification.
+        return_index (bool, optional): Whether to return the index of the label instead of the label itself.
         vision_model_kwargs (dict, optional): Arguments for the vision model.
         model_kwargs (dict, optional): Arguments for the language model.
 
     Returns:
-        T: Label that the data/images were classified into.
+        Union[T, int]: Label or index that the data/images were classified into.
     """
 
     async def marvin_call(x):
@@ -302,6 +304,7 @@ async def classify_async(
             data=x,
             labels=labels,
             instructions=instructions,
+            return_index=return_index,
             model_kwargs=model_kwargs,
         )
 
@@ -415,9 +418,10 @@ def classify(
     labels: Union[Enum, list[T], type],
     images: Union[Image, list[Image]] = None,
     instructions: str = None,
+    return_index: bool = False,
     vision_model_kwargs: dict = None,
     model_kwargs: dict = None,
-) -> T:
+) -> Union[T, int]:
     """
     Classifies provided data and/or images into one of the specified labels synchronously.
 
@@ -426,11 +430,12 @@ def classify(
         labels (Union[Enum, list[T], type]): Labels to classify into.
         images (Union[Image, list[Image]], optional): Additional images for classification.
         instructions (str, optional): Instructions for the classification.
+        return_index (bool, optional): Whether to return the index of the label instead of the label itself.
         vision_model_kwargs (dict, optional): Arguments for the vision model.
         model_kwargs (dict, optional): Arguments for the language model.
 
     Returns:
-        T: Label that the data/images were classified into.
+        Union[T, int]: Label or index that the data/images were classified into.
     """
     return run_sync(
         classify_async(
@@ -438,6 +443,7 @@ def classify(
             labels=labels,
             images=images,
             instructions=instructions,
+            return_index=return_index,
             vision_model_kwargs=vision_model_kwargs,
             model_kwargs=model_kwargs,
         )
@@ -449,14 +455,16 @@ async def classify_async_map(
     data: list[Union[str, Image]],
     labels: Union[Enum, list[T], type],
     instructions: Optional[str] = None,
+    return_index: bool = False,
     model_kwargs: Optional[dict] = None,
-) -> list[T]:
+) -> list[Union[T, int]]:
     return await map_async(
         fn=classify_async,
         map_kwargs=dict(data=data),
         unmapped_kwargs=dict(
             labels=labels,
             instructions=instructions,
+            return_index=return_index,
             model_kwargs=model_kwargs,
         ),
     )
@@ -466,13 +474,15 @@ def classify_map(
     data: list[Union[str, Image]],
     labels: Union[Enum, list[T], type],
     instructions: Optional[str] = None,
+    return_index: bool = False,
     model_kwargs: Optional[dict] = None,
-) -> list[T]:
+) -> list[Union[T, int]]:
     return run_sync(
         classify_async_map(
             data=data,
             labels=labels,
             instructions=instructions,
+            return_index=return_index,
             model_kwargs=model_kwargs,
         )
     )

--- a/tests/ai/beta/vision/test_classify.py
+++ b/tests/ai/beta/vision/test_classify.py
@@ -95,6 +95,14 @@ class TestAsync:
         assert result == "urban"
 
 
+class TestReturnIndex:
+    def test_return_index(self):
+        result = marvin.beta.classify(
+            "This is a great feature!", ["bad", "good"], return_index=True
+        )
+        assert result == 1
+
+
 class TestMapping:
     def test_map(self):
         ny = marvin.beta.Image(

--- a/tests/ai/test_classify.py
+++ b/tests/ai/test_classify.py
@@ -145,7 +145,7 @@ class TestMapping:
     def test_classify_map(self):
         result = marvin.classify.map(["This is great!", "This is terrible!"], Sentiment)
         assert isinstance(result, list)
-        assert result == ["Negative", "Positive"]
+        assert result == ["Positive", "Negative"]
 
     def test_classify_map_with_instructions(self, gpt_4):
         result = marvin.classify.map(

--- a/tests/ai/test_classify.py
+++ b/tests/ai/test_classify.py
@@ -144,6 +144,17 @@ class TestClassify:
 
             assert router(user_input).value == expected_selection
 
+    class TestConvertInputData:
+        def test_convert_input_data(self):
+            class Name(BaseModel):
+                first: str
+                last: str
+
+            result = marvin.classify(
+                Name(first="Alice", last="Smith"), ["Alice", "Bob"]
+            )
+            assert result == "Alice"
+
 
 class TestMapping:
     def test_classify_map(self):

--- a/tests/ai/test_classify.py
+++ b/tests/ai/test_classify.py
@@ -4,7 +4,7 @@ from typing import Literal
 import marvin
 import pytest
 
-Sentiment = Literal["Positive", "Negative"]
+Sentiment = Literal["Negative", "Positive"]
 
 
 class GitHubIssueTag(Enum):
@@ -82,6 +82,13 @@ class TestClassify:
             result = await marvin.classify_async("This is a great feature!", bool)
             assert result is True
 
+    class TestReturnIndex:
+        def test_return_index(self):
+            result = marvin.classify(
+                "This is a great feature!", ["bad", "good"], return_index=True
+            )
+            assert result == 1
+
     class TestExamples:
         async def test_hogwarts_sorting_hat(self):
             description = "Brave, daring, chivalrous, and sometimes a bit reckless."
@@ -121,7 +128,7 @@ class TestMapping:
     def test_classify_map(self):
         result = marvin.classify.map(["This is great!", "This is terrible!"], Sentiment)
         assert isinstance(result, list)
-        assert result == ["Positive", "Negative"]
+        assert result == ["Negative", "Positive"]
 
     def test_classify_map_with_instructions(self, gpt_4):
         result = marvin.classify.map(
@@ -138,3 +145,9 @@ class TestMapping:
         )
         assert isinstance(result, list)
         assert result == ["Positive", "Negative"]
+
+    def test_classify_return_index(self):
+        result = marvin.classify.map(
+            ["This is great!", "This is terrible!"], Sentiment, return_index=True
+        )
+        assert result == [1, 0]

--- a/tests/ai/test_classify.py
+++ b/tests/ai/test_classify.py
@@ -80,7 +80,11 @@ class TestClassify:
             assert result is True
 
         def test_classify_negative_sentiment(self):
-            result = marvin.classify("This feature is terrible!", bool)
+            result = marvin.classify(
+                "This feature is terrible!",
+                bool,
+                instructions="Is the sentiment positive?",
+            )
             assert result is False
 
         def test_classify_falseish(self):

--- a/tests/ai/test_classify.py
+++ b/tests/ai/test_classify.py
@@ -3,6 +3,7 @@ from typing import Literal
 
 import marvin
 import pytest
+from pydantic import BaseModel
 
 Sentiment = Literal["Negative", "Positive"]
 
@@ -56,6 +57,22 @@ class TestClassify:
             # matched the data, rather than the label *description*
             result = marvin.classify(0, ["letter", "number"])
             assert result == "number"
+
+        def test_classify_object(self):
+            """
+            Test that objects are returned from classify
+            """
+
+            class Person(BaseModel):
+                name: str
+                age: int
+
+            p1 = Person(name="Alice", age=30)
+            p2 = Person(name="Bob", age=25)
+            p3 = Person(name="Charlie", age=35)
+
+            result = marvin.classify("a person in wonderland", [p1, p2, p3])
+            assert result is p1
 
     class TestBool:
         def test_classify_positive_sentiment(self):


### PR DESCRIPTION
```python
result = marvin.classify('book', ['a thing you read', 'a thing you sing'], return_index=True)
assert result == 0
```

Above is a simple example but this is useful when you want to classify objects that aren't already strings. Getting the index makes it easy to match the object to the selected string description

In testing the above, I discovered and fixed (arguably) a bug that cleans up this DX even more. You can now pass objects as labels and get the object back (assuming it can automatically be turned into a string by Pydantic). Previously they would be converted into (bad) string representations, which were returned as the result of the classifier.

```python
class Person(BaseModel):
    name: str
    age: int

p1 = Person(name="Alice", age=30)
p2 = Person(name="Bob", age=25)
p3 = Person(name="Charlie", age=35)

result = marvin.classify("a person in wonderland", [p1, p2, p3])
assert result is p1
```