### PR TITLE
Add support for user content / images / audio / binary

### DIFF
--- a/src/marvin/engine/llm.py
+++ b/src/marvin/engine/llm.py
@@ -1,12 +1,13 @@
 """Utility functions for LLM completions using Pydantic AI."""
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Sequence
 
 from pydantic_ai.messages import (
     ModelRequest,
     ModelResponse,
     SystemPromptPart,
     TextPart,
+    UserContent,
     UserPromptPart,
 )
 from typing_extensions import TypeVar
@@ -22,7 +23,7 @@ def SystemMessage(content: str) -> ModelRequest:
     return ModelRequest(parts=[SystemPromptPart(content=content)])
 
 
-def UserMessage(content: str) -> ModelRequest:
+def UserMessage(content: str | Sequence[UserContent]) -> ModelRequest:
     return ModelRequest(parts=[UserPromptPart(content=content)])
 
 

--- a/src/marvin/fns/run.py
+++ b/src/marvin/fns/run.py
@@ -1,5 +1,7 @@
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from typing import Annotated, Any, TypeVar
+
+from pydantic_ai.messages import UserContent
 
 import marvin.utilities.asyncio
 from marvin import Task, Thread
@@ -42,7 +44,7 @@ def run_tasks(
 
 
 async def run_async(
-    instructions: str,
+    instructions: str | Sequence[UserContent],
     result_type: type[T] | Annotated[T, Any] = str,
     tools: list[Callable[..., Any]] = [],
     thread: Thread | str | None = None,
@@ -68,7 +70,7 @@ async def run_async(
 
 
 def run(
-    instructions: str,
+    instructions: str | Sequence[UserContent],
     result_type: type[T] = str,
     tools: list[Callable[..., Any]] = [],
     thread: Thread | str | None = None,

--- a/src/marvin/fns/say.py
+++ b/src/marvin/fns/say.py
@@ -1,4 +1,6 @@
-from typing import Any
+from typing import Any, Sequence
+
+from pydantic_ai.messages import UserContent
 
 import marvin
 from marvin.agents.actor import Actor
@@ -7,7 +9,7 @@ from marvin.utilities.asyncio import run_sync
 
 
 async def say_async(
-    message: str,
+    message: str | Sequence[UserContent],
     instructions: str | None = None,
     agent: Actor | None = None,
     thread: Thread | str | None = None,
@@ -50,7 +52,7 @@ async def say_async(
 
 
 def say(
-    message: str,
+    message: str | Sequence[UserContent],
     instructions: str | None = None,
     agent: Actor | None = None,
     thread: Thread | str | None = None,

--- a/src/marvin/tasks/task.py
+++ b/src/marvin/tasks/task.py
@@ -262,12 +262,14 @@ class Task(Generic[T]):
         if isinstance(instructions, str):
             self.instructions = instructions
         else:
-            self.instructions = "\n\n".join(
-                [i for i in instructions if isinstance(i, str)]
-            )
-            attachments = (attachments or []) + [
-                i for i in instructions if not isinstance(i, str)
-            ]
+            str_instructions = []
+            attachments = attachments or []
+            for i in instructions:
+                if isinstance(i, str):
+                    str_instructions.append(i)
+                else:
+                    attachments.append(i)
+            self.instructions = "\n\n".join(str_instructions)
 
         # optional fields with defaults
         self.attachments = attachments or []

--- a/src/marvin/tasks/task.py
+++ b/src/marvin/tasks/task.py
@@ -23,6 +23,7 @@ from typing import (
 )
 
 from pydantic import TypeAdapter
+from pydantic_ai.messages import UserContent
 
 import marvin
 import marvin.thread
@@ -81,6 +82,11 @@ class Task(Generic[T]):
     instructions: str = field(
         metadata={"description": "Instructions for the task"},
         kw_only=False,
+    )
+
+    attachments: Sequence[UserContent] = field(
+        default_factory=list,
+        metadata={"description": "Attachments to the task"},
     )
 
     result_type: ResultType[T] = field(  # type: ignore[reportRedeclaration]
@@ -209,7 +215,8 @@ class Task(Generic[T]):
 
     def __init__(
         self,
-        instructions: str,
+        instructions: str | Sequence[UserContent],
+        attachments: Sequence[UserContent] | None = None,
         result_type: ResultType[T] = NOTSET,
         *,
         name: str | None = None,
@@ -231,6 +238,7 @@ class Task(Generic[T]):
 
         Args:
             instructions: Instructions for the task
+            attachments: Optional attachments to the task
             name: Optional name for this task
             result_type: Expected type of the result
             prompt_template: Optional Jinja template for customizing task appearance
@@ -251,9 +259,18 @@ class Task(Generic[T]):
 
         """
         # required fields
-        self.instructions = instructions
+        if isinstance(instructions, str):
+            self.instructions = instructions
+        else:
+            self.instructions = "\n\n".join(
+                [i for i in instructions if isinstance(i, str)]
+            )
+            attachments = (attachments or []) + [
+                i for i in instructions if not isinstance(i, str)
+            ]
 
         # optional fields with defaults
+        self.attachments = attachments or []
         self.name = name
         self.result_type = result_type if result_type is not NOTSET else str
         self.prompt_template = prompt_template
@@ -434,15 +451,16 @@ class Task(Generic[T]):
         type_adapter = get_type_adapter(result_type)
         return type_adapter.validate_python(raw_result)
 
-    def get_prompt(self) -> str:
+    def get_prompt(self) -> str | Sequence[UserContent]:
         """Get the rendered prompt for this task.
 
         Uses the task's prompt_template (or default if None) and renders it with
         this task instance as the `task` variable.
         """
-        prompt = Template(source=self.prompt_template).render(task=self)
-
-        return prompt
+        return [
+            Template(source=self.prompt_template).render(task=self),
+            *self.attachments,
+        ]
 
     async def run_async(
         self,
@@ -547,9 +565,8 @@ class Task(Generic[T]):
             thread = marvin.thread.get_current_thread()
 
         if thread:
-            await thread.add_info_message_async(
+            await thread.add_user_message_async(
                 self.get_prompt(),
-                prefix="A new task has started",
             )
 
     async def mark_skipped(self, thread: Thread | None = None) -> None:

--- a/src/marvin/thread.py
+++ b/src/marvin/thread.py
@@ -7,9 +7,10 @@ import uuid
 from contextvars import ContextVar
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Any, Optional
+from typing import Any, Optional, Sequence
 
 from pydantic import TypeAdapter
+from pydantic_ai.messages import UserContent
 from pydantic_ai.usage import Usage
 from sqlalchemy import select
 
@@ -176,11 +177,13 @@ class Thread:
         messages = await self.add_messages_async([SystemMessage(content=message)])
         return messages[0]
 
-    def add_user_message(self, message: str) -> Message:
+    def add_user_message(self, message: str | Sequence[UserContent]) -> Message:
         """Add a user message to the thread."""
         return run_sync(self.add_user_message_async(message))
 
-    async def add_user_message_async(self, message: str) -> Message:
+    async def add_user_message_async(
+        self, message: str | Sequence[UserContent]
+    ) -> Message:
         """Add a user message to the thread."""
         messages = await self.add_messages_async([UserMessage(content=message)])
         return messages[0]

--- a/tests/ai/fns/test_run.py
+++ b/tests/ai/fns/test_run.py
@@ -1,0 +1,33 @@
+from pydantic_ai import ImageUrl
+
+import marvin
+
+
+class TestRun:
+    def test_run(self):
+        result = marvin.run('Say "Hello"')
+        assert result == "Hello"
+
+
+class TestRunWithAttachments:
+    def test_run_with_attachments(self):
+        result = marvin.run(
+            "What company's logo is this?",
+            attachments=[
+                ImageUrl(
+                    "https://1000logos.net/wp-content/uploads/2021/05/Coca-Cola-logo.png"
+                )
+            ],
+        )
+        assert "Coca-Cola" in result
+
+    def test_run_with_attachments_as_list(self):
+        result = marvin.run(
+            [
+                "What company's logo is this?",
+                ImageUrl(
+                    "https://1000logos.net/wp-content/uploads/2021/05/Coca-Cola-logo.png"
+                ),
+            ],
+        )
+        assert "Coca-Cola" in result

--- a/tests/ai/tasks/test_tasks.py
+++ b/tests/ai/tasks/test_tasks.py
@@ -1,0 +1,14 @@
+from marvin import Task
+
+
+class TestTaskPrompt:
+    async def test_task_return_string_prompt(self):
+        # default tasks return a list; ensure strings work as well
+        class MyTask(Task):
+            def get_prompt(self) -> str:
+                return 'Say the word "hello"'
+
+        task = MyTask("")
+        prompt = task.get_prompt()
+        assert prompt == 'Say the word "hello"'
+        assert task.run() == "hello"

--- a/tests/basic/tasks/test_tasks.py
+++ b/tests/basic/tasks/test_tasks.py
@@ -139,7 +139,7 @@ class TestClassification:
             "Provide the integer indices of your chosen "
             """labels: {0: "'red'", 1: "'green'", 2: "'blue'"}"""
         )
-        assert expected_instruction in prompt
+        assert expected_instruction in prompt[0]
 
         # Test that custom prompts don't include the instruction
         task = Task(
@@ -148,8 +148,8 @@ class TestClassification:
             prompt_template="Custom prompt: {{task.instructions}}",
         )
         prompt = task.get_prompt()
-        assert expected_instruction not in prompt
-        assert prompt == "Custom prompt: Choose color"
+        assert expected_instruction not in prompt[0]
+        assert prompt[0] == "Custom prompt: Choose color"
 
     async def test_classifier_edge_cases(self):
         """Test edge cases for classifier types."""

--- a/uv.lock
+++ b/uv.lock
@@ -1168,7 +1168,7 @@ wheels = [
 
 [[package]]
 name = "marvin"
-version = "3.0.2.dev51+g9e0e00d8.d20250303"
+version = "3.0.2.dev56+gf4d79469.d20250303"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/7d48e832-76c6-45ae-b120-f386894617c1)

```python
from pydantic_ai import ImageUrl
import marvin


marvin_img = "https://github.com/PrefectHQ/marvin/raw/main/docs/assets/img/quotes/it_hates_me.png"


print("With attachments")
r1 = marvin.run("What does this image say?", attachments=[ImageUrl(marvin_img)])


print("As a list")
r2 = marvin.run(["What does this image say?", ImageUrl(marvin_img)])
```

<img width="1135" alt="image" src="https://github.com/user-attachments/assets/e9be07d7-cc29-4b95-9bb2-4a0b1640abad" />
