### PR TITLE
fix: handle multiple EndTurn tools with Union type for allow_fail

### DIFF
--- a/src/marvin/agents/agent.py
+++ b/src/marvin/agents/agent.py
@@ -179,15 +179,14 @@ class Agent(Actor):
             tool_output_name = getattr(
                 output_type_for_tool_output, "__name__", tool_output_name
             )
+        elif len(final_end_turn_defs) > 1:
+            # For multiple EndTurn tools, use Union to allow model to choose
+            from typing import Union
+
+            output_type_for_tool_output = Union[tuple(final_end_turn_defs)]
         else:
-            # Use None if zero or multiple EndTurn tools are present
-            # This avoids schema issues but might prevent multi-turn scenarios?
-            # TODO: Revisit handling of multiple EndTurn tools / Union[EndTurn]
+            # Use None if no EndTurn tools are present
             output_type_for_tool_output = type(None)
-            if len(final_end_turn_defs) > 1:
-                logger.warning(
-                    "Multiple EndTurn tools detected, output validation might be limited."
-                )
 
         final_tool_output = ToolOutput(
             type_=output_type_for_tool_output,


### PR DESCRIPTION
## summary
fixes infinite loop and "multiple endturn tools" warning when using `allow_fail=True`

## root cause
- when a task has `allow_fail=True`, it creates two endturn tools: `MarkTaskSuccessful` and `MarkTaskFailed`
- previous code (agent.py:186) set `output_type=type(None)` when >1 endturn tool detected
- this caused the agent to not validate its output as an EndTurn, leading to infinite loop with repeated "Multiple EndTurn tools detected" warnings

## solution
- use `Union[Tool1, Tool2]` as output_type when multiple endturn tools exist
- this allows pydantic_ai to properly validate the agent's response as one of the union types
- the model can now choose between marking the task successful or failed

## testing
- added 3 new tests in `tests/basic/tasks/test_tasks.py::TestAllowFail`:
  - test that tasks with allow_fail complete without infinite loop (regression test)
  - test that allow_fail creates both MarkTaskSuccessful and MarkTaskFailed tools
  - test that multiple EndTurn tools result in Union output type
- manually tested with repros - tasks can now properly succeed OR fail
- 61/62 existing tests pass (1 failure due to API connection issue, not our change)

## related
- builds on PR #1229 which fixed concurrent task execution

🤖 Generated with [Claude Code](https://claude.com/claude-code)