### PR TITLE
fix(fns): resolve return annotations with `from __future__ import annotations`

### DIFF
--- a/src/marvin/utilities/types.py
+++ b/src/marvin/utilities/types.py
@@ -14,6 +14,7 @@ from typing import (
     TypeVar,
     get_args,
     get_origin,
+    get_type_hints,
 )
 
 from marvin.utilities.asyncio import run_sync
@@ -270,6 +271,15 @@ def issubclass_safe(x: Any, cls: type | tuple[type, ...]) -> bool:
     return False
 
 
+def _resolve_return_annotation(func: Callable[..., Any], sig: inspect.Signature) -> Any:
+    """Resolve return annotation, handling PEP 563 stringified annotations."""
+    try:
+        hints = get_type_hints(func)
+        return hints["return"]
+    except (KeyError, NameError, AttributeError, TypeError):
+        return sig.return_annotation
+
+
 @dataclass
 class ParameterModel:
     name: str
@@ -362,7 +372,7 @@ class PythonFunction(Generic[P, R]):
             "name": name,
             "docstring": inspect.cleandoc(docstring) if docstring else None,
             "parameters": parameters,
-            "return_annotation": sig.return_annotation,
+            "return_annotation": _resolve_return_annotation(func, sig),
             "source_code": source_code,
         }
 

--- a/tests/basic/utilities/_future_annotations_helper.py
+++ b/tests/basic/utilities/_future_annotations_helper.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class FutureModel(BaseModel):
+    value: str
+
+
+def build_future_model() -> FutureModel:
+    return FutureModel(value="x")

--- a/tests/basic/utilities/test_types.py
+++ b/tests/basic/utilities/test_types.py
@@ -1,12 +1,19 @@
 import enum
+import inspect
 from typing import Literal
 
 import pytest
+from pydantic import BaseModel
 
 from marvin.utilities.types import (
     Labels,
+    PythonFunction,
     as_classifier,
     is_classifier,
+)
+from tests.basic.utilities._future_annotations_helper import (
+    FutureModel,
+    build_future_model,
 )
 
 
@@ -132,3 +139,35 @@ class TestClassification:
             1: "42",
             2: "True",
         }
+
+
+class TestPythonFunctionAnnotations:
+    def test_resolves_string_return_annotations(self):
+        python_function = PythonFunction.from_function(build_future_model)
+        assert python_function.return_annotation is FutureModel
+
+    def test_works_normally_without_future_annotations(self):
+        class PlainModel(BaseModel): ...
+
+        def build_plain_model() -> PlainModel:
+            return PlainModel()
+
+        python_function = PythonFunction.from_function(build_plain_model)
+        assert python_function.return_annotation is PlainModel
+
+    def test_no_return_annotation_returns_empty(self):
+        def no_return_annotation():
+            pass
+
+        python_function = PythonFunction.from_function(no_return_annotation)
+        assert python_function.return_annotation is inspect.Signature.empty
+
+    def test_unresolvable_forward_ref_falls_back(self):
+        """When get_type_hints cannot resolve a forward ref, fall back to sig.return_annotation."""
+        # Simulate a function with a string annotation that cannot be resolved
+        def unresolvable() -> "NonExistentType":  # noqa: F821
+            pass
+
+        python_function = PythonFunction.from_function(unresolvable)
+        # Should fall back to the string annotation rather than crashing
+        assert python_function.return_annotation == "NonExistentType"


### PR DESCRIPTION
## Summary

Fixes #950

When `from __future__ import annotations` ([PEP 563](https://peps.python.org/pep-0563/)) is active in a module, all type annotations become strings at runtime. `PythonFunction.from_function()` reads `sig.return_annotation` directly, which returns a string like `"Recipe"` instead of the actual `Recipe` class. This causes `@marvin.fn` decorated functions to produce string outputs instead of typed Pydantic model instances.

## Root Cause

`inspect.signature(func).return_annotation` returns the raw annotation value. Under PEP 563, annotations are stored as strings and not evaluated until explicitly resolved. The fix at `src/marvin/utilities/types.py:372` was using this raw value without resolution.

## Changes

- `src/marvin/utilities/types.py`: Add `_resolve_return_annotation()` helper that uses `typing.get_type_hints()` to resolve stringified annotations, with a fallback to `sig.return_annotation` when resolution fails (handles unresolvable forward refs, built-in functions, etc.)
- `tests/basic/utilities/test_types.py`: Add 4 tests covering: future annotations resolution, normal annotations, no annotation, and unresolvable forward ref fallback
- `tests/basic/utilities/_future_annotations_helper.py`: Test helper module with `from __future__ import annotations` active

## Testing

- [x] All 263 existing + new tests pass (no regressions)
- [x] Bug reproduction confirmed fixed
- [x] Ruff lint passes
- [x] Unresolvable forward ref gracefully falls back

```bash
# Verify:
uv run pytest tests/basic/utilities/test_types.py -v
```

## Notes

Minimal fix — only changes the annotation resolution path. No unrelated changes. The approach follows the same `typing.get_type_hints()` strategy suggested in #1258. The exception handler is narrowed to `KeyError | NameError | AttributeError | TypeError` to avoid masking unexpected errors.