### PR TITLE
Fix pydantic-ai deprecation warning: mcp_servers -> toolsets

### DIFF
--- a/src/marvin/agents/agent.py
+++ b/src/marvin/agents/agent.py
@@ -206,7 +206,7 @@ class Agent(Actor):
             agent_kwargs["tools"] = combined_tools
 
         if active_mcp_servers:
-            agent_kwargs["mcp_servers"] = active_mcp_servers
+            agent_kwargs["toolsets"] = active_mcp_servers
 
         agentlet = pydantic_ai.Agent[Any, Any](**agent_kwargs)
 


### PR DESCRIPTION
## Summary

Fixes the deprecation warning from pydantic-ai by updating the parameter name from `mcp_servers` to `toolsets` when instantiating pydantic-ai's Agent.

Closes #1205

## Problem

The test suite was showing this deprecation warning:
```
tests/ai/test_mcp.py::test_mcp_git_server_tool_usage_and_output
  /home/runner/work/marvin/marvin/.venv/lib/python3.11/site-packages/pydantic_ai/agent/__init__.py:310: 
  DeprecationWarning: `mcp_servers` is deprecated, use `toolsets` instead
```

## Solution

Updated the single location where Marvin passes MCP servers to pydantic-ai's Agent constructor:
- Changed `agent_kwargs["mcp_servers"]` to `agent_kwargs["toolsets"]` in `src/marvin/agents/agent.py:209`

This is an internal implementation detail only. **Marvin's public API remains unchanged** - users continue to use `mcp_servers` when creating Marvin Agents.

## Testing

✅ Verified the deprecation warning exists on main branch
✅ Confirmed the warning is eliminated with this fix  
✅ All MCP-related tests pass:
- `tests/ai/test_mcp.py`
- `tests/agents/test_mcp_integration.py`

## Backwards Compatibility

This change maintains full backwards compatibility:
- Marvin's public API is unchanged
- Users continue to pass `mcp_servers` to Marvin's Agent class
- Only the internal pydantic-ai integration is updated

🤖 Generated with [Claude Code](https://claude.ai/code)