### PR TITLE
Add thread summary asset to slackbot

### DIFF
--- a/examples/slackbot/ASSETS.md
+++ b/examples/slackbot/ASSETS.md
@@ -78,6 +78,16 @@ FACTS = Asset(key="facts://thread/{thread_ts}")
 # This better represents actual data flow
 ```
 
+As an initial step, the Slackbot now materializes a `THREAD_SUMMARY` asset
+whenever a conversation progresses. The summary depends on the `CONVERSATION`
+asset representing the Slack thread, creating a chain:
+
+```
+CONVERSATION -> THREAD_SUMMARY -> USER_FACTS
+```
+
+This allows future assets to build on the evolving thread summary.
+
 ### 4. Model Outputs as Assets
 ```python
 USER_QUESTION = Asset(key="questions://user/{user_id}/{timestamp}")


### PR DESCRIPTION
## Summary
- create THREAD_SUMMARY Prefect asset
- materialize summaries after each Slack message
- document thread summary workflow

## Testing
- `ruff check examples/slackbot/src/slackbot/assets.py examples/slackbot/src/slackbot/api.py`
- `ruff format examples/slackbot/src/slackbot/assets.py examples/slackbot/src/slackbot/api.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'chromadb')*

------
https://chatgpt.com/codex/tasks/task_e_6845165faf548326a740ce682d781190