### PR TITLE
Improve the grammar

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 Marvin is a lightweight AI toolkit for building natural language interfaces that are reliable, scalable, and easy to trust.
 
-Each of Marvin's tools is simple and self-documenting, using AI to solve common but complex challenges like entity extraction, classification, and generating synthetic data. Each tool is independent and incrementally adoptable, so you can use them on their own or in combination with any other library. Marvin is also multi-modal, supporting both image and audio generation as well using images as inputs for extraction and classification.
+Each of Marvin's tools is simple and self-documenting, using AI to solve common but complex challenges like entity extraction, classification, and generating synthetic data. Each tool is independent and incrementally adoptable, so you can use them on their own or in combination with any other library. Marvin is also multi-modal, supporting both image and audio generation as well as using images as inputs for extraction and classification.
 
 Marvin is for developers who care more about _using_ AI than _building_ AI, and we are focused on creating an exceptional developer experience. Marvin users should feel empowered to bring tightly-scoped "AI magic" into any traditional software project with just a few extra lines of code.
 


### PR DESCRIPTION
`as well using images as inputs` => `as well as using images as inputs`

This pull request includes a minor correction to the `README.md` file to fix a grammatical error.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L15-R15): Corrected the phrase "as well using images" to "as well as using images" for better readability.