### PR TITLE
fix github label validation and error handling

### DIFF
--- a/examples/slackbot/src/slackbot/api.py
+++ b/examples/slackbot/src/slackbot/api.py
@@ -279,12 +279,7 @@ async def handle_message(payload: SlackPayload, db: Database):
                 channel_id=event.channel,
                 thread_ts=thread_ts,
             )
-            # Still return completed so we don't retry
-            return Completed(
-                message="Error during agent execution",
-                name="ERROR_HANDLED",
-                data=dict(error=str(e), user_context=user_context),
-            )
+            raise
         finally:
             try:
                 await mark_thread_completed(db, message_ts)

--- a/examples/slackbot/src/slackbot/github/models.py
+++ b/examples/slackbot/src/slackbot/github/models.py
@@ -18,7 +18,7 @@ class GitHubLabel(BaseModel):
 
     name: str = Field(default="")
     color: str = Field(default="")
-    description: str = Field(default="")
+    description: str | None = Field(default="")
 
 
 class GitHubComment(BaseModel):


### PR DESCRIPTION
## summary
- fix pydantic validation error when github returns null label descriptions
- remove ERROR_HANDLED completed state so flows properly fail

## changes

### github labels fix
- `GitHubLabel.description` now accepts `str | None` 
- github api sometimes returns `null` for label descriptions
- fixes validation error: `Input should be a valid string [type=string_type, input_value=None]`

### error handling fix
- removed `Completed(name="ERROR_HANDLED")` pattern
- errors are now re-raised after sending user-friendly slack message
- maintains good UX while allowing proper flow failure monitoring

## why
proper failure states are important for:
- alerting/monitoring
- understanding when the bot actually fails vs succeeds
- debugging issues in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)