### PR TITLE
expose Team as suggested by docs

### DIFF
--- a/src/marvin/__init__.py
+++ b/src/marvin/__init__.py
@@ -13,7 +13,7 @@ from marvin.memory.memory import Memory
 # public access
 from marvin.instructions import instructions
 from marvin.defaults import defaults
-from marvin.agents.team import Swarm
+from marvin.agents.team import Swarm, Team
 from . import handlers
 
 # marvin fns
@@ -49,6 +49,7 @@ __version__ = _version("marvin")
 __all__ = [
     "Agent",
     "Memory",
+    "Team",
     "Swarm",
     "Task",
     "Thread",


### PR DESCRIPTION
closes #1153 

i dont really want to expose this (the abstraction could use some battle testing) - but with `Swarm` exposed, id argue the cats already out of the bag so for consistency this should also be available top level. i say we revisit this later