### PR TITLE
fix: dispose engine after import-time table creation

### DIFF
--- a/docs/api-reference/marvin-database.mdx
+++ b/docs/api-reference/marvin-database.mdx
@@ -120,15 +120,16 @@ Custom type for Usage objects that stores them as JSON in the database.
 
 ### `create_db_and_tables`
 ```python
-def create_db_and_tables(force: bool = False)
+def create_db_and_tables(force: bool = False, dispose_engine: bool = False)
 ```
-Create all database tables synchronously.
-
-This is a synchronous alternative to create_db_and_tables() that can be used
-in contexts where asyncio.run() cannot be called.
+Create all database tables.
 
 Args:
     force: If True, drops all existing tables before creating new ones.
+    dispose_engine: If True, dispose the engine after creating tables.
+        This is useful when called from asyncio.run() to ensure the
+        aiosqlite worker thread is cleaned up and doesn't prevent
+        Python from exiting.
 
 ### `ensure_db_tables_exist`
 ```python


### PR DESCRIPTION
## Summary
- fixes #1255 - process hangs on exit after importing marvin
- adds `dispose_engine` parameter to `create_db_and_tables()` to clean up the aiosqlite worker thread
- `ensure_db_tables_exist()` now disposes the engine after table creation to prevent hanging

## Background
When marvin is imported, `ensure_db_tables_exist()` runs `asyncio.run(create_db_and_tables())`. This creates an async engine that gets cached. The underlying aiosqlite connection spawns a worker thread that could prevent Python from exiting cleanly if not properly disposed.

## Changes
- Added `dispose_engine: bool = False` parameter to `create_db_and_tables()`
- When `dispose_engine=True`, the engine is disposed and removed from the cache after table creation
- Updated `ensure_db_tables_exist()` to pass `dispose_engine=True` when called from import

## Test plan
- [x] Added regression test `test_create_db_and_tables_with_dispose_cleans_up_engine`
- [x] Verified with reproduction script that no non-daemon threads remain after import
- [x] All existing database tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)