### PR TITLE
feat: Add GitHub discussions integration for Slack bot

### DIFF
--- a/examples/slackbot/src/slackbot/core.py
+++ b/examples/slackbot/src/slackbot/core.py
@@ -20,6 +20,12 @@ from raggy.vectorstores.tpuf import TurboPuffer, query_namespace
 from turbopuffer import NotFoundError
 
 from slackbot.assets import store_user_facts
+from slackbot.discussion_tools import (
+    execute_discussion_creation,
+    propose_discussion_creation,
+    read_discussion,
+    search_discussions,
+)
 from slackbot.research_agent import (
     research_prefect_topic,
 )
@@ -79,6 +85,18 @@ You have a suite of tools to gather and store information. Use them methodically
    - **IMPORTANT:** When checking commands that require optional dependencies (e.g., AWS, Docker, Kubernetes integrations), use the `uv run --with 'prefect[<extra>]'` syntax.
    - Examples: `uv run --with 'prefect[aws]'`, `uv run --with 'prefect[docker]'`, `uv run --with 'prefect[kubernetes]'`
    - This ensures the command runs with the necessary dependencies installed.
+6. **For GitHub Discussions (USE SPARINGLY):** Only when you help clarify something truly valuable that would benefit the entire community:
+   - First use `search_discussions` to check if similar discussions exist
+   - Use `read_discussion` to get full context of relevant existing discussions
+   - Only propose creating a discussion for genuinely valuable, reusable knowledge
+   - Use `propose_discussion_creation` to suggest creating one - requires user approval
+   - Only after explicit user approval, use `execute_discussion_creation` to create it
+   - BE SELECTIVE: Not every conversation needs to become a discussion. Only create for:
+     * Clarified concepts that multiple users would benefit from
+     * Solutions to non-obvious problems
+     * Important patterns or best practices discovered through conversation
+     * FAQ-worthy content that doesn't exist elsewhere
+   - NEVER create discussions for: simple questions, basic how-tos, or anything already well-documented
 """
 
 
@@ -215,6 +233,10 @@ def create_agent(
             display_callable_signature,  # check the work of the research agent, verify signatures of callable objects
             check_cli_command,  # verify CLI commands before suggesting them
             get_latest_prefect_release_notes,  # get the latest release notes for Prefect
+            search_discussions,  # Search existing GitHub discussions
+            read_discussion,  # Read full discussion content
+            propose_discussion_creation,  # Propose creating a new discussion (requires approval)
+            execute_discussion_creation,  # Execute discussion creation after approval
         ],
         deps_type=UserContext,
     )

--- a/examples/slackbot/src/slackbot/discussion_tools.py
+++ b/examples/slackbot/src/slackbot/discussion_tools.py
@@ -1,0 +1,255 @@
+"""Discussion tools for the Slack bot agent."""
+
+from typing import Optional
+
+from pydantic_ai import RunContext
+
+from marvin.utilities.logging import get_logger
+from slackbot.github_discussions import (
+    create_github_discussion,
+    read_github_discussion,
+    search_github_discussions,
+)
+
+logger = get_logger(__name__)
+
+
+def search_discussions(
+    ctx: RunContext,
+    query: str,
+    repo: str = "prefecthq/marvin",
+    limit: int = 5,
+    category: Optional[str] = None,
+) -> str:
+    """
+    Search GitHub discussions for relevant content.
+
+    This tool searches through existing GitHub discussions to find relevant information
+    before creating new discussions. It helps avoid duplicates and find related content.
+
+    Args:
+        query: Semantic search query for discussions
+        repo: Repository in format "owner/repo" (default: "prefecthq/marvin")
+        limit: Maximum number of results (default: 5)
+        category: Optional category filter
+
+    Returns:
+        Formatted string with search results
+    """
+    results = search_github_discussions(query, repo, limit, category)
+
+    if not results.discussions:
+        return f"No discussions found matching query: {query}"
+
+    output = [f"Found {results.total_count} discussions matching '{query}':\n"]
+
+    for disc in results.discussions:
+        output.append(f"#{disc.number}: {disc.title}")
+        output.append(f"  Category: {disc.category}")
+        output.append(f"  Author: {disc.author_login}")
+        output.append(f"  Created: {disc.created_at}")
+        output.append(f"  URL: {disc.url}")
+
+        # Show first 200 chars of body
+        body_preview = disc.body[:200] + "..." if len(disc.body) > 200 else disc.body
+        output.append(f"  Preview: {body_preview}")
+
+        if disc.answer_chosen_at:
+            output.append(f"  ✓ Answered by {disc.answer_chosen_by}")
+
+        output.append("")  # Blank line between results
+
+    return "\n".join(output)
+
+
+def read_discussion(
+    ctx: RunContext,
+    discussion_number: int,
+    repo: str = "prefecthq/marvin",
+    include_comments: bool = False,
+) -> str:
+    """
+    Read a specific GitHub discussion by number.
+
+    This tool retrieves the full content of a discussion, optionally including comments.
+    Use this to get complete information about a discussion before deciding whether
+    to create a new one or add to an existing one.
+
+    Args:
+        discussion_number: The discussion number to read
+        repo: Repository in format "owner/repo" (default: "prefecthq/marvin")
+        include_comments: Whether to include comments (default: False)
+
+    Returns:
+        Formatted string with discussion content
+    """
+    result = read_github_discussion(discussion_number, repo, include_comments)
+
+    if not result:
+        return f"Discussion #{discussion_number} not found in {repo}"
+
+    discussion, comments = result
+
+    output = [
+        f"Discussion #{discussion.number}: {discussion.title}",
+        f"Category: {discussion.category}",
+        f"Author: {discussion.author_login}",
+        f"Created: {discussion.created_at}",
+        f"URL: {discussion.url}",
+        "",
+        "Body:",
+        discussion.body,
+        "",
+    ]
+
+    if discussion.answer_chosen_at:
+        output.append(
+            f"✓ Answered by {discussion.answer_chosen_by} at {discussion.answer_chosen_at}"
+        )
+        output.append("")
+
+    if include_comments and comments:
+        output.append(f"Comments ({len(comments)}):")
+        output.append("")
+
+        for comment in comments:
+            output.append(f"Comment by {comment.author_login} at {comment.created_at}:")
+            output.append(comment.body)
+            output.append("")
+
+    return "\n".join(output)
+
+
+def propose_discussion_creation(
+    ctx: RunContext,
+    title: str,
+    body: str,
+    category: str = "General",
+    repo: str = "prefecthq/marvin",
+    slack_thread_url: Optional[str] = None,
+) -> str:
+    """
+    Propose creating a new GitHub discussion (requires user approval).
+
+    This tool prepares a GitHub discussion for creation but DOES NOT create it immediately.
+    It will return a proposal that requires explicit user approval before the discussion
+    is actually created. Use this after searching for existing discussions and determining
+    that a new one is needed.
+
+    The discussion body should include relevant context from the Slack conversation
+    and be formatted in a way that's useful for future reference.
+
+    Args:
+        title: Discussion title (should be clear and searchable)
+        body: Discussion body (include context, problem, solution if applicable)
+        category: Discussion category (e.g., "General", "Q&A", "Ideas", "Show and Tell")
+        repo: Repository in format "owner/repo" (default: "prefecthq/marvin")
+        slack_thread_url: Optional URL to the original Slack thread
+
+    Returns:
+        Proposal message indicating what would be created
+    """
+    # Format the body with Slack thread reference if provided
+    if slack_thread_url:
+        formatted_body = f"{body}\n\n---\n*This discussion was created from a [Slack thread]({slack_thread_url})*"
+    else:
+        formatted_body = body
+
+    # Log the proposal
+    logger.info(f"Discussion creation proposed: {title} in {repo}/{category}")
+
+    proposal = f"""
+📝 **Proposed GitHub Discussion**
+
+**Repository:** {repo}
+**Category:** {category}
+**Title:** {title}
+
+**Body:**
+{formatted_body}
+
+---
+*To create this discussion, please respond with approval. You can also suggest edits before creation.*
+
+Note: Before approving, please verify:
+1. No similar discussion already exists
+2. The content is valuable for future reference
+3. The category is appropriate
+4. Sensitive information is not included
+"""
+
+    # Store the proposal in context for later execution if approved
+    if hasattr(ctx, "state") and ctx.state:
+        ctx.state["pending_discussion"] = {
+            "title": title,
+            "body": formatted_body,
+            "category": category,
+            "repo": repo,
+        }
+
+    return proposal
+
+
+def execute_discussion_creation(
+    ctx: RunContext,
+    approved: bool = False,
+) -> str:
+    """
+    Execute the creation of a previously proposed GitHub discussion.
+
+    This tool should only be called after propose_discussion_creation and
+    after receiving explicit user approval.
+
+    Args:
+        approved: Whether the user has approved the creation
+
+    Returns:
+        Result message indicating success or cancellation
+    """
+    if not approved:
+        return "Discussion creation cancelled."
+
+    # Retrieve the pending discussion from context
+    if (
+        not hasattr(ctx, "state")
+        or not ctx.state
+        or "pending_discussion" not in ctx.state
+    ):
+        return "No pending discussion found. Please propose a discussion first."
+
+    pending = ctx.state["pending_discussion"]
+
+    # Create the discussion (approval check is disabled since we have explicit approval)
+    discussion = create_github_discussion(
+        title=pending["title"],
+        body=pending["body"],
+        category=pending["category"],
+        repo=pending["repo"],
+        require_approval=False,  # We have explicit approval
+    )
+
+    if discussion:
+        # Clear the pending discussion
+        del ctx.state["pending_discussion"]
+
+        return f"""
+✅ Discussion created successfully!
+
+**Discussion #{discussion.number}:** {discussion.title}
+**URL:** {discussion.url}
+**Category:** {discussion.category}
+
+The discussion has been created and is now available for the community.
+"""
+    else:
+        return """
+❌ Failed to create discussion.
+
+Please check:
+1. GitHub authentication is configured
+2. The repository exists and you have write access
+3. The category exists in the repository
+4. Network connectivity to GitHub
+
+You may need to create the discussion manually.
+"""

--- a/examples/slackbot/src/slackbot/github_discussions.py
+++ b/examples/slackbot/src/slackbot/github_discussions.py
@@ -1,0 +1,493 @@
+"""GitHub Discussions integration for Slack bot."""
+
+import json
+import subprocess
+from typing import Optional
+
+from pydantic import BaseModel
+
+from marvin.utilities.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+class Discussion(BaseModel):
+    """GitHub Discussion model."""
+
+    id: str
+    number: int
+    title: str
+    body: str
+    category: str
+    created_at: str
+    updated_at: str
+    author_login: str
+    url: str
+    answer_chosen_at: Optional[str] = None
+    answer_chosen_by: Optional[str] = None
+    comments_count: int = 0
+
+
+class DiscussionComment(BaseModel):
+    """GitHub Discussion comment model."""
+
+    id: str
+    body: str
+    author_login: str
+    created_at: str
+
+
+class DiscussionSearchResult(BaseModel):
+    """Result from searching GitHub discussions."""
+
+    discussions: list[Discussion]
+    total_count: int
+    query: str
+
+
+def search_github_discussions(
+    query: str,
+    repo: str = "prefecthq/marvin",
+    limit: int = 5,
+    category: Optional[str] = None,
+) -> DiscussionSearchResult:
+    """
+    Search GitHub discussions using semantic search.
+
+    Args:
+        query: Search query for discussions
+        repo: Repository in format "owner/repo"
+        limit: Maximum number of results to return
+        category: Optional category filter
+
+    Returns:
+        DiscussionSearchResult with matching discussions
+    """
+    owner, repo_name = repo.split("/")
+
+    # Build the search query string for GitHub search
+    search_query = f"repo:{repo} {query}"
+    if category:
+        search_query += f" category:{category}"
+
+    # Build the GraphQL query for searching discussions
+    graphql_query = """
+    query($searchQuery: String!, $limit: Int!) {
+      search(query: $searchQuery, type: DISCUSSION, first: $limit) {
+        discussionCount
+        nodes {
+          ... on Discussion {
+            id
+            number
+            title
+            body
+            category {
+              name
+            }
+            createdAt
+            updatedAt
+            author {
+              login
+            }
+            url
+            answerChosenAt
+            answerChosenBy {
+              login
+            }
+            comments {
+              totalCount
+            }
+          }
+        }
+      }
+    }
+    """
+
+    variables = {
+        "searchQuery": search_query,
+        "limit": limit,
+    }
+
+    # Execute the GraphQL query using gh CLI
+    cmd = [
+        "gh",
+        "api",
+        "graphql",
+        "-f",
+        f"query={graphql_query}",
+        "--jq",
+        ".",
+    ]
+
+    # Add variables (skip "query" since it's already in the GraphQL query)
+    for key, value in variables.items():
+        if isinstance(value, int):
+            cmd.extend(["-F", f"{key}={value}"])
+        else:
+            cmd.extend(["-f", f"{key}={value}"])
+
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+        data = json.loads(result.stdout)
+
+        discussions = []
+        nodes = data.get("data", {}).get("search", {}).get("nodes", [])
+
+        for node in nodes:
+            if node:  # Skip null nodes
+                discussions.append(
+                    Discussion(
+                        id=node["id"],
+                        number=node["number"],
+                        title=node["title"],
+                        body=node["body"],
+                        category=node["category"]["name"]
+                        if node.get("category")
+                        else "Uncategorized",
+                        created_at=node["createdAt"],
+                        updated_at=node["updatedAt"],
+                        author_login=node["author"]["login"]
+                        if node.get("author")
+                        else "unknown",
+                        url=node["url"],
+                        answer_chosen_at=node.get("answerChosenAt"),
+                        answer_chosen_by=node["answerChosenBy"]["login"]
+                        if node.get("answerChosenBy")
+                        else None,
+                        comments_count=node["comments"]["totalCount"]
+                        if node.get("comments")
+                        else 0,
+                    )
+                )
+
+        total_count = data.get("data", {}).get("search", {}).get("discussionCount", 0)
+
+        return DiscussionSearchResult(
+            discussions=discussions,
+            total_count=total_count,
+            query=query,
+        )
+
+    except subprocess.CalledProcessError as e:
+        logger.error(f"Failed to search discussions: {e.stderr}")
+        return DiscussionSearchResult(discussions=[], total_count=0, query=query)
+    except json.JSONDecodeError as e:
+        logger.error(f"Failed to parse GitHub API response: {e}")
+        return DiscussionSearchResult(discussions=[], total_count=0, query=query)
+
+
+def read_github_discussion(
+    discussion_number: int,
+    repo: str = "prefecthq/marvin",
+    include_comments: bool = False,
+) -> Optional[tuple[Discussion, list[DiscussionComment]]]:
+    """
+    Read a specific GitHub discussion by number.
+
+    Args:
+        discussion_number: The discussion number
+        repo: Repository in format "owner/repo"
+        include_comments: Whether to include comments
+
+    Returns:
+        Tuple of (Discussion, list[DiscussionComment]) or None if not found
+    """
+    owner, repo_name = repo.split("/")
+
+    # Build the GraphQL query
+    graphql_query = """
+    query($owner: String!, $repo: String!, $number: Int!) {
+      repository(owner: $owner, name: $repo) {
+        discussion(number: $number) {
+          id
+          number
+          title
+          body
+          category {
+            name
+          }
+          createdAt
+          updatedAt
+          author {
+            login
+          }
+          url
+          answerChosenAt
+          answerChosenBy {
+            login
+          }
+          comments(first: 50) {
+            totalCount
+            nodes {
+              id
+              body
+              author {
+                login
+              }
+              createdAt
+            }
+          }
+        }
+      }
+    }
+    """
+
+    variables = {
+        "owner": owner,
+        "repo": repo_name,
+        "number": discussion_number,
+    }
+
+    # Execute the GraphQL query
+    cmd = [
+        "gh",
+        "api",
+        "graphql",
+        "-f",
+        f"query={graphql_query}",
+        "--jq",
+        ".",
+    ]
+
+    for key, value in variables.items():
+        if isinstance(value, int):
+            cmd.extend(["-F", f"{key}={value}"])
+        else:
+            cmd.extend(["-f", f"{key}={value}"])
+
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+        data = json.loads(result.stdout)
+
+        node = data.get("data", {}).get("repository", {}).get("discussion")
+        if not node:
+            return None
+
+        discussion = Discussion(
+            id=node["id"],
+            number=node["number"],
+            title=node["title"],
+            body=node["body"],
+            category=node["category"]["name"]
+            if node.get("category")
+            else "Uncategorized",
+            created_at=node["createdAt"],
+            updated_at=node["updatedAt"],
+            author_login=node["author"]["login"] if node.get("author") else "unknown",
+            url=node["url"],
+            answer_chosen_at=node.get("answerChosenAt"),
+            answer_chosen_by=node["answerChosenBy"]["login"]
+            if node.get("answerChosenBy")
+            else None,
+            comments_count=node["comments"]["totalCount"]
+            if node.get("comments")
+            else 0,
+        )
+
+        comments = []
+        if include_comments and node.get("comments"):
+            for comment_node in node["comments"].get("nodes", []):
+                if comment_node:
+                    comments.append(
+                        DiscussionComment(
+                            id=comment_node["id"],
+                            body=comment_node["body"],
+                            author_login=comment_node["author"]["login"]
+                            if comment_node.get("author")
+                            else "unknown",
+                            created_at=comment_node["createdAt"],
+                        )
+                    )
+
+        return discussion, comments
+
+    except subprocess.CalledProcessError as e:
+        logger.error(f"Failed to read discussion: {e.stderr}")
+        return None
+    except json.JSONDecodeError as e:
+        logger.error(f"Failed to parse GitHub API response: {e}")
+        return None
+
+
+def create_github_discussion(
+    title: str,
+    body: str,
+    category: str,
+    repo: str = "prefecthq/marvin",
+    require_approval: bool = True,
+) -> Optional[Discussion]:
+    """
+    Create a new GitHub discussion.
+
+    Args:
+        title: Discussion title
+        body: Discussion body content
+        category: Discussion category name
+        repo: Repository in format "owner/repo"
+        require_approval: Whether to require user approval before creating
+
+    Returns:
+        Created Discussion or None if creation failed or was cancelled
+    """
+    if require_approval:
+        # This would be called in the context where user approval can be requested
+        logger.info(f"Would create discussion: {title} in {repo}/{category}")
+        return None
+
+    owner, repo_name = repo.split("/")
+
+    # First, get the category ID
+    category_query = """
+    query($owner: String!, $repo: String!) {
+      repository(owner: $owner, name: $repo) {
+        discussionCategories(first: 20) {
+          nodes {
+            id
+            name
+          }
+        }
+      }
+    }
+    """
+
+    cmd = [
+        "gh",
+        "api",
+        "graphql",
+        "-f",
+        f"query={category_query}",
+        "-f",
+        f"owner={owner}",
+        "-f",
+        f"repo={repo_name}",
+        "--jq",
+        ".",
+    ]
+
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+        data = json.loads(result.stdout)
+
+        categories = (
+            data.get("data", {})
+            .get("repository", {})
+            .get("discussionCategories", {})
+            .get("nodes", [])
+        )
+        category_id = None
+
+        for cat in categories:
+            if cat and cat.get("name") == category:
+                category_id = cat["id"]
+                break
+
+        if not category_id:
+            logger.error(f"Category '{category}' not found in {repo}")
+            return None
+
+        # Now create the discussion
+        mutation = """
+        mutation($repositoryId: ID!, $categoryId: ID!, $title: String!, $body: String!) {
+          createDiscussion(input: {
+            repositoryId: $repositoryId,
+            categoryId: $categoryId,
+            title: $title,
+            body: $body
+          }) {
+            discussion {
+              id
+              number
+              title
+              body
+              category {
+                name
+              }
+              createdAt
+              updatedAt
+              author {
+                login
+              }
+              url
+              comments {
+                totalCount
+              }
+            }
+          }
+        }
+        """
+
+        # Get repository ID
+        repo_query = """
+        query($owner: String!, $repo: String!) {
+          repository(owner: $owner, name: $repo) {
+            id
+          }
+        }
+        """
+
+        cmd = [
+            "gh",
+            "api",
+            "graphql",
+            "-f",
+            f"query={repo_query}",
+            "-f",
+            f"owner={owner}",
+            "-f",
+            f"repo={repo_name}",
+            "--jq",
+            ".data.repository.id",
+        ]
+
+        result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+        repository_id = result.stdout.strip().strip('"')
+
+        # Create the discussion
+        cmd = [
+            "gh",
+            "api",
+            "graphql",
+            "-f",
+            f"query={mutation}",
+            "-f",
+            f"repositoryId={repository_id}",
+            "-f",
+            f"categoryId={category_id}",
+            "-f",
+            f"title={title}",
+            "-f",
+            f"body={body}",
+            "--jq",
+            ".",
+        ]
+
+        result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+        data = json.loads(result.stdout)
+
+        node = data.get("data", {}).get("createDiscussion", {}).get("discussion")
+        if node:
+            return Discussion(
+                id=node["id"],
+                number=node["number"],
+                title=node["title"],
+                body=node["body"],
+                category=node["category"]["name"] if node.get("category") else category,
+                created_at=node["createdAt"],
+                updated_at=node["updatedAt"],
+                author_login=node["author"]["login"]
+                if node.get("author")
+                else "unknown",
+                url=node["url"],
+                answer_chosen_at=None,
+                answer_chosen_by=None,
+                comments_count=0,
+            )
+
+        return None
+
+    except subprocess.CalledProcessError as e:
+        logger.error(f"Failed to create discussion: {e.stderr}")
+        return None
+    except json.JSONDecodeError as e:
+        logger.error(f"Failed to parse GitHub API response: {e}")
+        return None


### PR DESCRIPTION
## Summary
- Adds tools to search, read, and create GitHub discussions from valuable Slack conversations
- Helps preserve important knowledge from ephemeral Slack threads into searchable, permanent discussions
- Includes approval mechanism to prevent spam

## Implementation

### New Files
- `examples/slackbot/src/slackbot/github_discussions.py` - Core GitHub API integration using GraphQL
- `examples/slackbot/src/slackbot/discussion_tools.py` - Agent-ready tool wrappers

### Key Features
- **Search discussions** - Find existing discussions to avoid duplicates
- **Read discussions** - Get full content including comments
- **Create discussions** - With approval workflow to ensure quality
- **Slack thread linking** - Preserves context from original conversation

### Safety Mechanisms
- Creation requires explicit user approval
- System prompt emphasizes using sparingly
- Only for truly valuable, reusable knowledge

## Test Plan
- [x] Test search functionality 
- [x] Test read functionality
- [x] Test approval blocking mechanism
- [ ] Test in live Slack environment
- [ ] Verify GraphQL queries work with various repo configurations

🤖 Generated with [Claude Code](https://claude.ai/code)