### PR TITLE
feat: integrate learning-sdk into slackbot for persistent memory

### DIFF
--- a/examples/slackbot/pyproject.toml
+++ b/examples/slackbot/pyproject.toml
@@ -42,6 +42,7 @@ dependencies = [
   "raggy[tpuf] @ git+https://github.com/zzstoatzz/raggy.git",
   "pretty-mod",
   "claude-agent-sdk",
+  "agentic-learning",
 ]
 
 

--- a/examples/slackbot/src/slackbot/settings.py
+++ b/examples/slackbot/src/slackbot/settings.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from typing import ClassVar, Literal
 
 from prefect.blocks.system import Secret
+from prefect.exceptions import ObjectNotFound
 from prefect.variables import Variable
 from pydantic import Field, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -56,6 +57,10 @@ class SlackbotSettings(BaseSettings):
         default="anthropic-api-key",
         description="Name of the Prefect secret block containing Anthropic API key",
     )
+    letta_api_key_secret_name: str = Field(
+        default="letta-api-key",
+        description="Name of the Prefect secret block containing Letta API key",
+    )
 
     vector_store_type: Literal["turbopuffer"] = Field(
         default="turbopuffer", description="Type of vector store to use"
@@ -94,6 +99,12 @@ class SlackbotSettings(BaseSettings):
                 os.environ["TURBOPUFFER_API_KEY"] = api_key
             except Exception:
                 pass  # If secret doesn't exist, turbopuffer will handle the error
+        if not os.getenv("LETTA_API_KEY"):
+            try:
+                api_key = Secret.load(self.letta_api_key_secret_name, _sync=True).get()  # type: ignore
+                os.environ["LETTA_API_KEY"] = api_key
+            except ObjectNotFound:
+                pass  # If secret doesn't exist, learning-sdk won't be used
         if not self.admin_slack_user_id:
             self.admin_slack_user_id = Variable.get("admin-slack-id", _sync=True)
         return self

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,6 +96,9 @@ extend-select = ["I"]
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F401", "I001", "RUF013"]
 
+[tool.uv]
+prerelease = "allow"
+
 [tool.uv.sources]
 slackbot = { workspace = true }
 


### PR DESCRIPTION
## Summary
- Add `letta_api_key_secret_name` setting to load Letta API key from Prefect secrets
- Wrap agent run with `learning()` context manager for persistent memory
- Add `agentic-learning` dependency to slackbot

Each Slack user gets their own memory agent (`slackbot-{user_id}`), enabling cross-session learning.

## Test plan
- [ ] Create Prefect secret block `letta-api-key` with Letta API key
- [ ] Deploy slackbot and verify memory persists across conversations
- [ ] Test that different users have separate memory contexts

🤖 Generated with [Claude Code](https://claude.com/claude-code)