### PR TITLE
Add planning

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,25 +43,105 @@ We believe working with AI should spark joy (and maybe a few "wow" moments):
 
 - 🧩 **Task-Centric Architecture**: Break complex AI workflows into manageable, observable steps.
 - 🤖 **Specialized Agents**: Deploy task-specific AI agents for efficient problem-solving.
-- 🔒 **Type-Safe Results**: Bridge the gap between AI and traditional software with type-safe, validated outputs
+- 🔒 **Type-Safe Results**: Bridge the gap between AI and traditional software with type-safe, validated outputs.
 - 🎛️ **Flexible Control**: Continuously tune the balance of control and autonomy in your workflows.
 - 🕹️ **Multi-Agent Orchestration**: Coordinate multiple AI agents within a single workflow or task.
-- 🧵 **Thread management**: Manage the agentic loop by composing tasks into customizable threads.
+- 🧵 **Thread Management**: Manage the agentic loop by composing tasks into customizable threads.
 - 🔗 **Ecosystem Integration**: Seamlessly work with your existing code, tools, and the broader AI ecosystem.
-- 🚀 **Developer Speed:** Start simple, scale up, sleep well
+- 🚀 **Developer Speed**: Start simple, scale up, sleep well.
 
+## Core Abstractions
+
+Marvin is built around a few powerful abstractions that make it easy to work with AI:
+
+### Tasks
+
+Tasks are the fundamental unit of work in Marvin. Each task represents a clear objective that can be accomplished by an AI agent:
+
+```python
+# The simplest way to run a task
+result = marvin.run("Write a haiku about coding")
+
+# Create a task with more control
+task = marvin.Task(
+    instructions="Write a haiku about coding",
+    result_type=str,
+    tools=[my_custom_tool]
+)
+```
+
+Tasks are:
+- 🎯 **Objective-Focused**: Each task has clear instructions and a type-safe result
+- 🛠️ **Tool-Enabled**: Tasks can use custom tools to interact with your code and data
+- 📊 **Observable**: Monitor progress, inspect results, and debug failures
+- 🔄 **Composable**: Build complex workflows by connecting tasks together
+
+### Agents and Teams
+
+Agents are portable LLM configurations that can be assigned to tasks. They encapsulate everything an AI needs to work effectively:
+
+```python
+# Create a specialized agent
+writer = marvin.Agent(
+    name="Technical Writer",
+    instructions="Write clear, engaging content for developers"
+)
+
+# Create a team of agents that work together
+team = marvin.Swarm([
+    writer,
+    marvin.Agent("Editor"),
+    marvin.Agent("Fact Checker")
+])
+
+# Use agents with tasks
+result = marvin.run(
+    "Write a blog post about Python type hints",
+    agents=[team]  # or team
+)
+```
+
+Agents are:
+- 📝 **Specialized**: Give agents specific instructions and personalities
+- 🎭 **Portable**: Reuse agent configurations across different tasks
+- 🤝 **Collaborative**: Form teams of agents that work together
+- 🔧 **Customizable**: Configure model, temperature, and other settings
+
+### Planning and Orchestration
+
+Marvin makes it easy to break down complex objectives into manageable tasks:
+
+```python
+# Let Marvin plan a complex workflow
+tasks = marvin.plan("Create a blog post about AI trends")
+marvin.run_tasks(tasks)
+
+# Or orchestrate tasks manually
+with marvin.Thread() as thread:
+    research = marvin.run("Research recent AI developments")
+    outline = marvin.run("Create an outline", context={"research": research})
+    draft = marvin.run("Write the first draft", context={"outline": outline})
+```
+
+Planning features:
+- 📋 **Smart Planning**: Break down complex objectives into discrete, dependent tasks
+- 🔄 **Task Dependencies**: Tasks can depend on each other's outputs
+- 📈 **Progress Tracking**: Monitor the execution of your workflow
+- 🧵 **Thread Management**: Share context and history between tasks
 
 ## Keep it Simple
 
 Marvin includes high-level functions for the most common tasks, like summarizing text, classifying data, extracting structured information, and more.
 
-- 📖 **Summarize**: Get a quick summary of a text
-- 🏷️ **Classify**: Categorize data into predefined classes
-- 🔍 **Extract**: Extract structured information from a text
-- 🪄 **Cast**: Transform data into a different type
-- ✨ **Generate**: Create structured data from a description
-- 💬 **Say**: Converse with an LLM
-- 🦾 **`@fn`**: Write custom AI functions without source code
+- 🚀 **`marvin.run`**: Execute any task with an AI agent
+- 📖 **`marvin.summarize`**: Get a quick summary of a text
+- 🏷️ **`marvin.classify`**: Categorize data into predefined classes
+- 🔍 **`marvin.extract`**: Extract structured information from a text
+- 🪄 **`marvin.cast`**: Transform data into a different type
+- ✨ **`marvin.generate`**: Create structured data from a description
+- 💬 **`marvin.say`**: Converse with an LLM
+- 🧠 **`marvin.plan`**: Break down complex objectives into tasks
+- 🦾 **`@marvin.fn`**: Write custom AI functions without source code
 
 All Marvin functions have thread management built-in, meaning they can be composed into chains of tasks that share context and history.
 
@@ -200,3 +280,5 @@ print(f"# {article.title}\n\n{article.content}")
 >- Used by major companies like Google, Mozilla, and Unity
 >```
 </details>
+
+## Keep it Simple

--- a/docs/concepts/tasks.mdx
+++ b/docs/concepts/tasks.mdx
@@ -255,6 +255,33 @@ task = marvin.Task(
 
 Tasks can be configured with a parent task. Creating hierarchies of tasks can help agents understand the relationships between different tasks and to better understand the task they are working on.
 
+### Task Planning
+
+When a task is created with `plan=True`, the agent is given the ability to break down complex tasks into smaller, more manageable subtasks. This is particularly useful for handling large or complex objectives that benefit from being tackled incrementally.
+
+The agent can create subtasks at any point during task execution, and these subtasks become part of the task hierarchy. Each subtask is treated as a dependency of the parent task, ensuring that all subtasks are completed before the parent task is considered finished.
+
+```python
+import marvin
+
+task = marvin.Task(
+    instructions="Write a comprehensive report about AI",
+    plan=True  # Enable task planning
+)
+```
+
+When planning is enabled, the agent can:
+- Create one or more subtasks at any time
+- Define clear, focused objectives for each subtask
+- Establish dependencies between subtasks
+- Monitor progress through the task hierarchy
+
+This feature is especially valuable for:
+- Breaking down complex tasks into manageable pieces
+- Creating checkpoints in long-running processes
+- Enabling parallel work on independent subtasks
+- Maintaining clear progress tracking
+
 ### Depends on
 
 Tasks can be configured with a list of tasks that they depend on. This information helps Marvin prioritize work and avoid running a task before its upstream dependencies are complete.
@@ -266,6 +293,7 @@ Marvin tasks support several additional options to control their behavior:
 - `allow_fail`: Whether the task is allowed to be marked as failed (default: False)
 - `allow_skip`: Whether the task is allowed to be skipped (default: False)
 - `cli`: Whether to enable CLI interaction tools for the agent (default: False)
+- `plan`: Whether to enable task planning capabilities, allowing the agent to create subtasks to help complete the parent task (default: False)
 
 ## Runtime properties
 

--- a/docs/functions/plan.mdx
+++ b/docs/functions/plan.mdx
@@ -1,0 +1,120 @@
+---
+title: Plan
+description: Break down complex objectives into manageable tasks
+icon: list-check
+---
+
+The `plan` function helps you break down complex objectives into a series of smaller, manageable tasks. 
+It's particularly useful for handling large or complex goals that benefit from being tackled incrementally.
+
+For simple tasks, you can use `marvin.run()` directly. The `plan` function is designed for complex 
+workflows that benefit from being broken down into steps - see [Task Planning](/concepts/tasks#task-planning) 
+for more details.
+
+## Usage
+
+Create a simple task plan:
+
+```python
+import marvin
+
+# Create and execute a series of tasks
+tasks = marvin.plan("Create a new blog post about AI trends")
+marvin.run_tasks(tasks)
+```
+
+## Parameters
+
+- `instructions`: The objective to achieve
+- `agent`: Optional agent to use for planning
+- `thread`: Optional thread for conversation context
+- `context`: Optional dict of additional context
+- `available_agents`: Optional list of agents that can be used for planning
+- `tools`: Optional list of tools that can be used for planning
+- `parent_task`: Optional parent task for the planned tasks
+
+## Returns
+
+Returns a list of `Task` objects that, when completed, will achieve the specified objective.
+
+## Async Support
+
+The function is also available in an async version:
+
+```python
+import marvin
+import asyncio
+
+async def main():
+    tasks = await marvin.plan_async(
+        "Create a new blog post about AI trends"
+    )
+    await marvin.run_tasks_async(tasks)
+
+asyncio.run(main())
+```
+
+## Examples
+
+### Multiple Agents
+
+Assign different tasks to specialized agents:
+
+```python
+import marvin
+
+# Create specialized agents
+researcher = marvin.Agent(name="Researcher", model="openai:gpt-4")
+writer = marvin.Agent(name="Writer", model="openai:gpt-4")
+editor = marvin.Agent(name="Editor", model="openai:gpt-4")
+
+# Plan tasks with multiple agents
+tasks = marvin.plan(
+    "Create a comprehensive research report on quantum computing",
+    available_agents=[researcher, writer, editor]
+)
+marvin.run_tasks(tasks)
+```
+
+### With Context
+
+Provide additional requirements:
+
+```python
+import marvin
+
+# Provide detailed context for planning
+context = {
+    "target_audience": "technical professionals",
+    "word_count": 2000,
+    "key_topics": ["neural networks", "transformers", "reinforcement learning"]
+}
+
+tasks = marvin.plan(
+    "Write a technical blog post about AI advancements",
+    context=context
+)
+marvin.run_tasks(tasks)
+```
+
+### With Tools
+
+Make specific tools available to tasks:
+
+```python
+import marvin
+
+def fetch_papers(topic: str, limit: int = 5) -> list[str]:
+    """Fetch latest research papers on a topic."""
+    pass
+
+def analyze_sentiment(text: str) -> float:
+    """Analyze sentiment of text."""
+    pass
+
+tasks = marvin.plan(
+    "Create a sentiment analysis report for recent AI papers",
+    tools=[fetch_papers, analyze_sentiment]
+)
+marvin.run_tasks(tasks)
+``` 

--- a/src/marvin/__init__.py
+++ b/src/marvin/__init__.py
@@ -29,6 +29,7 @@ from marvin.fns.generate import (
 from marvin.fns.fn import fn
 from marvin.fns.say import say, say_async
 from marvin.fns.summarize import summarize, summarize_async
+from marvin.fns.plan import plan, plan_async
 
 ensure_tables_exist()
 
@@ -53,6 +54,8 @@ __all__ = [
     "generate_schema",
     "generate_schema_async",
     "instructions",
+    "plan",
+    "plan_async",
     "run",
     "run_async",
     "run_tasks",

--- a/src/marvin/agents/agent.py
+++ b/src/marvin/agents/agent.py
@@ -179,6 +179,7 @@ def get_agentlet(
         end_strategy="exhaustive",
         result_tool_name=result_tool_name or "EndTurn",
         result_tool_description="This tool will end your turn. You may only use one EndTurn tool per turn.",
+        retries=marvin.settings.agent_retries,
     )
 
     from marvin.engine.events import (

--- a/src/marvin/agents/team.py
+++ b/src/marvin/agents/team.py
@@ -41,6 +41,19 @@ class Team(Actor):
             raise ValueError("Team must have at least one member")
         self.active_member = self.members[0]
 
+    def __enter__(self):
+        """Set this team and its active member as current in context."""
+        super().__enter__()
+        # Recursively enter context for active member
+        self.active_member.__enter__()
+        return self
+
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any):
+        """Reset the team and active member context."""
+        # Exit active member context first
+        self.active_member.__exit__(exc_type, exc_val, exc_tb)
+        super().__exit__(exc_type, exc_val, exc_tb)
+
     async def start_turn(self, orchestrator: "Orchestrator"):
         await self.active_member.start_turn(orchestrator=orchestrator)
 

--- a/src/marvin/fns/plan.py
+++ b/src/marvin/fns/plan.py
@@ -1,0 +1,228 @@
+from dataclasses import dataclass, field
+from typing import Any, Callable, TypeVar
+
+import marvin
+from marvin.agents.agent import Agent
+from marvin.tasks.task import Task
+from marvin.thread import Thread
+from marvin.utilities.asyncio import run_sync
+
+T = TypeVar("T")
+
+
+@dataclass(kw_only=True)
+class PlanTask:
+    id: int
+    instructions: str
+    name: str | None
+    allow_fail: bool = False
+    allow_skip: bool = False
+    parent_id: int | None = field(
+        default=None,
+        metadata={
+            "description": "ID of the parent task. Parent tasks can not be completed until all of their children are completed."
+        },
+    )
+    depends_on_ids: list[int] | None = field(
+        default=None,
+        metadata={
+            "description": "IDs of tasks that must be completed before this task can be run."
+        },
+    )
+    agent_ids: list[int] | None = field(
+        default=None,
+        metadata={
+            "description": "IDs of agents who will work on this task. Provide None to work on it yourself."
+        },
+    )
+    tool_ids: list[int] | None = field(
+        default=None,
+        metadata={
+            "description": "IDs of tools to make available to this task. Agents will also have their own tools available."
+        },
+    )
+
+
+PROMPT = """
+You are a task planner. You have been given some instructions about your
+objectives and must produce at least one Marvin Task that, when completed, will
+allow you or other AI agents achieve the objective. Each task should represent a
+discrete, observable goal, neither too small to be a nuisance or lead to
+repetivite work, nor too large to be difficult to manage.
+
+These tasks will be executed by AI agents, like you. Create tasks appropriately.
+Do not create tasks like "Validate results" unless a separate validation step is
+actually required or helpful. Do not create tasks that require tools that are
+not available.
+"""
+
+
+def create_tasks(
+    plan: list[PlanTask],
+    agent_map: dict[int, Agent],
+    tool_map: dict[int, Callable[..., Any]],
+) -> list[Task]:
+    # topological sort so we process children before parents and dependencies before dependents
+    sorted_tasks: list[PlanTask] = []
+    visited: set[int] = set()
+    temp_visited: set[int] = set()  # for cycle detection
+    task_map: dict[int, PlanTask] = {task.id: task for task in plan}
+
+    def visit(task_id: int) -> None:
+        if task_id in temp_visited:
+            raise ValueError(
+                f"Cycle detected in task dependencies involving task {task_id}"
+            )
+        if task_id in visited:
+            return
+
+        temp_visited.add(task_id)
+        task = task_map[task_id]
+
+        # Visit parent first if it exists
+        if task.parent_id is not None:
+            if task.parent_id not in task_map:
+                raise ValueError(
+                    f"Parent task {task.parent_id} not found for task {task_id}"
+                )
+            visit(task.parent_id)
+
+        # Visit dependencies
+        if task.depends_on_ids:
+            for dep_id in task.depends_on_ids:
+                if dep_id not in task_map:
+                    raise ValueError(
+                        f"Dependency task {dep_id} not found for task {task_id}"
+                    )
+                visit(dep_id)
+
+        temp_visited.remove(task_id)
+        visited.add(task_id)
+        sorted_tasks.append(task)
+
+    # Visit all tasks
+    for task in plan:
+        if task.id not in visited:
+            visit(task.id)
+
+    # Convert PlanTasks to Tasks in dependency order
+    tasks: dict[int, Task] = {}
+    for plan_task in sorted_tasks:
+        task = Task(
+            name=plan_task.name,
+            instructions=plan_task.instructions,
+            agents=(
+                [agent_map[id] for id in plan_task.agent_ids]
+                if plan_task.agent_ids
+                else None
+            ),
+            result_type=str,
+            tools=(
+                [tool_map[id] for id in plan_task.tool_ids]
+                if plan_task.tool_ids
+                else None
+            ),
+            allow_fail=plan_task.allow_fail,
+            allow_skip=plan_task.allow_skip,
+            parent=(tasks[plan_task.parent_id] if plan_task.parent_id else None),
+            depends_on=(
+                [tasks[id] for id in plan_task.depends_on_ids]
+                if plan_task.depends_on_ids
+                else None
+            ),
+        )
+        tasks.update({plan_task.id: task})
+
+    return list(tasks.values())
+
+
+async def plan_async(
+    instructions: str,
+    agent: Agent | None = None,
+    thread: Thread | str | None = None,
+    context: dict[str, Any] | None = None,
+    available_agents: list[Agent] | None = None,
+    tools: list[Callable[..., Any]] | None = None,
+) -> list[Task]:
+    """
+    Generate a series of new tasks in order to achieve a goal.
+
+    Args:
+        instructions: The objective to achieve.
+        agent: The agent to use for planning.
+        thread: The thread to use for planning.
+        context: Additional context to use for planning.
+        available_agents: A list of agents that can be used for planning.
+        tools: A list of tools that can be used for planning.
+
+    Returns:
+        A list of Marvin Tasks that will allow you or other AI agents to achieve the objective.
+
+    Examples:
+        >>> tasks = await marvin.plan_async("Create a new blog post about the latest AI trends.")
+        >>> await marvin.run_tasks_async(tasks)
+    """
+    agent_map = {i: a for i, a in enumerate(available_agents or [])}
+    tool_map = {i: t for i, t in enumerate(tools or [])}
+
+    task_context = context or {}
+    task_context["Available agents"] = agent_map
+    task_context["Available tools"] = tool_map
+    prompt = (
+        PROMPT
+        + f"\n\n Here is the planning objective:\n<objective>\n{instructions}\n</objective>"
+    )
+
+    task = marvin.Task[list[PlanTask]](
+        name="Planning Task",
+        instructions=prompt,
+        context=task_context,
+        result_type=list[PlanTask],
+        agents=[agent] if agent else None,
+    )
+
+    tasks = await task.run_async(thread=thread, handlers=[])
+    return create_tasks(
+        tasks,
+        agent_map=agent_map | {None: task.get_actor()},
+        tool_map=tool_map,
+    )
+
+
+def plan(
+    instructions: str,
+    agent: Agent | None = None,
+    thread: Thread | str | None = None,
+    context: dict[str, Any] | None = None,
+    available_agents: list[Agent] | None = None,
+    tools: list[Callable[..., Any]] | None = None,
+) -> list[Task]:
+    """
+    Generate a series of Marvin Tasks that will allow you or other AI agents to achieve a goal.
+
+    Args:
+        instructions: The objective to achieve.
+        agent: The agent to use for planning.
+        thread: The thread to use for planning.
+        context: Additional context to use for planning.
+        available_agents: A list of agents that can be used for planning.
+        tools: A list of tools that can be used for planning.
+
+    Returns:
+        A list of Marvin Tasks that will allow you or other AI agents to achieve the objective.
+
+
+    Examples:
+        >>> tasks = marvin.plan("Create a new blog post about the latest AI trends.")
+        >>> marvin.run_tasks(tasks)
+    """
+    return run_sync(
+        plan_async(
+            instructions=instructions,
+            agent=agent,
+            thread=thread,
+            context=context,
+            available_agents=available_agents,
+            tools=tools,
+        )
+    )

--- a/src/marvin/tasks/task.py
+++ b/src/marvin/tasks/task.py
@@ -144,6 +144,7 @@ class Task(Generic[T]):
         default=None,
         metadata={"description": "Optional parent task"},
         init=False,
+        repr=False,
     )
 
     subtasks: set["Task[Any]"] = field(
@@ -205,7 +206,7 @@ class Task(Generic[T]):
         tools: list[Callable[..., Any]] | None = None,
         memories: list[Memory] | None = None,
         result_validator: Callable[..., Any] | None = None,
-        parent: "Task[T] | None" = None,
+        parent: "Task[T] | None | Literal['__NOTSET__']" = NOTSET,
         depends_on: Sequence["Task[T]"] | None = None,
         allow_fail: bool = False,
         allow_skip: bool = False,
@@ -253,7 +254,9 @@ class Task(Generic[T]):
         self.result = None
 
         # if no parent is provided, use the current task from context
-        self.parent = parent if parent is not None else _current_task.get()
+        if parent is NOTSET:
+            parent = _current_task.get()
+        self.parent = parent
         self.subtasks: set[Task[Any]] = set()
         self.depends_on: set[Task[Any]] = set(depends_on or [])
 

--- a/src/marvin/tasks/task.py
+++ b/src/marvin/tasks/task.py
@@ -211,6 +211,7 @@ class Task(Generic[T]):
         allow_fail: bool = False,
         allow_skip: bool = False,
         cli: bool = False,
+        plan: bool = False,
     ) -> None:
         """Initialize a Task.
 
@@ -231,6 +232,7 @@ class Task(Generic[T]):
             allow_fail: Whether to allow the task to fail
             allow_skip: Whether to allow the task to skip
             cli: Whether to enable CLI interaction tools
+            plan: Whether to enable a tool for planning subtasks
 
         """
         # required fields
@@ -247,7 +249,7 @@ class Task(Generic[T]):
         self.allow_fail = allow_fail
         self.allow_skip = allow_skip
         self.cli = cli
-
+        self.plan = plan
         # key fields
         self.id = uuid.uuid4().hex[:8]
         self.state = TaskState.PENDING
@@ -324,7 +326,7 @@ class Task(Generic[T]):
     def friendly_name(self, verbose: bool = True) -> str:
         """Get a friendly name for this task."""
         if self.name:
-            return f'Task "{self.name}"'
+            return f'Task {self.id} ("{self.name}")'
         if verbose:
             # Replace consecutive newlines with a single space
             instructions = " ".join(self.instructions.split())
@@ -359,6 +361,7 @@ class Task(Generic[T]):
             import marvin.tools.interactive.cli
 
             tools.append(marvin.tools.interactive.cli.cli)
+
         return tools
 
     def is_classifier(self) -> bool:
@@ -461,6 +464,8 @@ class Task(Generic[T]):
             tools.append(self.mark_failed_tool())
         if self.allow_skip:
             tools.append(self.mark_skipped_tool())
+        if self.plan:
+            tools.append(marvin.engine.end_turn.create_plan_subtasks(parent_task=self))
 
         return tools
 

--- a/src/marvin/utilities/tools.py
+++ b/src/marvin/utilities/tools.py
@@ -2,7 +2,7 @@ import inspect
 from collections.abc import Callable
 from dataclasses import dataclass
 from functools import wraps
-from typing import Any, Literal, TypeVar, overload
+from typing import Any, Literal, TypeVar
 
 import pydantic_ai
 from pydantic_ai import RunContext
@@ -13,75 +13,48 @@ T = TypeVar("T")
 logger = get_logger(__name__)
 
 
-@overload
 def update_fn(
-    name_or_func: str,
-    *,
-    description: str | None = None,
-) -> Callable[[Callable[..., T]], Callable[..., T]]: ...
-
-
-@overload
-def update_fn(
-    name_or_func: None = None,
-    *,
-    name: str,
-    description: str | None = None,
-) -> Callable[[Callable[..., T]], Callable[..., T]]: ...
-
-
-@overload
-def update_fn(
-    name_or_func: Callable[..., T],
-    *,
-    name: str,
-    description: str | None = None,
-) -> Callable[..., T]: ...
-
-
-def update_fn(
-    name_or_func: str | Callable[..., T] | None = None,
     *,
     name: str | None = None,
     description: str | None = None,
-) -> Callable[[Callable[..., T]], Callable[..., T]] | Callable[..., T]:
+) -> Callable[[Callable[..., T]], Callable[..., T]]:
     """Rename a function and optionally set its docstring.
 
-    Can be used as a decorator or called directly on a function.
+    Can be used as a decorator with keyword arguments only.
 
     Args:
-        name_or_func: Either the new name (when used as decorator) or the function to rename
-        name: The new name (when used as a function)
+        name: The new name for the function (optional). If provided, must not be empty.
         description: Optional docstring for the function
 
     Example:
-        # As decorator with positional arg:
-        @update_fn('hello_there', description='Says hello')
+        # With name:
+        @update_fn(name='hello_there')
         def my_fn(x):
             return x
 
-        # As decorator with keyword args:
+        # With name and description:
         @update_fn(name='hello_there', description='Says hello')
         def my_fn(x):
             return x
 
-        # As function:
-        def add_stuff(x):
-            return x + 1
-        new_fn = update_fn(add_stuff, name='add_stuff_123', description='Adds stuff')
-
-        # Works with async functions too:
-        @update_fn('async_hello')
-        async def my_async_fn(x):
+        # With no arguments:
+        @update_fn()
+        def my_fn(x):
             return x
 
+        # Works with async functions too:
+        @update_fn(name='async_hello')
+        async def my_async_fn(x):
+            return x
     """
+    if name is not None and not name:
+        raise ValueError("name cannot be empty if provided")
 
-    def apply(func: Callable[..., T], new_name: str) -> Callable[..., T]:
+    def decorator(func: Callable[..., T]) -> Callable[..., T]:
         if inspect.iscoroutinefunction(func):
 
             @wraps(func)
-            async def wrapper(*args: Any, **kwargs: Any) -> T:  # type: ignore[reportRedeclaration]
+            async def wrapper(*args: Any, **kwargs: Any) -> T:
                 return await func(*args, **kwargs)
         else:
 
@@ -89,23 +62,11 @@ def update_fn(
             def wrapper(*args: Any, **kwargs: Any) -> T:
                 return func(*args, **kwargs)
 
-        wrapper.__name__ = new_name
+        if name is not None:
+            wrapper.__name__ = name
         if description is not None:
             wrapper.__doc__ = description
         return wrapper
-
-    if callable(name_or_func):
-        # Used as function
-        if name is None:
-            raise ValueError("name must be provided when used as a function")
-        return apply(name_or_func, name)
-    # Used as decorator
-    decorator_name = name_or_func if name_or_func is not None else name
-    if decorator_name is None:
-        raise ValueError("name must be provided either as argument or keyword")
-
-    def decorator(func: Callable[..., T]) -> Callable[..., T]:
-        return apply(func, decorator_name)
 
     return decorator
 

--- a/tests/basic/utilities/test_tools.py
+++ b/tests/basic/utilities/test_tools.py
@@ -3,123 +3,169 @@ import pytest
 from marvin.utilities.tools import update_fn
 
 
-def test_update_fn_sync_decorator_name():
-    """Test update_fn as decorator with name argument"""
+class TestUpdateFnCalled:
+    """Tests for update_fn when used as a direct function call"""
 
-    @update_fn(name="new_name")
-    def my_fn(x: int) -> int:
-        return x + 1
+    def test_name(self):
+        """Test update_fn as direct function call with name argument"""
 
-    assert my_fn.__name__ == "new_name"
-    assert my_fn(1) == 2
-
-
-def test_update_fn_sync_decorator_with_description():
-    """Test update_fn as decorator with name and description"""
-
-    @update_fn(name="another_name", description="adds stuff")
-    def another_fn(x: int) -> int:
-        return x + 2
-
-    assert another_fn.__name__ == "another_name"
-    assert another_fn.__doc__ == "adds stuff"
-    assert another_fn(1) == 3
-
-
-def test_update_fn_sync_no_args():
-    """Test update_fn as decorator with no arguments"""
-
-    @update_fn()
-    def third_fn(x: int) -> int:
-        return x + 3
-
-    assert third_fn(1) == 4
-
-
-async def test_update_fn_async_decorator_name():
-    """Test update_fn as decorator with name argument on async function"""
-
-    @update_fn(name="async_name")
-    async def my_async_fn(x: int) -> int:
-        return x + 1
-
-    assert my_async_fn.__name__ == "async_name"
-    assert await my_async_fn(1) == 2
-
-
-async def test_update_fn_async_decorator_with_description():
-    """Test update_fn as decorator with name and description on async function"""
-
-    @update_fn(name="another_async", description="adds stuff async")
-    async def another_async_fn(x: int) -> int:
-        return x + 2
-
-    assert another_async_fn.__name__ == "another_async"
-    assert another_async_fn.__doc__ == "adds stuff async"
-    assert await another_async_fn(1) == 3
-
-
-def test_update_fn_description_only():
-    """Test update_fn as decorator with only description"""
-
-    @update_fn(description="only description")
-    def my_fn(x: int) -> int:
-        return x + 1
-
-    assert my_fn.__doc__ == "only description"
-    assert my_fn(1) == 2
-
-
-def test_update_fn_preserves_original_name():
-    """Test that original function name is preserved when no name provided"""
-
-    @update_fn(description="some description")
-    def original_name_fn(x: int) -> int:
-        return x + 1
-
-    assert original_name_fn.__name__ == "original_name_fn"
-
-
-def test_update_fn_preserves_original_docstring():
-    """Test that original docstring is preserved when no description provided"""
-
-    @update_fn(name="new_name")
-    def my_fn(x: int) -> int:
-        """Original docstring"""
-        return x + 1
-
-    assert my_fn.__doc__ == "Original docstring"
-
-
-def test_update_fn_preserves_all_original():
-    """Test that both original name and docstring are preserved with empty decorator"""
-
-    @update_fn()
-    def preserve_me(x: int) -> int:
-        """Keep this docstring"""
-        return x + 1
-
-    assert preserve_me.__name__ == "preserve_me"
-    assert preserve_me.__doc__ == "Keep this docstring"
-
-
-def test_update_fn_empty_description_allowed():
-    """Test that empty description is allowed"""
-
-    @update_fn(name="new_name", description="")
-    def my_fn(x: int) -> int:
-        """Original doc"""
-        return x + 1
-
-    assert my_fn.__name__ == "new_name"
-    assert my_fn.__doc__ == ""
-
-
-def test_update_fn_empty_name_not_allowed():
-    """Test that empty name is not allowed"""
-
-    with pytest.raises(ValueError, match="name cannot be empty if provided"):
-
-        @update_fn(name="")
         def my_fn(x: int) -> int:
             return x + 1
+
+        updated = update_fn(my_fn, name="new_name")
+        assert updated.__name__ == "new_name"
+        assert updated(1) == 2
+
+    def test_name_and_description(self):
+        """Test update_fn as direct function call with name and description"""
+
+        def my_fn(x: int) -> int:
+            return x + 1
+
+        updated = update_fn(my_fn, name="new_name", description="adds stuff")
+        assert updated.__name__ == "new_name"
+        assert updated.__doc__ == "adds stuff"
+        assert updated(1) == 2
+
+    async def test_async(self):
+        """Test update_fn as direct function call with async function"""
+
+        async def my_async_fn(x: int) -> int:
+            return x + 1
+
+        updated = update_fn(my_async_fn, name="new_async_name")
+        assert updated.__name__ == "new_async_name"
+        assert await updated(1) == 2
+
+    def test_preserves_docstring(self):
+        """Test that original docstring is preserved in direct call when no description provided"""
+
+        def my_fn(x: int) -> int:
+            """Original docstring"""
+            return x + 1
+
+        updated = update_fn(my_fn, name="new_name")
+        assert updated.__doc__ == "Original docstring"
+
+    def test_preserves_name(self):
+        """Test that original name is preserved in direct call when no name provided"""
+
+        def original_name_fn(x: int) -> int:
+            return x + 1
+
+        updated = update_fn(original_name_fn, description="new description")
+        assert updated.__name__ == "original_name_fn"
+
+
+class TestUpdateFnDecorator:
+    """Tests for update_fn when used as a decorator"""
+
+    def test_name(self):
+        """Test update_fn as decorator with name argument"""
+
+        @update_fn(name="new_name")
+        def my_fn(x: int) -> int:
+            return x + 1
+
+        assert my_fn.__name__ == "new_name"
+        assert my_fn(1) == 2
+
+    def test_name_and_description(self):
+        """Test update_fn as decorator with name and description"""
+
+        @update_fn(name="another_name", description="adds stuff")
+        def another_fn(x: int) -> int:
+            return x + 2
+
+        assert another_fn.__name__ == "another_name"
+        assert another_fn.__doc__ == "adds stuff"
+        assert another_fn(1) == 3
+
+    def test_no_args(self):
+        """Test update_fn as decorator with no arguments"""
+
+        @update_fn()
+        def third_fn(x: int) -> int:
+            return x + 3
+
+        assert third_fn(1) == 4
+
+    async def test_async_name(self):
+        """Test update_fn as decorator with name argument on async function"""
+
+        @update_fn(name="async_name")
+        async def my_async_fn(x: int) -> int:
+            return x + 1
+
+        assert my_async_fn.__name__ == "async_name"
+        assert await my_async_fn(1) == 2
+
+    async def test_async_name_and_description(self):
+        """Test update_fn as decorator with name and description on async function"""
+
+        @update_fn(name="another_async", description="adds stuff async")
+        async def another_async_fn(x: int) -> int:
+            return x + 2
+
+        assert another_async_fn.__name__ == "another_async"
+        assert another_async_fn.__doc__ == "adds stuff async"
+        assert await another_async_fn(1) == 3
+
+    def test_description_only(self):
+        """Test update_fn as decorator with only description"""
+
+        @update_fn(description="only description")
+        def my_fn(x: int) -> int:
+            return x + 1
+
+        assert my_fn.__doc__ == "only description"
+        assert my_fn(1) == 2
+
+    def test_preserves_original_name(self):
+        """Test that original function name is preserved when no name provided"""
+
+        @update_fn(description="some description")
+        def original_name_fn(x: int) -> int:
+            return x + 1
+
+        assert original_name_fn.__name__ == "original_name_fn"
+
+    def test_preserves_original_docstring(self):
+        """Test that original docstring is preserved when no description provided"""
+
+        @update_fn(name="new_name")
+        def my_fn(x: int) -> int:
+            """Original docstring"""
+            return x + 1
+
+        assert my_fn.__doc__ == "Original docstring"
+
+    def test_preserves_all_original(self):
+        """Test that both original name and docstring are preserved with empty decorator"""
+
+        @update_fn()
+        def preserve_me(x: int) -> int:
+            """Keep this docstring"""
+            return x + 1
+
+        assert preserve_me.__name__ == "preserve_me"
+        assert preserve_me.__doc__ == "Keep this docstring"
+
+    def test_empty_description_allowed(self):
+        """Test that empty description is allowed"""
+
+        @update_fn(name="new_name", description="")
+        def my_fn(x: int) -> int:
+            """Original doc"""
+            return x + 1
+
+        assert my_fn.__name__ == "new_name"
+        assert my_fn.__doc__ == ""
+
+    def test_empty_name_not_allowed(self):
+        """Test that empty name is not allowed"""
+        with pytest.raises(ValueError, match="name cannot be empty if provided"):
+
+            @update_fn(name="")
+            def my_fn(x: int) -> int:
+                return x + 1

--- a/tests/basic/utilities/test_tools.py
+++ b/tests/basic/utilities/test_tools.py
@@ -3,10 +3,10 @@ import pytest
 from marvin.utilities.tools import update_fn
 
 
-def test_update_fn_sync_decorator_positional():
-    """Test update_fn as decorator with positional argument"""
+def test_update_fn_sync_decorator_name():
+    """Test update_fn as decorator with name argument"""
 
-    @update_fn("new_name")
+    @update_fn(name="new_name")
     def my_fn(x: int) -> int:
         return x + 1
 
@@ -14,8 +14,8 @@ def test_update_fn_sync_decorator_positional():
     assert my_fn(1) == 2
 
 
-def test_update_fn_sync_decorator_keyword():
-    """Test update_fn as decorator with keyword arguments"""
+def test_update_fn_sync_decorator_with_description():
+    """Test update_fn as decorator with name and description"""
 
     @update_fn(name="another_name", description="adds stuff")
     def another_fn(x: int) -> int:
@@ -26,21 +26,20 @@ def test_update_fn_sync_decorator_keyword():
     assert another_fn(1) == 3
 
 
-def test_update_fn_sync_direct():
-    """Test update_fn called directly on a function"""
+def test_update_fn_sync_no_args():
+    """Test update_fn as decorator with no arguments"""
 
+    @update_fn()
     def third_fn(x: int) -> int:
         return x + 3
 
-    renamed = update_fn(third_fn, name="third_name")
-    assert renamed.__name__ == "third_name"
-    assert renamed(1) == 4
+    assert third_fn(1) == 4
 
 
-async def test_update_fn_async_decorator_positional():
-    """Test update_fn as decorator with positional argument on async function"""
+async def test_update_fn_async_decorator_name():
+    """Test update_fn as decorator with name argument on async function"""
 
-    @update_fn("async_name")
+    @update_fn(name="async_name")
     async def my_async_fn(x: int) -> int:
         return x + 1
 
@@ -48,8 +47,8 @@ async def test_update_fn_async_decorator_positional():
     assert await my_async_fn(1) == 2
 
 
-async def test_update_fn_async_decorator_keyword():
-    """Test update_fn as decorator with keyword arguments on async function"""
+async def test_update_fn_async_decorator_with_description():
+    """Test update_fn as decorator with name and description on async function"""
 
     @update_fn(name="another_async", description="adds stuff async")
     async def another_async_fn(x: int) -> int:
@@ -60,31 +59,67 @@ async def test_update_fn_async_decorator_keyword():
     assert await another_async_fn(1) == 3
 
 
-async def test_update_fn_async_direct():
-    """Test update_fn called directly on async function"""
+def test_update_fn_description_only():
+    """Test update_fn as decorator with only description"""
 
-    async def third_async_fn(x: int) -> int:
-        return x + 3
+    @update_fn(description="only description")
+    def my_fn(x: int) -> int:
+        return x + 1
 
-    renamed = update_fn(third_async_fn, name="third_async")
-    assert renamed.__name__ == "third_async"
-    assert await renamed(1) == 4
-
-
-def test_update_fn_validation_missing_name_direct():
-    """Test update_fn validation when name is missing in direct call"""
-    with pytest.raises(
-        ValueError, match="name must be provided when used as a function"
-    ):
-        update_fn(lambda x: x)
+    assert my_fn.__doc__ == "only description"
+    assert my_fn(1) == 2
 
 
-def test_update_fn_validation_missing_name_decorator():
-    """Test update_fn validation when name is missing in decorator"""
-    with pytest.raises(
-        ValueError, match="name must be provided either as argument or keyword"
-    ):
+def test_update_fn_preserves_original_name():
+    """Test that original function name is preserved when no name provided"""
 
-        @update_fn()
-        def my_fn(x):
-            return x
+    @update_fn(description="some description")
+    def original_name_fn(x: int) -> int:
+        return x + 1
+
+    assert original_name_fn.__name__ == "original_name_fn"
+
+
+def test_update_fn_preserves_original_docstring():
+    """Test that original docstring is preserved when no description provided"""
+
+    @update_fn(name="new_name")
+    def my_fn(x: int) -> int:
+        """Original docstring"""
+        return x + 1
+
+    assert my_fn.__doc__ == "Original docstring"
+
+
+def test_update_fn_preserves_all_original():
+    """Test that both original name and docstring are preserved with empty decorator"""
+
+    @update_fn()
+    def preserve_me(x: int) -> int:
+        """Keep this docstring"""
+        return x + 1
+
+    assert preserve_me.__name__ == "preserve_me"
+    assert preserve_me.__doc__ == "Keep this docstring"
+
+
+def test_update_fn_empty_description_allowed():
+    """Test that empty description is allowed"""
+
+    @update_fn(name="new_name", description="")
+    def my_fn(x: int) -> int:
+        """Original doc"""
+        return x + 1
+
+    assert my_fn.__name__ == "new_name"
+    assert my_fn.__doc__ == ""
+
+
+def test_update_fn_empty_name_not_allowed():
+    """Test that empty name is not allowed"""
+
+    with pytest.raises(ValueError, match="name cannot be empty if provided"):
+
+        @update_fn(name="")
+        def my_fn(x: int) -> int:
+            return x + 1


### PR DESCRIPTION
Adds:
- `marvin.plan` and `marvin.plan_async`, which both take an instruction and return a list of new marvin tasks, that can be executed individually or with `marvin.run_tasks`
- Task(plan=True), which will permit agents to use a new `plan` tool to generate subtasks for that task