### PR TITLE
Fix agent printing too often while thinking

### DIFF
--- a/src/marvin/handlers/print_handler.py
+++ b/src/marvin/handlers/print_handler.py
@@ -230,7 +230,7 @@ class PrintHandler(Handler):
         # Create a stable ID from actor ID and message index
         actor_id = str(event.actor.id)
         # Use the timestamp as part of the stable ID to handle multiple messages from same actor
-        msg_time = event.timestamp.isoformat()
+        msg_time = event.timestamp.isoformat(timespec='hour')
         event_id = f"{actor_id}_{msg_time}"
 
         # Create or update the panel

--- a/src/marvin/handlers/print_handler.py
+++ b/src/marvin/handlers/print_handler.py
@@ -230,7 +230,7 @@ class PrintHandler(Handler):
         # Create a stable ID from actor ID and message index
         actor_id = str(event.actor.id)
         # Use the timestamp as part of the stable ID to handle multiple messages from same actor
-        msg_time = event.timestamp.isoformat(timespec='hours')
+        msg_time = event.timestamp.isoformat(timespec="hours")
         event_id = f"{actor_id}_{msg_time}"
 
         # Create or update the panel

--- a/src/marvin/handlers/print_handler.py
+++ b/src/marvin/handlers/print_handler.py
@@ -230,7 +230,7 @@ class PrintHandler(Handler):
         # Create a stable ID from actor ID and message index
         actor_id = str(event.actor.id)
         # Use the timestamp as part of the stable ID to handle multiple messages from same actor
-        msg_time = event.timestamp.isoformat(timespec='hour')
+        msg_time = event.timestamp.isoformat(timespec='hours')
         event_id = f"{actor_id}_{msg_time}"
 
         # Create or update the panel


### PR DESCRIPTION
This change fixes the logic in the print handler allowing thinking events to print within the same panel. Without this logic, Marvin would make a new panel if thinking events were even a millisecond apart, which  happens quite frequently 😉. 