### PR TITLE
Fix code blocks in Slack messages

### DIFF
--- a/examples/slackbot/.dockerignore
+++ b/examples/slackbot/.dockerignore
@@ -36,6 +36,9 @@ share/python-wheels/
 pip-log.txt
 pip-delete-this-directory.txt
 
+# Exclude unit tests
+tests/
+
 # Unit test / coverage reports
 htmlcov/
 .tox/

--- a/examples/slackbot/src/slackbot/slack.py
+++ b/examples/slackbot/src/slackbot/slack.py
@@ -90,6 +90,27 @@ def convert_md_links_to_slack(text: str) -> str:
     )
 
 
+def transform_code_block(text: str) -> str:
+    """
+    Remove the language specifier from a Markdown code block.
+    Slack does not support language-specific code blocks.
+
+    Example:
+        ```python
+        print("Hello, World!")
+        ```
+
+        becomes:
+        ```
+        print("Hello, World!")
+        ```
+    """
+    # Remove the language specifier from the code block
+    code_block_pattern = r"```(?:\w+)?(.*?)```"
+
+    return re.sub(code_block_pattern, r"```\1```", text, flags=re.DOTALL)
+
+
 async def post_slack_message(
     message: str,
     channel_id: str,

--- a/examples/slackbot/src/slackbot/slack.py
+++ b/examples/slackbot/src/slackbot/slack.py
@@ -249,10 +249,12 @@ async def edit_slack_message(
     """Edit an existing Slack message by appending new text or replacing it.
 
     Args:
-        channel (str): The Slack channel ID.
-        ts (str): The timestamp of the message to edit.
+        channel_id (str): The Slack channel ID.
+        thread_ts (str): The timestamp of the message to edit.
         new_text (str): The new text to append or replace in the message.
         mode (str): The mode of text editing, 'append' (default) or 'replace'.
+        delimiter (Union[str, None]): The delimiter to use if appending to an
+            existing message.
 
     Returns:
         httpx.Response: The response from the Slack API.

--- a/examples/slackbot/tests/test_slack_message_class.py
+++ b/examples/slackbot/tests/test_slack_message_class.py
@@ -1,0 +1,73 @@
+import os
+import unittest
+from unittest import mock
+
+@mock.patch.dict(os.environ, {"MARVIN_SLACKBOT_SLACK_API_TOKEN": "xoxb-fake"})
+class SlackMessageClassTests(unittest.TestCase):
+    def test_transforms_code_text(self):
+        from slackbot.slack import SlackMessage
+
+        code = """```python
+        print(test)
+        ```"""
+
+        message = SlackMessage(code)
+
+        expected = """```
+        print(test)
+        ```"""
+
+        self.assertEqual(expected, message._get_transformed_text())
+
+    def test_append(self):
+        from slackbot.slack import SlackMessage
+
+        code = "Original message"
+
+        message = SlackMessage(code)
+        message.append("Updated text")
+
+        expected = "Original message\n\nUpdated text"
+
+        self.assertEqual(expected, message.json()["text"])
+
+    def test_correct_attributes(self):
+        from slackbot.slack import SlackMessage
+        text = "Test message"
+        code = """```python
+        print(test)
+        ```"""
+        code_output = """```
+        print(test)
+        ```"""
+
+        message = SlackMessage(text)
+        attributes = {
+            "text": text
+        }
+        self.assertEqual(attributes, message.json())
+
+        message = SlackMessage(text, channel_id=1, ts=1234567890)
+        attributes = {
+            "text": text,
+            "channel": 1,
+            "ts": 1234567890
+        }
+        self.assertEqual(attributes, message.json())
+
+        message = SlackMessage(text, channel_id=1, thread_ts=1234567890)
+        attributes = {
+            "text": text,
+            "channel": 1,
+            "thread_ts": 1234567890
+        }
+        self.assertEqual(attributes, message.json())
+
+        message = SlackMessage(code, channel_id=1, thread_ts=1234567890)
+        attributes = {
+            "text": code_output,
+            "channel": 1,
+            "thread_ts": 1234567890
+        }
+        self.assertEqual(attributes, message.json())
+


### PR DESCRIPTION
* Add transformation to remove the language marker from code blocks
* Refactor transformations into new `SlackMessage` class
* Add unit tests