### PR TITLE
Support `tool_choice` parameter for runs

### DIFF
--- a/src/marvin/beta/assistants/runs.py
+++ b/src/marvin/beta/assistants/runs.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Optional, Union
+from typing import Any, Callable, Literal, Optional, Union
 
 from openai import AsyncAssistantEventHandler
 from openai.types.beta.threads import Message
@@ -34,6 +34,8 @@ class Run(BaseModel, ExposeSyncMethodsMixin):
                                                                for the run.
         additional_tools (list[AssistantTool], optional): Additional tools to append
                                                           to the assistant's tools.
+        tool_choice (Union[Literal["auto", "none", "required"], AssistantTool], optional):
+                                                    The tool use behaviour for the run.
         run (OpenAIRun): The OpenAI run object.
         data (Any): Any additional data associated with the run.
     """
@@ -66,6 +68,12 @@ class Run(BaseModel, ExposeSyncMethodsMixin):
     additional_tools: Optional[list[AssistantTool]] = Field(
         None,
         description="Additional tools to append to the assistant's tools. ",
+    )
+    tool_choice: Optional[
+        Union[Literal["none", "auto", "required"], AssistantTool]
+    ] = Field(
+        default=None,
+        description="The tool use behaviour for the run. Can be 'none', 'auto', 'required', or a specific tool.",
     )
     run: OpenAIRun = Field(None, repr=False)
     data: Any = None
@@ -153,6 +161,13 @@ class Run(BaseModel, ExposeSyncMethodsMixin):
 
         if model := self._get_model():
             run_kwargs["model"] = model
+
+        if tool_choice := self.tool_choice:
+            run_kwargs["tool_choice"] = (
+                tool_choice.model_dump(mode="json")
+                if isinstance(tool_choice, Tool)
+                else tool_choice
+            )
 
         return run_kwargs
 


### PR DESCRIPTION
Closes https://github.com/PrefectHQ/marvin/issues/927

Allows you to specify the `tool_choice` parameter for Runs (see [Open Ai docs](https://platform.openai.com/docs/api-reference/runs/createRun#runs-createrun-tool_choice)). This parameter allows you to force the assistant to use a particular tool.

Example usage, forcing the use of the vector store file search:

```python
from marvin.beta import Assistant, Thread
from marvin.tools.assistants import FileSearch

# new thread
thread = Thread()

# Load some assistant with a vector store attached
ai = Assistant.load(assistant_id="<assistant ID>", tools=[FileSearch],
        tool_resources={
           "file_search": {
               "vector_store_ids": ["<vector store ID>"]
           }
        })

# Run the thread, forcing the use of FileSearch
thread.run(assistant=ai, tool_choice=FileSearch)
```




