### PR TITLE
Add missing concepts to menu

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -41,7 +41,7 @@
                             "concepts/tasks",
                             "concepts/agents",
                             "concepts/threads",
-                            "concepts/tools-and-context",
+                            "concepts/tools-and-context"
                         ]
                     },
                     {


### PR DESCRIPTION
Two of the concepts pages were missing from the Concepts menu making them less easy to discover -  Tools and Context, and Teams.