### PR TITLE
add beta retry decorator for `marvin.fn`

### DIFF
--- a/cookbook/reasking.py
+++ b/cookbook/reasking.py
@@ -1,0 +1,24 @@
+from typing import Annotated
+
+import marvin
+from marvin.beta.retries import retry_on_validation_error
+from pydantic import AfterValidator
+
+
+def verify_random_number(number: int) -> int:
+    if number != 37:
+        raise ValueError("Everyone knows the most random number is 37!")
+    return number
+
+
+RandomNumber = Annotated[int, AfterValidator(verify_random_number)]
+
+
+@retry_on_validation_error  # shows the validation error message in subsequent retries
+@marvin.fn
+def get_random_number() -> RandomNumber:
+    """returns a random number"""
+
+
+if __name__ == "__main__":
+    print(get_random_number())

--- a/cookbook/reasking.py
+++ b/cookbook/reasking.py
@@ -1,7 +1,7 @@
 from typing import Annotated
 
 import marvin
-from marvin.beta.retries import retry_on_validation_error
+from marvin.beta.retries import retry_fn_on_validation_error
 from pydantic import AfterValidator
 
 
@@ -14,7 +14,7 @@ def verify_random_number(number: int) -> int:
 RandomNumber = Annotated[int, AfterValidator(verify_random_number)]
 
 
-@retry_on_validation_error  # shows the validation error message in subsequent retries
+@retry_fn_on_validation_error  # shows the validation error message in subsequent retries
 @marvin.fn
 def get_random_number() -> RandomNumber:
     """returns a random number"""

--- a/src/marvin/beta/retries.py
+++ b/src/marvin/beta/retries.py
@@ -1,0 +1,43 @@
+from functools import wraps
+from typing import Callable
+
+from pydantic import ValidationError
+
+
+def default_exception_handler(exc: Exception) -> str:
+    return str(exc)
+
+
+def retry_on_validation_error(
+    fn=None,
+    max_retries: int = 3,
+    exception_handler: Callable[[Exception], str] = default_exception_handler,
+):
+    """Decorator for `marvin.fn` that retries the function if it raises a `ValidationError`.
+    Optionally, you can provide a custom exception handler to parse the validation error
+    and return a custom message that will be appended to the original docstring.
+    """
+
+    def decorator(fn):
+        @wraps(fn)
+        def wrapper(*args, **kwargs):
+            additional_context = ""
+            original_docstring = fn.__wrapped__.__doc__
+            retries = 0
+            while True:
+                try:
+                    if additional_context:
+                        fn.__wrapped__.__doc__ = f"{original_docstring}\n\nYou've tried this before, but it failed:\n{additional_context}"
+                    return fn(*args, **kwargs)
+                except ValidationError as e:
+                    additional_context += f"\n{exception_handler(e)}"
+                    retries += 1
+                    if retries == max_retries:
+                        raise e
+
+        return wrapper
+
+    if fn is None:
+        return decorator
+    else:
+        return decorator(fn)

--- a/src/marvin/beta/retries.py
+++ b/src/marvin/beta/retries.py
@@ -8,7 +8,7 @@ def default_exception_handler(exc: Exception) -> str:
     return str(exc)
 
 
-def retry_on_validation_error(
+def retry_fn_on_validation_error(
     fn=None,
     max_retries: int = 3,
     exception_handler: Callable[[Exception], str] = default_exception_handler,

--- a/tests/ai/beta/vision/test_cast.py
+++ b/tests/ai/beta/vision/test_cast.py
@@ -106,10 +106,8 @@ class TestMapping:
             Location(city="New York", state="NY"),
             Location(city="New York City", state="NY"),
         )
-        assert result[1] in (
-            Location(city="Washington", state="DC"),
-            Location(city="Washington", state="D.C."),
-        )
+        assert result[1].city == "Washington"
+        assert result[1].state.index("D") < result[1].state.index("C")
 
     @pytest.mark.flaky(reruns=3)
     async def test_async_map(self):


### PR DESCRIPTION
adds a `beta` retry decorator to be used with `marvin.fn` that will include validation errors (as is, by default) in subsequent retries

you may also configure `max_retries` and a handler to parse `ValidationError`s to the additional context that is actually passed back to the LLM


```python
from typing import Annotated

import marvin
from marvin.beta.retries import retry_fn_on_validation_error
from pydantic import AfterValidator


def verify_random_number(number: int) -> int:
    if number != 37:
        raise ValueError("Everyone knows the most random number is 37!")
    return number


RandomNumber = Annotated[int, AfterValidator(verify_random_number)]


@retry_fn_on_validation_error  # shows the validation error message in subsequent retries
@marvin.fn
def get_random_number() -> RandomNumber:
    """returns a random number"""


if __name__ == "__main__":
    print(get_random_number())

```