### PR TITLE
Fix Slackbot improvements (tasks 1-2): Progress message and uv extras

### DIFF
--- a/examples/slackbot/src/slackbot/api.py
+++ b/examples/slackbot/src/slackbot/api.py
@@ -58,7 +58,9 @@ async def run_agent(
 
     start_time = time.monotonic()
     progress = await create_progress_message(
-        channel_id=channel_id, thread_ts=thread_ts, initial_text="🔄 Thinking..."
+        channel_id=channel_id,
+        thread_ts=thread_ts,
+        initial_text="🔄 Thinking... this may take a while",
     )
 
     try:

--- a/examples/slackbot/src/slackbot/core.py
+++ b/examples/slackbot/src/slackbot/core.py
@@ -72,6 +72,9 @@ You have a suite of tools to gather and store information. Use them methodically
 3.  **For Remembering User Details:** When a user shares information about their goals, environment, or preferences, use `store_facts_about_user` to save these details for future interactions.
 4. **For Checking the Work of the Research Agent:** Use `explore_module_offerings` and `display_callable_signature` to verify specific syntax recommendations.
 5. **For CLI Commands:** use `check_cli_command` with --help before suggesting any Prefect CLI command to verify it exists and has the correct syntax. This prevents suggesting non-existent commands.
+   - **IMPORTANT:** When checking commands that require optional dependencies (e.g., AWS, Docker, Kubernetes integrations), use the `uv run --extra <extra>` prefix
+   - Examples: `uv run --extra aws prefect`, `uv run --extra docker prefect`, `uv run --extra kubernetes prefect`
+   - This ensures the command runs with the necessary dependencies installed
 """
 
 

--- a/examples/slackbot/src/slackbot/search.py
+++ b/examples/slackbot/src/slackbot/search.py
@@ -240,9 +240,11 @@ def check_cli_command(command: str, args: list[str] | None = None) -> str:
     - Always check with --help first to verify command structure
     - Common commands to verify: prefect deploy, prefect work-pool, prefect worker, etc.
     - This helps prevent suggesting non-existent or incorrectly formatted commands
+    - For commands that require optional dependencies, use `uv run --extra <extra>` prefix
+      Examples: `uv run --extra aws`, `uv run --extra docker`, `uv run --extra kubernetes`
 
     Args:
-        command: The base command to run (e.g., "prefect", "prefect deploy")
+        command: The base command to run (e.g., "prefect", "prefect deploy", "uv run --extra docker prefect")
         args: Additional arguments to pass (e.g., ["--help"], ["work-pool", "create", "--help"])
 
     Returns:
@@ -257,6 +259,9 @@ def check_cli_command(command: str, args: list[str] | None = None) -> str:
 
         # Check specific subcommand help
         >>> check_cli_command("prefect", ["worker", "start", "--help"])
+
+        # Check commands that need optional extras
+        >>> check_cli_command("uv run --extra docker", ["prefect", "work-pool", "create", "--help"])
     """
     if args is None:
         args = []


### PR DESCRIPTION
## Summary
- Add "may take a while" message to initial Slackbot response  
- Update LLM instructions to use `uv run --extra` for optional dependencies

## Related Issue
Addresses #1188 (tasks 1 and 2)

## Changes
1. **Progress message improvement**: Updated the initial thinking message to `"🔄 Thinking... this may take a while"` so users know to wait when Marvin is processing
2. **Optional dependencies support**: Added instructions to the LLM system prompt and `check_cli_command` tool to use `uv run --extra <extra>` when commands require optional dependencies (e.g., AWS, Docker, Kubernetes integrations)

## Test Plan
- [ ] Test that the Slackbot shows the updated progress message
- [ ] Verify the bot can properly suggest commands with optional extras when needed
- [ ] Confirm existing functionality still works as expected

Note: Task 3 (handling message edits) will be addressed in a separate PR as it requires more investigation.

🤖 Generated with [Claude Code](https://claude.ai/code)