### PR TITLE
feat(slackbot): wire message-store block via Prefect Variable + handle GCS NotFound

### DIFF
--- a/examples/slackbot/src/slackbot/_internal/message_store.py
+++ b/examples/slackbot/src/slackbot/_internal/message_store.py
@@ -24,6 +24,17 @@ from pydantic_ai.messages import ModelMessage, ModelMessagesTypeAdapter
 
 logger = get_logger(__name__)
 
+# Backends raise their own "not found" exception types — collect them so
+# `MessageStore.get` can treat a missing thread uniformly as []. Imported
+# defensively so this module doesn't hard-require any particular backend.
+_NOT_FOUND_EXCEPTIONS: tuple[type[BaseException], ...] = (FileNotFoundError,)
+try:
+    from google.api_core.exceptions import NotFound as _GcsNotFound
+
+    _NOT_FOUND_EXCEPTIONS = (*_NOT_FOUND_EXCEPTIONS, _GcsNotFound)
+except ImportError:
+    pass
+
 # Slack thread_ts is always `<seconds>.<microseconds>`, e.g. "1778543248.702039".
 # We use it directly as a filesystem path key — validate strictly so a caller
 # can't supply `../...` or absolute paths and influence what the store
@@ -81,7 +92,7 @@ class MessageStore:
         key = _thread_key(thread_ts)
         try:
             data = await self._fs.aread_path(key)  # type: ignore[attr-defined]
-        except FileNotFoundError:
+        except _NOT_FOUND_EXCEPTIONS:
             return []
         except ValueError as e:
             # LocalFileSystem signals missing files with `ValueError("Path ...

--- a/examples/slackbot/src/slackbot/settings.py
+++ b/examples/slackbot/src/slackbot/settings.py
@@ -118,6 +118,15 @@ class SlackbotSettings(BaseSettings):
                 pass  # If secret doesn't exist, turbopuffer will handle the error
         if not self.admin_slack_user_id:
             self.admin_slack_user_id = Variable.get("admin-slack-id", _sync=True)
+        if self.message_store_block is None:
+            # Allow the message-store block slug to be configured via a Prefect
+            # Variable so we don't have to round-trip through Cloud Run env-var
+            # changes for it.
+            self.message_store_block = Variable.get(
+                "marvin_message_store_block",
+                default=None,
+                _sync=True,  # type: ignore
+            )
         return self
 
     @property


### PR DESCRIPTION
Follow-up to #1342 and #1343. Two small changes so the bot can pick up the GcsBucket persistence without touching the Cloud Run service config:

## Summary

- **Variable-based config.** `SlackbotSettings._apply_post_validation_defaults` now reads `message_store_block` from the `marvin_message_store_block` Prefect Variable when the env var is unset. Same pattern already used for `admin-slack-id`/`marvin_ai_model`. Operators set the Variable in the workspace and the next bot revision picks it up — no Cloud Run env-var change needed.
- **Handle GCS \`NotFound\`.** `MessageStore.get` was only catching `FileNotFoundError` and the LocalFileSystem `ValueError("Path … does not exist.")`. `GcsBucket.aread_path` raises `google.api_core.exceptions.NotFound`, which is a subclass of neither — so the *very first* read of any thread under GCS would crash. Collect backend-specific not-found exceptions into a tuple at import time, guarded by `try/except ImportError` so the dependency stays optional.

## Workspace state already applied

I created these out-of-band so they're ready to go the moment the next image rolls out:
- GCS bucket: \`gs://marvin-bot-chat-history\` (project \`prefect-sbx-natenowack\`, US, created via existing \`gcp-credentials/gcp-credentials\`)
- Prefect block: \`gcs-bucket/marvin-chat-history\`, backed by the same credentials block
- Prefect Variable: \`marvin_message_store_block = gcs-bucket/marvin-chat-history\`

## Test plan
- [x] End-to-end smoke against the real bucket (`load_message_store("gcs-bucket/marvin-chat-history", ...)` → `get` empty → `append` → `get` → matches types). Caught the `NotFound` bug.
- [x] LocalFileSystem smoke still passes (round-trip, concurrent appends, thread isolation, path-traversal rejection).
- [x] Lint pass.
- [ ] After merge + image build: send a mention in stg, check `gs://marvin-bot-chat-history/threads/<thread_ts>.json` shows up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)