### PR TITLE
docs: replace all uv pip commands with uv add

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ Marvin provides an intuitive API for defining workflows and delegating work to L
 
 ## Installation
 
-Install `marvin`:
+Marvin is available on [PyPI](https://pypi.org/project/marvin/):
 
 ```bash
-uv pip install marvin
+uv add marvin
 ```
 
 Configure your LLM provider (Marvin uses OpenAI by default but natively supports [all Pydantic AI models](https://ai.pydantic.dev/models/)):

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -18,8 +18,6 @@ The easiest way to install Marvin is a package manager like `pip` or [`uv`](http
 ```bash uv
 # add marvin to your project
 uv add marvin
-# add marvin to your virtual environment
-uv pip install marvin
 # add marvin to your script
 uv add --script some_script.py marvin
 # run a python process with marvin installed ephemerally

--- a/docs/patterns/memory.mdx
+++ b/docs/patterns/memory.mdx
@@ -140,7 +140,7 @@ pip install "marvin[chroma]"
 ```
 
 ```bash uv
-uv pip install "marvin[chroma]"
+uv add "marvin[chroma]"
 ```
 </CodeGroup>
 
@@ -170,7 +170,7 @@ pip install "marvin[lance]"
 ```
 
 ```bash uv
-uv pip install "marvin[lance]"
+uv add "marvin[lance]"
 ```
 
 </CodeGroup>
@@ -198,7 +198,7 @@ pip install "marvin[postgres]"
 ```
 
 ```bash uv
-uv pip install "marvin[postgres]"
+uv add "marvin[postgres]"
 ```
 
 </CodeGroup>
@@ -229,7 +229,7 @@ pip install "marvin" "qdrant-client[fastembed]"
 ```
 
 ```bash uv
-uv pip install "marvin" "qdrant-client[fastembed]"
+uv add marvin "qdrant-client[fastembed]"
 ```
 
 </CodeGroup>
@@ -259,6 +259,6 @@ pip install "marvin[memory]"  # Includes chroma, lance, postgres, qdrant
 ```
 
 ```bash uv
-uv pip install "marvin[memory]"  # Includes chroma, lance, postgres and qdrant
+uv add "marvin[memory]"  # Includes chroma, lance, postgres and qdrant
 ```
 </CodeGroup>

--- a/examples/slackbot/README.md
+++ b/examples/slackbot/README.md
@@ -18,12 +18,8 @@ The slackbot can be run locally with minimal setup.
 ### Local Development
 
 ```console
-# Create and activate a virtual environment with uv
-uv venv --python 3.12
-source .venv/bin/activate
-
-# Install dependencies
-uv pip install -e ".[slackbot]" -U
+# Install dependencies (from the repo root)
+uv sync --extra slackbot
 ```
 
 ### Configuration


### PR DESCRIPTION
## summary

eliminates all `uv pip` usage from documentation and examples, replacing with proper `uv add` or `uv sync` commands

## background

per project guidelines, `uv pip` is forbidden. all dependency management should use `uv add`, `uv sync`, or `uv run`. the README and docs were still recommending `uv pip install` which is incorrect.

## changes

- **README.md**: changed installation from `uv pip install marvin` to `uv add marvin` and added PyPI link
- **docs/installation.mdx**: removed the redundant `uv pip install` line
- **docs/patterns/memory.mdx**: changed all 5 instances of `uv pip install` to `uv add`
- **examples/slackbot/README.md**: simplified from `uv pip install -e ".[slackbot]" -U` to `uv sync --extra slackbot`

## verification

ran `rg "uv pip"` across all md and py files - zero matches found

🤖 Generated with [Claude Code](https://claude.com/claude-code)