### PR TITLE
Minor context improvements

### DIFF
--- a/src/marvin/utilities/context.py
+++ b/src/marvin/utilities/context.py
@@ -57,13 +57,16 @@ class ScopedContext:
         finally:
             try:
                 self._context_storage.reset(token)
-            except Exception:
-                # the only way we can reach this line is if the setup and
-                # teardown of this context are run in different frames or
-                # threads (which happens with pytest fixtures!), in which case
-                # the token is considered invalid. This catch serves as a
-                # "manual" reset of the context values
-                self._context_storage.set(current_context_copy)
+            except ValueError as exc:
+                if "was created in a different context" in str(exc).lower():
+                    # the only way we can reach this line is if the setup and
+                    # teardown of this context are run in different frames or
+                    # threads (which happens with pytest fixtures!), in which case
+                    # the token is considered invalid. This catch serves as a
+                    # "manual" reset of the context values
+                    self._context_storage.set(current_context_copy)
+                else:
+                    raise
 
 
 ctx = ScopedContext()

--- a/src/marvin/utilities/context.py
+++ b/src/marvin/utilities/context.py
@@ -26,10 +26,10 @@ class ScopedContext:
         ```
     """
 
-    def __init__(self):
-        """Initializes the ScopedContext with a default empty dictionary."""
+    def __init__(self, initial_value: dict = None):
+        """Initializes the ScopedContext with an initial valuedictionary."""
         self._context_storage = contextvars.ContextVar(
-            "scoped_context_storage", default={}
+            "scoped_context_storage", default=initial_value or {}
         )
 
     def get(self, key: str, default: Any = None) -> Any:


### PR DESCRIPTION
- adds `ctx[var]` item access (with keyerror if not found)
- improves the reset mechanism to use `reset` tokens if possible; certain situations like pytest can break this behavior, so a fallback to the old behavior is implemented as well