### PR TITLE
Slackbot: per-message dedupe; ignore only edits while in-progress

### DIFF
--- a/examples/slackbot/src/slackbot/api.py
+++ b/examples/slackbot/src/slackbot/api.py
@@ -264,7 +264,7 @@ async def handle_message(payload: SlackPayload, db: Database):
             )
         finally:
             # Only mark completion for the root message; do not block replies
-            if "is_root_message" in locals() and is_root_message:
+            if is_root_message:
                 try:
                     await mark_thread_completed(db, root_ts)
                 except Exception:

--- a/examples/slackbot/src/slackbot/slack.py
+++ b/examples/slackbot/src/slackbot/slack.py
@@ -31,6 +31,8 @@ class SlackEvent(BaseModel):
     type: str
     subtype: str | None = None
     text: str | None = None
+    # For message_changed edit events, Slack nests the edited message here
+    message: dict[str, Any] | None = None
     user: str | dict[str, Any] | None = None
     ts: str | None = None
     team: str | None = None


### PR DESCRIPTION
Scope\n- Keep behavior minimal: only ignore edits of the exact message being processed.\n- Do not block or dedupe other messages in the thread.\n\nChanges\n- Parse edit events by honoring Slack  structure (subtype + nested ).\n- Use the message timestamp (message_ts) as the idempotency key.\n- If acquire fails and status is in_progress AND this is an edit -> post the polite "still working" note in the thread.\n- Otherwise skip duplicate quietly.\n- Mark completion using  so subsequent mentions in the thread are unaffected.\n\nResult\n- Original ask: when users edit the message that mentioned the bot before it responds, we ignore that edit with a friendly note.\n- Replies and new mentions in the same thread proceed normally.\n\nNotes\n- No sprawl: tiny SQLite helper remains isolated in _internal/thread_status.\n- Lints/format pass.\n\nHappy to tune the edit-copy or widen edit detection if your workspace emits app_mention on edit (we can fallback to text-based heuristics).