### PR TITLE
fix typing for embedding_fn in postgres provider

### DIFF
--- a/src/marvin/memory/providers/postgres.py
+++ b/src/marvin/memory/providers/postgres.py
@@ -79,7 +79,7 @@ class PostgresMemory(MemoryProvider):
         description="Dimension of the embedding vectors. Must match your model output size.",
     )
 
-    embedding_fn: Callable = Field(
+    embedding_fn: OpenAIEmbeddings = Field(
         default_factory=lambda: OpenAIEmbeddings(model="text-embedding-ada-002"),
         description="Function that turns a string into a numeric vector.",
     )

--- a/src/marvin/memory/providers/postgres.py
+++ b/src/marvin/memory/providers/postgres.py
@@ -1,5 +1,5 @@
 import uuid
-from typing import Callable, Dict, Optional
+from typing import Dict, Optional
 
 # async pg
 import anyio


### PR DESCRIPTION
for some reason OpenAIEmbeddings function isnt a Callable like ChatOpenAI provider , so if providing a custon non openAIEmbedding function (base_url , etc.) this would fail validation, it passed if you didnt have to change anything, setting it to OpenAIEmbeddings allows you to customize it