### PR TITLE
Slackbot: ignore edits while initial response is in progress

### DIFF
--- a/examples/slackbot/src/slackbot/_internal/thread_status.py
+++ b/examples/slackbot/src/slackbot/_internal/thread_status.py
@@ -1,0 +1,96 @@
+"""Thread status tracking for Slack events (cross-process safe).
+
+This module encapsulates a tiny SQLite-backed status mechanism to avoid duplicate
+processing of the same Slack thread when users edit their original post or when
+Slack delivers multiple events. It keeps the rest of the app simple and avoids
+sprawling status logic across files.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from slackbot.core import Database
+
+Status = Literal["in_progress", "completed"]
+
+
+_SCHEMA_CREATED = False
+
+
+async def ensure_schema(db: Database) -> None:
+    global _SCHEMA_CREATED
+    if _SCHEMA_CREATED:
+        return
+
+    def _create() -> None:
+        db.con.execute(
+            """
+            CREATE TABLE IF NOT EXISTS slack_thread_status (
+                thread_ts TEXT PRIMARY KEY,
+                status TEXT NOT NULL CHECK (status IN ('in_progress','completed')),
+                updated_at REAL NOT NULL
+            );
+            """
+        )
+        db.con.commit()
+
+    await db.loop.run_in_executor(db.executor, _create)
+    _SCHEMA_CREATED = True
+
+
+async def try_acquire(db: Database, thread_ts: str) -> bool:
+    """Attempt to mark a thread as in_progress; returns True if acquired.
+
+    Uses an atomic INSERT OR IGNORE on a PRIMARY KEY to prevent duplicates across
+    concurrent processes or tasks.
+    """
+    await ensure_schema(db)
+
+    def _insert() -> int:
+        cur = db.con.cursor()
+        cur.execute(
+            """
+            INSERT OR IGNORE INTO slack_thread_status (thread_ts, status, updated_at)
+            VALUES (?, 'in_progress', strftime('%s','now'))
+            """,
+            (thread_ts,),
+        )
+        db.con.commit()
+        return cur.rowcount
+
+    rowcount: int = await db.loop.run_in_executor(db.executor, _insert)
+    return rowcount == 1
+
+
+async def get_status(db: Database, thread_ts: str) -> Status | None:
+    await ensure_schema(db)
+
+    def _query() -> Status | None:
+        cur = db.con.cursor()
+        cur.execute(
+            "SELECT status FROM slack_thread_status WHERE thread_ts = ?",
+            (thread_ts,),
+        )
+        row = cur.fetchone()
+        return row[0] if row else None  # type: ignore[return-value]
+
+    return await db.loop.run_in_executor(db.executor, _query)
+
+
+async def mark_completed(db: Database, thread_ts: str) -> None:
+    await ensure_schema(db)
+
+    def _update() -> None:
+        cur = db.con.cursor()
+        cur.execute(
+            """
+            UPDATE slack_thread_status
+            SET status = 'completed', updated_at = strftime('%s','now')
+            WHERE thread_ts = ?
+            """,
+            (thread_ts,),
+        )
+        db.con.commit()
+
+    await db.loop.run_in_executor(db.executor, _update)

--- a/examples/slackbot/src/slackbot/core.py
+++ b/examples/slackbot/src/slackbot/core.py
@@ -129,6 +129,9 @@ class Database:
 
         await self.loop.run_in_executor(self.executor, _insert)
 
+    # Note: Thread status tracking is handled in-process within api.py to keep
+    # persistence minimal for the examples package.
+
 
 @task(task_run_name="build user context for {user_id}")
 def build_user_context(

--- a/examples/slackbot/src/slackbot/slack.py
+++ b/examples/slackbot/src/slackbot/slack.py
@@ -29,6 +29,7 @@ class EventBlock(BaseModel):
 class SlackEvent(BaseModel):
     client_msg_id: str | None = None
     type: str
+    subtype: str | None = None
     text: str | None = None
     user: str | dict[str, Any] | None = None
     ts: str | None = None


### PR DESCRIPTION
Summary\n- Prevent duplicate responses when users edit their original mention mid-run\n- Cross-process dedupe via tiny sqlite status in _internal.thread_status (idempotency key = root thread_ts)\n- If an edit arrives while in progress, post a polite notice asking for follow-ups as new thread messages\n- Keep app logic lean: minimal changes to api.py; no changes to core DB class\n\nDesign\n- Adds _internal/thread_status.py with ensure_schema/try_acquire/get_status/mark_completed. Schema is created lazily.\n- api.py acquires per-thread key before processing; on conflict, checks status: in_progress => send edit-ignored message; completed => skip.\n- Uses the existing sqlite DB file from settings; no new service or dep.\n- Adds optional SlackEvent.subtype for future-proof edit detection; otherwise behavior is based on duplicate events regardless of subtype.\n\nNotes\n- Keeps example scope small and avoids sprawl into core.\n- Passes ruff and format hooks.\n- Happy to adjust the copy for the polite notice or extend dedupe keying if you want to incorporate client_msg_id.\n