### PR TITLE
Format timestamp platform independently for assistant message panels

### DIFF
--- a/src/marvin/beta/assistants/formatting.py
+++ b/src/marvin/beta/assistants/formatting.py
@@ -48,7 +48,8 @@ def download_temp_file(file_id: str):
 
 
 def format_timestamp(timestamp: int) -> str:
-    return datetime.fromtimestamp(timestamp).strftime("%-I:%M:%S %p")
+    """Outputs timestamp as a string in 12 hour format. Hours are left-padded with space instead of zero."""
+    return datetime.datetime.fromtimestamp(timestamp).strftime("%I:%M:%S %p").lstrip('0').rjust(11)
 
 
 def create_panel(content: Any, title: str, timestamp: int, color: str):

--- a/src/marvin/beta/assistants/formatting.py
+++ b/src/marvin/beta/assistants/formatting.py
@@ -49,7 +49,12 @@ def download_temp_file(file_id: str):
 
 def format_timestamp(timestamp: int) -> str:
     """Outputs timestamp as a string in 12 hour format. Hours are left-padded with space instead of zero."""
-    return datetime.datetime.fromtimestamp(timestamp).strftime("%I:%M:%S %p").lstrip('0').rjust(11)
+    return (
+        datetime.datetime.fromtimestamp(timestamp)
+        .strftime("%I:%M:%S %p")
+        .lstrip('0')
+        .rjust(11)
+    )
 
 
 def create_panel(content: Any, title: str, timestamp: int, color: str):

--- a/src/marvin/beta/assistants/formatting.py
+++ b/src/marvin/beta/assistants/formatting.py
@@ -48,7 +48,7 @@ def download_temp_file(file_id: str):
 
 
 def format_timestamp(timestamp: int) -> str:
-    return datetime.fromtimestamp(timestamp).strftime("%l:%M:%S %p")
+    return datetime.fromtimestamp(timestamp).strftime("%I:%M:%S %p")
 
 
 def create_panel(content: Any, title: str, timestamp: int, color: str):

--- a/src/marvin/beta/assistants/formatting.py
+++ b/src/marvin/beta/assistants/formatting.py
@@ -52,7 +52,7 @@ def format_timestamp(timestamp: int) -> str:
     return (
         datetime.datetime.fromtimestamp(timestamp)
         .strftime("%I:%M:%S %p")
-        .lstrip('0')
+        .lstrip("0")
         .rjust(11)
     )
 

--- a/src/marvin/beta/assistants/formatting.py
+++ b/src/marvin/beta/assistants/formatting.py
@@ -48,7 +48,7 @@ def download_temp_file(file_id: str):
 
 
 def format_timestamp(timestamp: int) -> str:
-    return datetime.fromtimestamp(timestamp).strftime("%I:%M:%S %p")
+    return datetime.fromtimestamp(timestamp).strftime("%-I:%M:%S %p")
 
 
 def create_panel(content: Any, title: str, timestamp: int, color: str):


### PR DESCRIPTION
12 hour time format is `%I` (capital i), but `%l` (lowercase l) was incorrectly being used.

This fixes the following error that can occur when using the assistants api:
```
File "marvin\beta\assistants\formatting.py", line 51, in format_timestamp
return datetime.fromtimestamp(timestamp).strftime("%l:%M:%S %p")
ValueError: Invalid format string
```