### PR TITLE
Add AIML API provider-specific example scripts

### DIFF
--- a/examples/provider_specific/aimlapi/run_agent.py
+++ b/examples/provider_specific/aimlapi/run_agent.py
@@ -1,0 +1,47 @@
+"""
+» AIML_API_KEY=your-api-key \
+uv run examples/provider_specific/aimlapi/run_agent.py
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from pydantic_ai.models.openai import OpenAIModel
+from pydantic_ai.providers.openai import OpenAIProvider
+
+import marvin
+
+AIML_API_URL = "https://api.aimlapi.com/v1"
+
+
+def get_provider() -> OpenAIProvider:
+    api_key = os.getenv("AIML_API_KEY")
+    if not api_key:
+        raise RuntimeError("Set AIML_API_KEY environment variable to your AI/ML API key.")
+    return OpenAIProvider(api_key=api_key, base_url=AIML_API_URL)
+
+
+def write_file(path: str, content: str) -> None:
+    """Write content to a file."""
+    Path(path).write_text(content)
+
+
+def main() -> None:
+    writer = marvin.Agent(
+        model=OpenAIModel("gpt-4o", provider=get_provider()),
+        name="AI/ML Writer",
+        instructions="Write concise, engaging content for developers",
+        tools=[write_file],
+    )
+
+    result = marvin.run(
+        "how to use pydantic? write haiku to docs.md",
+        agents=[writer],
+    )
+    print(result)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/provider_specific/aimlapi/structured_output.py
+++ b/examples/provider_specific/aimlapi/structured_output.py
@@ -1,0 +1,52 @@
+"""
+» AIML_API_KEY=your-api-key \
+uv run examples/provider_specific/aimlapi/structured_output.py
+"""
+
+from __future__ import annotations
+
+import os
+from typing_extensions import TypedDict
+
+from pydantic_ai.models.openai import OpenAIModel
+from pydantic_ai.providers.openai import OpenAIProvider
+
+import marvin
+
+AIML_API_URL = "https://api.aimlapi.com/v1"
+
+
+class LearningResource(TypedDict):
+    title: str
+    url: str
+    summary: str
+
+
+def get_provider() -> OpenAIProvider:
+    api_key = os.getenv("AIML_API_KEY")
+    if not api_key:
+        raise RuntimeError("Set AIML_API_KEY environment variable to your AI/ML API key.")
+    return OpenAIProvider(api_key=api_key, base_url=AIML_API_URL)
+
+
+def main() -> None:
+    researcher = marvin.Agent(
+        model=OpenAIModel("gpt-4o", provider=get_provider()),
+        name="Resource Researcher",
+        instructions=(
+            "Return structured JSON describing useful developer resources for the AI/ML API."
+        ),
+    )
+
+    resources = marvin.run(
+        "share three quickstart resources for building with the AI/ML API",
+        result_type=list[LearningResource],
+        agents=[researcher],
+    )
+
+    for resource in resources:
+        print(f"- {resource['title']}\n  {resource['url']}\n  {resource['summary']}\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/provider_specific/aimlapi/tools_agent.py
+++ b/examples/provider_specific/aimlapi/tools_agent.py
@@ -1,0 +1,56 @@
+"""
+» AIML_API_KEY=your-api-key \
+uv run examples/provider_specific/aimlapi/tools_agent.py
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import date, timedelta
+
+from pydantic_ai.models.openai import OpenAIModel
+from pydantic_ai.providers.openai import OpenAIProvider
+
+import marvin
+
+AIML_API_URL = "https://api.aimlapi.com/v1"
+
+
+def get_provider() -> OpenAIProvider:
+    api_key = os.getenv("AIML_API_KEY")
+    if not api_key:
+        raise RuntimeError("Set AIML_API_KEY environment variable to your AI/ML API key.")
+    return OpenAIProvider(api_key=api_key, base_url=AIML_API_URL)
+
+
+def get_event_date(offset_days: int = 0) -> str:
+    """Return an ISO formatted date offset from today."""
+    today = date.today()
+    return (today + timedelta(days=offset_days)).isoformat()
+
+
+def mock_weather_lookup(city: str) -> str:
+    """Pretend to look up weather for a city."""
+    return f"The forecast in {city} calls for mild temperatures and light winds."
+
+
+def main() -> None:
+    planner = marvin.Agent(
+        model=OpenAIModel("gpt-4o", provider=get_provider()),
+        name="AI/ML Event Planner",
+        instructions=(
+            "Plan concise community events for AI/ML API enthusiasts."
+            " Use the available tools for dates and weather when helpful."
+        ),
+        tools=[get_event_date, mock_weather_lookup],
+    )
+
+    plan = marvin.run(
+        "Design a Saturday workshop introducing the AI/ML API in Berlin",
+        agents=[planner],
+    )
+    print(plan)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Added three example scripts under examples/provider_specific/aimlapi: run_agent.py demonstrates agent execution and file writing, structured_output.py shows structured JSON output for developer resources, and tools_agent.py illustrates tool-using agents for event planning.

From pr https://github.com/PrefectHQ/marvin/pull/1217 and issue https://github.com/PrefectHQ/marvin/issues/1171