### PR TITLE
Reference the correct variable

### DIFF
--- a/src/marvin/audio.py
+++ b/src/marvin/audio.py
@@ -243,7 +243,7 @@ class BackgroundAudioRecorder:
         if wait:
             self._thread.join()
         logger.info("Recording finished.")
-        self._is_recording = False
+        self.is_recording = False
 
 
 class BackgroundAudioStream:


### PR DESCRIPTION
Change `_is_recording` -> `is_recording`.

Since other lines use `is_recording`, when `stop` is called, it cannot `start` again.