### PR TITLE
feat(slackbot): persist thread history in a WritableFileSystem block

### DIFF
--- a/examples/slackbot/src/slackbot/_internal/message_store.py
+++ b/examples/slackbot/src/slackbot/_internal/message_store.py
@@ -1,0 +1,96 @@
+"""Durable per-thread storage for pydantic-ai `ModelMessage` history.
+
+The bot used to persist conversation history in a SQLite file on the
+container's local disk. On Cloud Run that disk is ephemeral — every revision
+deploy wiped the history, and ad-hoc retrieval ("what did marvin actually say
+in thread X?") required shelling into a running container.
+
+This module replaces that with a `WritableFileSystem`-backed store. Each
+thread's full `ModelMessage` list lives in a single JSON object keyed by
+thread_ts. Writes overwrite the whole object, protected by an in-process
+per-thread `asyncio.Lock` to keep concurrent turns in the same thread from
+clobbering each other (the bot is currently single-instance, so an in-process
+lock is sufficient — if we move to multiple replicas this needs to become a
+distributed lock or compare-and-swap, but that's not today's problem).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections import defaultdict
+from pathlib import Path
+
+from prefect.blocks.core import Block
+from prefect.filesystems import LocalFileSystem, WritableFileSystem
+from prefect.logging.loggers import get_logger
+from pydantic_ai.messages import ModelMessage, ModelMessagesTypeAdapter
+
+logger = get_logger(__name__)
+
+
+async def load_message_store(block_slug: str | None, local_dir: Path) -> "MessageStore":
+    """Construct a `MessageStore` from settings.
+
+    If `block_slug` is set, load that `WritableFileSystem` block from the
+    Prefect workspace (e.g. `gcs-bucket/marvin-chat-history` in prod/stg).
+    Otherwise fall back to a `LocalFileSystem` rooted at `local_dir` — fine
+    for local dev, not durable in Cloud Run.
+    """
+    if block_slug:
+        block = await Block.aload(block_slug)
+        if not isinstance(block, WritableFileSystem):
+            raise TypeError(
+                f"Block {block_slug!r} is not a WritableFileSystem "
+                f"(got {type(block).__name__})"
+            )
+        logger.info("Using message store block %s", block_slug)
+        return MessageStore(block)
+
+    local_dir.mkdir(parents=True, exist_ok=True)
+    logger.info("Using local message store at %s", local_dir)
+    return MessageStore(LocalFileSystem(basepath=str(local_dir)))
+
+
+def _thread_key(thread_ts: str) -> str:
+    return f"threads/{thread_ts}.json"
+
+
+class MessageStore:
+    """A thin per-thread message archive over a `WritableFileSystem` block."""
+
+    def __init__(self, fs: WritableFileSystem) -> None:
+        self._fs = fs
+        self._locks: defaultdict[str, asyncio.Lock] = defaultdict(asyncio.Lock)
+
+    async def get(self, thread_ts: str) -> list[ModelMessage]:
+        """Return the full message history for a thread, or [] if none stored."""
+        try:
+            data = await self._fs.aread_path(_thread_key(thread_ts))  # type: ignore[attr-defined]
+        except (FileNotFoundError, ValueError):
+            # LocalFileSystem raises ValueError("Path ... does not exist."),
+            # cloud impls typically raise FileNotFoundError. Treat both as "empty".
+            return []
+        except Exception:
+            logger.exception("Failed to read message history for thread %s", thread_ts)
+            raise
+        if not data:
+            return []
+        return list(ModelMessagesTypeAdapter.validate_json(data))
+
+    async def append(
+        self, thread_ts: str, new_messages: list[ModelMessage]
+    ) -> list[ModelMessage]:
+        """Append `new_messages` to the thread's history and return the full list.
+
+        Read-modify-write under a per-thread lock so two overlapping turns
+        in the same thread don't clobber each other.
+        """
+        if not new_messages:
+            return await self.get(thread_ts)
+
+        async with self._locks[thread_ts]:
+            existing = await self.get(thread_ts)
+            combined = existing + list(new_messages)
+            dumped = ModelMessagesTypeAdapter.dump_json(combined)
+            await self._fs.awrite_path(_thread_key(thread_ts), dumped)  # type: ignore[attr-defined]
+            return combined

--- a/examples/slackbot/src/slackbot/api.py
+++ b/examples/slackbot/src/slackbot/api.py
@@ -16,6 +16,7 @@ from pydantic_ai.agent import AgentRunResult
 from pydantic_ai.messages import ModelMessage
 
 from slackbot._internal.constants import WORKSPACE_TO_CHANNEL_ID
+from slackbot._internal.message_store import MessageStore, load_message_store
 from slackbot._internal.templates import CHANNEL_REDIRECT_MESSAGE, WELCOME_MESSAGE
 from slackbot._internal.thread_status import (
     get_status as get_thread_status,
@@ -155,7 +156,9 @@ def _extract_message_context(event: Any) -> tuple[bool, str | None, str | None, 
 
 
 @flow(name="Handle Slack Message", retries=1)
-async def handle_message(payload: SlackPayload, db: Database):
+async def handle_message(
+    payload: SlackPayload, db: Database, message_store: MessageStore
+):
     logger = get_run_logger()
     event = payload.event
     if not event or not all([event.text, event.channel, (event.thread_ts or event.ts)]):
@@ -244,7 +247,7 @@ async def handle_message(payload: SlackPayload, db: Database):
         logger.info(
             f"Processing message in thread {thread_ts}\nUser message: {cleaned_message}"
         )
-        conversation = await db.get_thread_messages(thread_ts)
+        conversation = await message_store.get(thread_ts)
 
         bot_user_id = None
         if payload.authorizations:
@@ -272,8 +275,9 @@ async def handle_message(payload: SlackPayload, db: Database):
                 thread_ts,
             )  # type: ignore
 
-            await db.add_thread_messages(thread_ts, result.new_messages())
-            conversation.extend(result.new_messages())
+            conversation = await message_store.append(
+                thread_ts, list(result.new_messages())
+            )
             assert event.channel is not None, "No channel found"
             await task(post_slack_message)(
                 message=result.output,
@@ -321,8 +325,12 @@ async def summarize_thread_so_far(flow: Flow, flow_run: FlowRun, state: State[An
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
+    message_store = await load_message_store(
+        settings.message_store_block, settings.message_store_local_dir
+    )
     async with Database.connect(settings.db_file) as db:
         app.state.db = db
+        app.state.message_store = message_store
         yield
 
 
@@ -343,6 +351,7 @@ async def chat_endpoint(request: Request) -> dict[str, Any]:
         raise HTTPException(400, "Invalid event type")
 
     db: Database = request.app.state.db
+    message_store: MessageStore = request.app.state.message_store
 
     if payload.type == "event_callback":
         if not payload.event:
@@ -377,7 +386,9 @@ async def chat_endpoint(request: Request) -> dict[str, Any]:
                 flow_run_name=f"respond in {channel_name}/{ts}",
             )
 
-            asyncio.create_task(handle_message.with_options(**flow_opts)(payload, db))
+            asyncio.create_task(
+                handle_message.with_options(**flow_opts)(payload, db, message_store)
+            )
     elif payload.type == "url_verification":
         return {"challenge": payload.challenge}
     else:

--- a/examples/slackbot/src/slackbot/core.py
+++ b/examples/slackbot/src/slackbot/core.py
@@ -11,7 +11,6 @@ from prefect import get_run_logger, task
 from prefect.logging.loggers import get_logger
 from pydantic_ai import Agent, RunContext
 from pydantic_ai.mcp import MCPServerStreamableHTTP
-from pydantic_ai.messages import ModelMessage, ModelMessagesTypeAdapter
 from pydantic_ai.models import KnownModelName, Model
 from pydantic_ai.settings import ModelSettings
 from raggy.vectorstores.tpuf import TurboPuffer
@@ -48,7 +47,12 @@ logger = get_logger(__name__)
 
 @dataclass
 class Database:
-    """Minimal async wrapper for a SQLite DB storing Slack thread conversations."""
+    """Minimal async wrapper around a SQLite connection.
+
+    Used by `_internal/thread_status.py` for cross-process dedup state
+    (the `slack_thread_status` table). Thread message history lives in a
+    `WritableFileSystem` block — see `_internal/message_store.py`.
+    """
 
     con: sqlite3.Connection
     loop: asyncio.AbstractEventLoop
@@ -62,18 +66,7 @@ class Database:
         executor = ThreadPoolExecutor(max_workers=1)
 
         def init_db():
-            con = sqlite3.connect(str(file))
-            con.execute(
-                """
-                CREATE TABLE IF NOT EXISTS slack_thread_messages (
-                    id INTEGER PRIMARY KEY AUTOINCREMENT,
-                    thread_ts TEXT NOT NULL,
-                    message_list TEXT NOT NULL
-                );
-                """
-            )
-            con.commit()
-            return con
+            return sqlite3.connect(str(file))
 
         con = await loop.run_in_executor(executor, init_db)
         logger.debug("Database initialized")
@@ -88,46 +81,6 @@ class Database:
             await loop.run_in_executor(executor, cleanup)
             executor.shutdown(wait=True)
             logger.debug("Database connection closed")
-
-    async def get_thread_messages(self, thread_ts: str) -> list[ModelMessage]:
-        def _query():
-            c = self.con.cursor()
-            c.execute(
-                """
-                SELECT message_list FROM slack_thread_messages
-                WHERE thread_ts = ?
-                ORDER BY id ASC
-                """,
-                (thread_ts,),
-            )
-            return c.fetchall()
-
-        rows = await self.loop.run_in_executor(self.executor, _query)
-        conversation: list[ModelMessage] = []
-        for (message_json,) in rows:
-            conversation.extend(ModelMessagesTypeAdapter.validate_json(message_json))
-        return conversation
-
-    async def add_thread_messages(
-        self, thread_ts: str, messages: list[ModelMessage]
-    ) -> None:
-        dumped = ModelMessagesTypeAdapter.dump_json(messages)
-
-        def _insert():
-            cur = self.con.cursor()
-            cur.execute(
-                """
-                INSERT INTO slack_thread_messages (thread_ts, message_list)
-                VALUES (?, ?)
-                """,
-                (thread_ts, dumped),
-            )
-            self.con.commit()
-
-        await self.loop.run_in_executor(self.executor, _insert)
-
-    # Note: Thread status tracking is handled in-process within api.py to keep
-    # persistence minimal for the examples package.
 
 
 @task(task_run_name="build user context for {user_id}")

--- a/examples/slackbot/src/slackbot/settings.py
+++ b/examples/slackbot/src/slackbot/settings.py
@@ -30,7 +30,29 @@ class SlackbotSettings(BaseSettings):
 
     # Existing settings...
     db_file: Path = Field(
-        default=Path("marvin_chat.sqlite"), description="Path to SQLite database file"
+        default=Path("marvin_chat.sqlite"),
+        description=(
+            "Path to SQLite database file. Used for ephemeral thread_status dedup "
+            "state only; durable thread message history is stored via "
+            "`message_store_block` (see below)."
+        ),
+    )
+
+    message_store_block: str | None = Field(
+        default=None,
+        description=(
+            "Slug of a Prefect `WritableFileSystem` block used to persist "
+            "thread message history (e.g. 'gcs-bucket/marvin-chat-history'). "
+            "If unset, falls back to a `LocalFileSystem` rooted at "
+            "`message_store_local_dir` — fine for dev, not durable in Cloud Run."
+        ),
+    )
+    message_store_local_dir: Path = Field(
+        default=Path("./marvin_chat_storage"),
+        description=(
+            "Local directory used as the message-store fallback when "
+            "`message_store_block` is unset."
+        ),
     )
 
     temperature: float = Field(


### PR DESCRIPTION
## Summary
- Replace the local SQLite `slack_thread_messages` table with a per-thread JSON archive stored in a Prefect `WritableFileSystem` block, configured via `MARVIN_SLACKBOT_MESSAGE_STORE_BLOCK`.
- Defaults to a `LocalFileSystem` rooted at `MARVIN_SLACKBOT_MESSAGE_STORE_LOCAL_DIR` (`./marvin_chat_storage` by default) so local dev keeps working unchanged.
- Thread message history now survives Cloud Run revision deploys and is readable from anywhere with workspace access (no more shelling into the container to inspect a thread).

## Why
The SQLite file lived at `marvin_chat.sqlite` on the container's working directory — Cloud Run ephemeral disk. Every redeploy wiped it. There was also no programmatic path to retrieve what marvin said in a thread short of opening Slack or hitting the container's disk directly. Pointing the store at a workspace-owned bucket block fixes both at once.

## Design
- `_internal/message_store.py` wraps a `WritableFileSystem` block. One JSON object per thread, keyed `threads/{thread_ts}.json`, containing the full `ModelMessage[]` (the same shape we already write today, just keyed and overwritten instead of append-rows).
- Writes do read-modify-write under a per-thread `asyncio.Lock` so two overlapping turns in the same thread don't clobber each other. The bot is single-instance on Cloud Run today; if we move to multi-replica we'll need a distributed primitive (CAS or external lock) — flagged in the module docstring.
- The `Database` class is preserved for the ephemeral `slack_thread_status` table (cross-process dedup state where losing it on redeploy is fine).

## Deploy steps (per environment)
This PR is safe to merge to `main` and deploy to **stg** before prd:

1. Install a GCS backend in the runtime image. Either:
   - `prefect-gcp` (for a `gcs-bucket/...` block that references our existing `gcp-credentials` block), or
   - `gcsfs` (for a `remote-file-system/...` block with a `gs://` basepath)
   
   Not added to slackbot pyproject in this PR because both transitively trip a `pydantic-ai`/`mistralai` resolution conflict on this workspace. Suggest adding via the Dockerfile or as a build-time install instead.
2. Create the storage block in the workspace (e.g. `gcs-bucket/marvin-chat-history`).
3. Set `MARVIN_SLACKBOT_MESSAGE_STORE_BLOCK=<slug>` on the Cloud Run service.

Without those steps the bot still runs — it falls back to `LocalFileSystem` (which on Cloud Run means ephemeral disk again, i.e. the current behavior). So a no-op rollout is also safe.

## Test plan
- [x] Lint + format pass (`ruff check`, `ruff format --check`).
- [x] Smoke test against `LocalFileSystem`: empty thread returns `[]`, single-turn round-trips with message types preserved, multi-turn accumulates, **concurrent appends to the same thread serialize cleanly via the per-thread lock**, separate threads are isolated. (Local script, not checked in.)
- [x] `slackbot.api` imports clean after the changes.
- [ ] Deploy to stg, send a few mentions in a test thread, confirm history persists across a redeploy.
- [ ] Verify `gs://<bucket>/threads/<thread_ts>.json` is readable from outside the bot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)