### PR TITLE
fix: remove stale delegates parameter from Agent documentation

### DIFF
--- a/docs/concepts/agents.mdx
+++ b/docs/concepts/agents.mdx
@@ -109,21 +109,6 @@ agent = marvin.Agent(
 )
 ```
 
-### Delegates
-
-Agents can be configured with a list of other agents that they can delegate work to. This is particularly useful when working with teams of agents:
-
-```python
-import marvin
-
-researcher = marvin.Agent(name="Researcher")
-writer = marvin.Agent(name="Writer")
-editor = marvin.Agent(
-    name="Editor",
-    delegates=[researcher, writer]
-)
-```
-
 ## Assigning agents to tasks
 
 Agents must be assigned to tasks in order to work on them. You can assign agents by passing them to the `agents` parameter when creating a task:


### PR DESCRIPTION
## summary

removes the stale `delegates` parameter documentation from the Agent class

## problem

issue #1239 reported that the documentation shows `Agent(delegates=[...])` as a valid parameter, but this causes a runtime error because the `delegates` field doesn't exist on the Agent class.

investigating the git history revealed:
- **jan 23, 2025** (commit 52c123ec): jeremiah added docs including the delegates section
- **jan 29, 2025** (commit 34c33fa9): delegates field was removed from Agent during refactor
- **documentation was never updated** to reflect the removal

## solution

removed the "delegates" section from `docs/concepts/agents.mdx` that documented a non-existent parameter

note: the `delegates` concept still exists on the deprecated Team classes, but not on Agent

## test plan

- [x] confirmed `Agent(delegates=[...])` raises TypeError
- [x] verified actual Agent parameters don't include delegates
- [x] removed stale documentation section

fixes #1239

🤖 Generated with [Claude Code](https://claude.com/claude-code)