### PR TITLE
fix: install claude code CLI in slackbot docker image

### DIFF
--- a/examples/slackbot/Dockerfile.slackbot
+++ b/examples/slackbot/Dockerfile.slackbot
@@ -1,6 +1,7 @@
 FROM python:3.13-slim
 
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+COPY --from=oven/bun:latest /usr/local/bin/bun /usr/local/bin/bun
 
 WORKDIR /app
 
@@ -8,10 +9,16 @@ COPY . /app
 
 RUN apt-get update && \
     apt-get install -y git build-essential curl && \
+    curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
+    apt-get install -y nodejs && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-RUN uv sync --extra slackbot --no-dev 
+RUN uv sync --extra slackbot --no-dev
+
+RUN bun install -g @anthropic-ai/claude-code
+
+ENV PATH="/root/.bun/bin:${PATH}"
 
 EXPOSE 4200
 


### PR DESCRIPTION
## summary

fixes the `CLINotFoundError` that occurs when the slackbot's research agent tries to use the claude agent SDK. PR #1244 integrated the SDK but didn't install the required `@anthropic-ai/claude-code` CLI in the docker image.

## changes

- copy bun binary from official `oven/bun:latest` image
- install nodejs 20.x from nodesource (required by claude CLI)
- install `@anthropic-ai/claude-code` globally via bun
- add `/root/.bun/bin` to PATH for CLI access

## verification

tested in the built image:
```bash
$ docker run --rm marvin-slackbot claude --version
2.0.43 (Claude Code)

$ docker run --rm marvin-slackbot which claude
/root/.bun/bin/claude
```

## error fixed

```
CLINotFoundError: Claude Code not found. Install with:
  npm install -g @anthropic-ai/claude-code
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)