### PR TITLE
Allow passing of `response_format` to Assistant constructor

### DIFF
--- a/src/marvin/beta/assistants/assistants.py
+++ b/src/marvin/beta/assistants/assistants.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, Optional, Union
+from typing import TYPE_CHECKING, Any, Callable, Literal, Optional, Union
 
 from openai import AsyncAssistantEventHandler
 from prompt_toolkit import PromptSession
@@ -13,7 +13,7 @@ import marvin.utilities.openai
 import marvin.utilities.tools
 from marvin.beta.assistants.handlers import PrintHandler
 from marvin.tools.assistants import AssistantTool
-from marvin.types import Tool
+from marvin.types import AssistantResponseFormat, Tool
 from marvin.utilities.asyncio import (
     ExposeSyncMethodsMixin,
     expose_sync_method,
@@ -64,6 +64,7 @@ class Assistant(BaseModel, ExposeSyncMethodsMixin):
     tools: list[Union[AssistantTool, Callable]] = []
     tool_resources: dict[str, Any] = {}
     metadata: dict[str, str] = {}
+    response_format: Optional[Union[Literal["auto"], AssistantResponseFormat]] = "auto"
     # context level tracks nested assistant contexts
     _context_level: int = PrivateAttr(0)
 
@@ -173,6 +174,7 @@ class Assistant(BaseModel, ExposeSyncMethodsMixin):
                     "metadata",
                     "tool_resources",
                     "metadata",
+                    "response_format",
                 }
             ),
             tools=[tool.model_dump() for tool in self.get_tools()],

--- a/src/marvin/types.py
+++ b/src/marvin/types.py
@@ -104,6 +104,18 @@ class FunctionCall(MarvinType):
     name: str
 
 
+class AssistantResponseFormat(MarvinType):
+    type: Literal["json_object", "text"]
+
+
+class JsonObjectAssistantResponseFormat(AssistantResponseFormat):
+    type: Literal["json_object"] = "json_object"
+
+
+class TextAssistantResponseFormat(AssistantResponseFormat):
+    type: Literal["text"] = "text"
+
+
 class ImageUrl(MarvinType):
     url: str = Field(
         description="URL of the image to be sent or a base64 encoded image."


### PR DESCRIPTION
Fixes https://github.com/PrefectHQ/marvin/issues/956

As the proposed example usage in that issue, this PR enables this kind of usage:

```python
Assistant(instructions=some_instructions, response_format=JsonObjectAssistantResponseFormat())
```
or this:
```python
Assistant(instructions=some_instructions, response_format=AssistantResponseFormat(type="json_object"))
```

Be sure that your instructions include a careful description of the JSON schema that you expect the LLM to generate. And note that the API means it when it says "json_object". In other words, this doesn't constrain the response to any JSON, it specifically ensures the model will return a single JSON object. So if you, for example, want a JSON array, the array will have to be a property in a wrapper object.

Here's the relevant Open AI endpoint doc: https://platform.openai.com/docs/api-reference/assistants