### PR TITLE
remove channel restrictions from slackbot

### DIFF
--- a/examples/slackbot/src/slackbot/_internal/constants.py
+++ b/examples/slackbot/src/slackbot/_internal/constants.py
@@ -1,4 +1,1 @@
-WORKSPACE_TO_CHANNEL_ID = {
-    "TAN3D79AL": "C046WGGKF4P",  # Prefect -> #ask-marvin-tests
-    "T03S63K44P6": "C03S3HZ2X3M",  # Stoat LLC -> #testing-slackbots
-}
+WORKSPACE_TO_CHANNEL_ID: dict[str, str] = {}


### PR DESCRIPTION
## Summary
- Remove workspace-to-channel mapping that restricted Marvin to only respond in designated channels
- Now Marvin will respond in any channel where it's mentioned

🤖 Generated with [Claude Code](https://claude.com/claude-code)