### PR TITLE
Update Chroma memory provider for Chroma Cloud

### DIFF
--- a/docs/patterns/memory.mdx
+++ b/docs/patterns/memory.mdx
@@ -144,6 +144,21 @@ uv pip install "marvin[chroma]"
 ```
 </CodeGroup>
 
+Configure Chroma:
+```python
+import marvin
+from marvin.memory.providers import chroma
+
+provider = chroma.ChromaEphemeralMemory()
+# or provider = chroma.ChromaPersistentMemory()
+# or provider = chroma.ChromaCloudMemory()
+
+memory = marvin.Memory(
+    key="knowledge",
+    provider=provider
+)
+```
+
 ### LanceDB
 
 LanceDB provides a fast, efficient vector store with columnar storage:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
 dev = [
     "apispec",
     "atproto",
-    "chromadb>=0.6.0",
+    "chromadb>=1.0.15",
     "commentjson",
     "copychat>=0.5.2",
     "dirty-equals>=0.9.0",


### PR DESCRIPTION
We've made a ton of performance and reliability improvements to Chroma since 0.6.0, so updating the chroma version will instantly make your default memory provider 4x faster.
Additionally, we're getting close to releasing Chroma Cloud, and packages before 1.0.0 are not compatible. We think marvin is really cool, so we'd love for marvin to properly work with our newest features.