### PR TITLE
fix(slackbot): tolerate MCP toolset connection failures

### DIFF
--- a/examples/slackbot/src/slackbot/_internal/tolerant_toolset.py
+++ b/examples/slackbot/src/slackbot/_internal/tolerant_toolset.py
@@ -1,0 +1,86 @@
+"""toolset wrapper that degrades to no-op if the underlying toolset can't connect.
+
+motivation: pydantic-ai opens MCP toolsets at the start of every `agent.run()`.
+when the upstream MCP server is slow to respond (cold start, transient outage),
+the toolset's `__aenter__` raises a TimeoutError wrapped in nested ExceptionGroups
+and the entire agent run fails. that's a bad trade for an optional toolset —
+we'd rather lose access to those tools for one run than fail the whole answer.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+
+from pydantic_ai._run_context import AgentDepsT, RunContext
+from pydantic_ai.toolsets import AbstractToolset, ToolsetTool
+
+
+class TolerantToolset(AbstractToolset[AgentDepsT]):
+    """Wrap a toolset so that connection failures degrade to an empty toolset.
+
+    if the inner toolset's `__aenter__` raises (e.g. MCP initialize timeout),
+    `get_tools()` returns `{}` for the duration of the run and `call_tool()`
+    will raise — but the agent has no tool defs so it won't try to call any.
+    each new `__aenter__` re-attempts the connection, so transient failures
+    don't permanently disable the toolset.
+    """
+
+    def __init__(
+        self,
+        inner: AbstractToolset[AgentDepsT],
+        *,
+        on_error: Callable[[BaseException], None] | None = None,
+    ) -> None:
+        self._inner = inner
+        self._on_error = on_error
+        self._available = False
+
+    @property
+    def id(self) -> str | None:
+        return self._inner.id
+
+    @property
+    def label(self) -> str:
+        return f"Tolerant({self._inner.label})"
+
+    async def __aenter__(self) -> "TolerantToolset[AgentDepsT]":
+        try:
+            await self._inner.__aenter__()
+            self._available = True
+        except BaseException as e:  # includes ExceptionGroup from anyio task groups
+            self._available = False
+            if self._on_error is not None:
+                self._on_error(e)
+        return self
+
+    async def __aexit__(self, *args: Any) -> bool | None:
+        if not self._available:
+            return None
+        try:
+            return await self._inner.__aexit__(*args)
+        except BaseException as e:
+            if self._on_error is not None:
+                self._on_error(e)
+            return None
+
+    async def get_tools(
+        self, ctx: RunContext[AgentDepsT]
+    ) -> dict[str, ToolsetTool[AgentDepsT]]:
+        if not self._available:
+            return {}
+        try:
+            return await self._inner.get_tools(ctx)
+        except BaseException as e:
+            if self._on_error is not None:
+                self._on_error(e)
+            return {}
+
+    async def call_tool(
+        self,
+        name: str,
+        tool_args: dict[str, Any],
+        ctx: RunContext[AgentDepsT],
+        tool: ToolsetTool[AgentDepsT],
+    ) -> Any:
+        # only reachable when get_tools returned a non-empty dict, i.e. _available is True
+        return await self._inner.call_tool(name, tool_args, ctx, tool)

--- a/examples/slackbot/src/slackbot/core.py
+++ b/examples/slackbot/src/slackbot/core.py
@@ -19,6 +19,7 @@ from raggy.vectorstores.tpuf import TurboPuffer
 from slackbot._internal.personalization import load_personalization_snapshot
 from slackbot._internal.prompting import build_system_prompt
 from slackbot._internal.templates import DEFAULT_SYSTEM_PROMPT
+from slackbot._internal.tolerant_toolset import TolerantToolset
 from slackbot.assets import store_user_facts
 from slackbot.github import (
     GitHubAuthError,
@@ -162,6 +163,14 @@ def create_agent(
     slack_search_mcp = MCPServerStreamableHTTP(
         url="https://marvin-slack-thread-assets.fastmcp.app/mcp",
     )
+    tolerant_slack_search = TolerantToolset(
+        slack_search_mcp,
+        on_error=lambda e: logger.warning(
+            "slack-search MCP unavailable for this run: %s: %s",
+            type(e).__name__,
+            e,
+        ),
+    )
     agent = Agent[
         UserContext, str
     ](
@@ -175,7 +184,7 @@ def create_agent(
             check_cli_command,  # verify CLI commands before suggesting them
             get_latest_prefect_release_notes,  # get the latest release notes for Prefect
         ],
-        toolsets=[slack_search_mcp],  # search Prefect community Slack threads
+        toolsets=[tolerant_slack_search],  # search Prefect community Slack threads
         deps_type=UserContext,
     )
 


### PR DESCRIPTION
## Summary
- Add `TolerantToolset` wrapper around `AbstractToolset` — when the inner toolset's `__aenter__` raises (e.g. MCP `initialize` timeout from a cold-starting fastmcp.app endpoint), the wrapper catches the failure, logs it via an `on_error` callback, and degrades to an empty toolset for that run instead of aborting the entire agent run.
- Wrap the `marvin-slack-thread-assets` MCP toolset with `TolerantToolset` in `core.py:create_agent()`.

## Why
A real failure in production: an `ExceptionGroup → ExceptionGroup → TimeoutError` from the slack-thread-search MCP `initialize` handshake aborted a Slackbot run, posting `❌ Error: unhandled errors in a TaskGroup (1 sub-exception)` to the user. The MCP server is optional context — losing access to thread search is fine; losing the whole answer isn't.

Each new `__aenter__` re-attempts the inner toolset's connection, so transient outages don't permanently disable it.

## Test plan
- [x] `repros/resilient_toolset_test.py` (local, gitignored) covers three cases against the same nested-`ExceptionGroup` shape we saw in prod:
  - failure path: wrapper degrades, `get_tools() == {}`, `on_error` fires once
  - success path: wrapper transparently delegates `get_tools` and `call_tool`
  - recovery path: after a failure, the next `__aenter__` re-tries and succeeds
- [x] Slackbot still imports cleanly (`from slackbot.core import create_agent`)
- [ ] Watch for `WARNING: slack-search MCP unavailable for this run: ...` in Prefect Cloud logs after deploy — that's the new visibility into transient MCP failures we previously lost in the generic TaskGroup wrapper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)