### PR TITLE
Add support contact tool and prompt updates

### DIFF
--- a/examples/slackbot/src/slackbot/_internal/templates.py
+++ b/examples/slackbot/src/slackbot/_internal/templates.py
@@ -34,6 +34,9 @@ CHANNEL_REDIRECT_MESSAGE = (
 
 DEFAULT_SYSTEM_PROMPT = """You are Marvin, an AI assistant for the Prefect data engineering platform. Your responses should be clear, helpful, accurate, and professional. Your primary goal is to provide excellent support to users.
 
+## Support Resources
+For direct support inquiries, users can contact help@prefect.io for official assistance. Use the `get_support_resources` tool when users ask about getting help or support.
+
 ## Output Context
 Your responses will be displayed in Slack. Format accordingly:
 - Use ``` for code blocks (WITHOUT language identifiers like python/js/etc - Slack doesn't support them)

--- a/examples/slackbot/src/slackbot/core.py
+++ b/examples/slackbot/src/slackbot/core.py
@@ -39,6 +39,7 @@ from slackbot.search import (
     display_callable_signature,
     explore_module_offerings,
     get_latest_prefect_release_notes,
+    get_support_resources,
     read_github_issues,
 )
 from slackbot.settings import settings
@@ -185,6 +186,7 @@ def create_agent(
             display_callable_signature,  # check the work of the research agent, verify signatures of callable objects
             check_cli_command,  # verify CLI commands before suggesting them
             get_latest_prefect_release_notes,  # get the latest release notes for Prefect
+            get_support_resources,  # provide official support contact information
         ],
         deps_type=UserContext,
     )

--- a/examples/slackbot/src/slackbot/search.py
+++ b/examples/slackbot/src/slackbot/search.py
@@ -272,3 +272,18 @@ def check_cli_command(command: str, args: list[str] | None = None) -> str:
         return f"Command '{full_command[0]}' not found. Make sure it's installed and in PATH."
     except Exception as e:
         return f"Error running command: {str(e)}"
+
+
+def get_support_resources() -> dict[str, str]:
+    """
+    Get available support resources and contact information for Prefect users.
+
+    Use this tool when users ask about getting help, support, or contacting Prefect.
+    This provides official support channels including email support.
+
+    Returns:
+        dict: Available support resources with contact details
+    """
+    return {
+        "support_email": "help@prefect.io",
+    }

--- a/examples/slackbot/src/slackbot/slack.py
+++ b/examples/slackbot/src/slackbot/slack.py
@@ -31,6 +31,8 @@ class SlackEvent(BaseModel):
     type: str
     subtype: str | None = None
     text: str | None = None
+    # For message_changed edit events, Slack nests the edited message here
+    message: dict[str, Any] | None = None
     user: str | dict[str, Any] | None = None
     ts: str | None = None
     team: str | None = None


### PR DESCRIPTION
## Summary
- Add `get_support_resources()` tool that returns `help@prefect.io` email address
- Update Marvin's system prompt to reference the support email and tool usage
- Include the new tool in slackbot agent configuration

## Background
Following Slack conversation where @nate mentioned the `help@prefect.io` support email that should be recommended by Marvin when users ask about getting support or help.

## Changes
- **New Tool**: `get_support_resources()` in `search.py` that returns official support contact information
- **Prompt Update**: Added "Support Resources" section to system prompt mentioning `help@prefect.io`
- **Tool Integration**: Added the new tool to the slackbot agent's tool list

## Test Plan
- [ ] Verify tool is available in slackbot agent
- [ ] Test that bot suggests support email when asked about getting help
- [ ] Confirm system prompt includes support resource information

🤖 Generated with [Claude Code](https://claude.ai/code)