### PR TITLE
feat(slackbot): store chat history in Prefect block documents

### DIFF
--- a/examples/slackbot/Dockerfile.slackbot
+++ b/examples/slackbot/Dockerfile.slackbot
@@ -16,18 +16,6 @@ RUN apt-get update && \
 
 RUN uv sync --extra slackbot --no-dev
 
-# Install prefect-gcp into the synced venv so the bot can load `gcs-bucket/...`
-# blocks at runtime for thread-message persistence. Kept out of pyproject.toml
-# because adding it there triggers a transitive resolution conflict with
-# pydantic-ai-slim's quarantined `[mistral]` extra. The upper bound pins to
-# the last release compatible with our locked `prefect==3.6.12`; 0.6.17+
-# requires prefect>=3.6.17 / 3.7.0+ which the workspace lock doesn't satisfy.
-# Pin `prefect==3.6.12` in the same command so the resolver can't silently
-# upgrade prefect out from under uv.lock.
-RUN uv pip install --python /app/.venv/bin/python \
-    "prefect==3.6.12" \
-    "prefect-gcp>=0.6.10,<0.6.17"
-
 RUN bun install -g @anthropic-ai/claude-code
 
 ENV PATH="/root/.bun/bin:${PATH}"

--- a/examples/slackbot/src/slackbot/_internal/message_store.py
+++ b/examples/slackbot/src/slackbot/_internal/message_store.py
@@ -1,110 +1,98 @@
 """Durable per-thread storage for pydantic-ai `ModelMessage` history.
 
-The bot used to persist conversation history in a SQLite file on the
-container's local disk. On Cloud Run that disk is ephemeral — every revision
-deploy wiped the history, and ad-hoc retrieval ("what did marvin actually say
-in thread X?") required shelling into a running container.
+Conversation history lives in the Prefect workspace as block documents —
+one per thread, named `chat-history-<sanitized_thread_ts>`. The bot
+already authenticates to the workspace, so this needs no extra infra
+(no bucket, no service account grant, no env-var dance).
 
-This module replaces that with a `WritableFileSystem`-backed store. Each
-thread's full `ModelMessage` list lives in a single JSON object keyed by
-thread_ts. Writes overwrite the whole object, protected by an in-process
-lock that guards the read-modify-write — see `MessageStore.append`.
+Why block documents (not Variables, not artifacts, not files):
+
+- Variables cap at 5000 chars per value — a single agent turn with tool
+  calls blows that.
+- Artifacts are version-chained on each `create_*_artifact(key=...)`
+  call, so they don't naturally support "overwrite latest" semantics
+  and accumulate records per turn.
+- Block documents store arbitrary JSON in their `data` column (no
+  practical size limit for our use case), support atomic upserts via
+  `block.save(name, overwrite=True)`, and are looked up by name in O(1).
+
+Reads use `ChatHistoryBlock.aload(name)` which raises `ValueError` on
+miss — the natural empty-thread path. Writes are guarded by a single
+in-process `asyncio.Lock` to keep concurrent turns from clobbering each
+other's read-modify-write (the bot is single-instance on Cloud Run; if
+we go multi-replica this needs a distributed primitive).
 """
 
 from __future__ import annotations
 
 import asyncio
 import re
-from pathlib import Path
 
 from prefect.blocks.core import Block
-from prefect.filesystems import LocalFileSystem, WritableFileSystem
 from prefect.logging.loggers import get_logger
+from pydantic import Field
 from pydantic_ai.messages import ModelMessage, ModelMessagesTypeAdapter
 
 logger = get_logger(__name__)
 
-# Backends raise their own "not found" exception types — collect them so
-# `MessageStore.get` can treat a missing thread uniformly as []. Imported
-# defensively so this module doesn't hard-require any particular backend.
-_NOT_FOUND_EXCEPTIONS: tuple[type[BaseException], ...] = (FileNotFoundError,)
-try:
-    from google.api_core.exceptions import NotFound as _GcsNotFound
-
-    _NOT_FOUND_EXCEPTIONS = (*_NOT_FOUND_EXCEPTIONS, _GcsNotFound)
-except ImportError:
-    pass
-
 # Slack thread_ts is always `<seconds>.<microseconds>`, e.g. "1778543248.702039".
-# We use it directly as a filesystem path key — validate strictly so a caller
-# can't supply `../...` or absolute paths and influence what the store
-# reads/writes. The `/chat` endpoint does not verify Slack signatures, so
-# treating thread_ts as untrusted input is the right default.
+# Validate strictly so a caller can't supply arbitrary characters — the value
+# becomes part of a Prefect block-document name and Slack signature
+# verification isn't in place on the `/chat` endpoint.
 _THREAD_TS_RE = re.compile(r"^\d+\.\d+$")
 
 
-async def load_message_store(block_slug: str | None, local_dir: Path) -> "MessageStore":
-    """Construct a `MessageStore` from settings.
+class ChatHistoryBlock(Block):
+    """Per-thread chat history as a Prefect block document.
 
-    If `block_slug` is set, load that `WritableFileSystem` block from the
-    Prefect workspace (e.g. `gcs-bucket/marvin-chat-history` in prod/stg).
-    Otherwise fall back to a `LocalFileSystem` rooted at `local_dir` — fine
-    for local dev, not durable in Cloud Run.
+    The `messages_json` field holds the full `ModelMessage[]` serialized
+    by `pydantic_ai.messages.ModelMessagesTypeAdapter`. We keep it as a
+    string (rather than a structured field) so the block schema doesn't
+    have to track every pydantic-ai message variant.
     """
-    if block_slug:
-        block = await Block.aload(block_slug)
-        if not isinstance(block, WritableFileSystem):
-            raise TypeError(
-                f"Block {block_slug!r} is not a WritableFileSystem "
-                f"(got {type(block).__name__})"
-            )
-        logger.info("Using message store block %s", block_slug)
-        return MessageStore(block)
 
-    local_dir.mkdir(parents=True, exist_ok=True)
-    logger.info("Using local message store at %s", local_dir)
-    return MessageStore(LocalFileSystem(basepath=str(local_dir)))
+    _block_type_name = "Chat History"
+    _logo_url = "https://avatars.githubusercontent.com/u/39270919"  # PrefectHQ
+
+    messages_json: str = Field(
+        default="[]",
+        description="pydantic-ai ModelMessage[] serialized via ModelMessagesTypeAdapter",
+    )
 
 
-def _thread_key(thread_ts: str) -> str:
+def _block_name(thread_ts: str) -> str:
     if not _THREAD_TS_RE.match(thread_ts):
         raise ValueError(f"invalid thread_ts: {thread_ts!r}")
-    return f"threads/{thread_ts}.json"
+    # Block document names must be alphanumeric + dashes only — replace `.`
+    # with `-` to keep round-tripping unambiguous.
+    return f"chat-history-{thread_ts.replace('.', '-')}"
 
 
 class MessageStore:
-    """A thin per-thread message archive over a `WritableFileSystem` block.
+    """Per-thread message archive over Prefect `ChatHistoryBlock` documents.
 
-    A single asyncio lock guards all read-modify-write transactions. With
-    the bot's traffic profile (low QPS, single Cloud Run instance) the
-    serialization cost is negligible, and it sidesteps the unbounded
-    per-thread lock dict that a finer-grained scheme would require. If
-    we ever go multi-replica or hit real contention, this becomes a
-    distributed primitive (CAS or external lock).
+    A single store-wide `asyncio.Lock` guards all read-modify-write
+    transactions. Bot traffic is low enough that the serialization is
+    free; if we ever go multi-replica this becomes a distributed
+    primitive (CAS or external lock).
     """
 
-    def __init__(self, fs: WritableFileSystem) -> None:
-        self._fs = fs
+    def __init__(self) -> None:
         self._write_lock = asyncio.Lock()
 
     async def get(self, thread_ts: str) -> list[ModelMessage]:
         """Return the full message history for a thread, or [] if none stored."""
-        key = _thread_key(thread_ts)
+        name = _block_name(thread_ts)
         try:
-            data = await self._fs.aread_path(key)  # type: ignore[attr-defined]
-        except _NOT_FOUND_EXCEPTIONS:
+            block = await ChatHistoryBlock.aload(name)
+        except ValueError:
+            # Block.aload raises ValueError when the document doesn't exist.
+            # That's the empty-thread case — any other ValueError shape would
+            # be unexpected and is fine to propagate.
             return []
-        except ValueError as e:
-            # LocalFileSystem signals missing files with `ValueError("Path ...
-            # does not exist.")`. Match only that case; re-raise anything else
-            # (e.g. "Path ... is not a file") so real failures don't get
-            # silently swallowed as empty history.
-            if "does not exist" in str(e):
-                return []
-            raise
-        if not data:
+        if not block.messages_json:
             return []
-        return list(ModelMessagesTypeAdapter.validate_json(data))
+        return list(ModelMessagesTypeAdapter.validate_json(block.messages_json))
 
     async def append(
         self, thread_ts: str, new_messages: list[ModelMessage]
@@ -120,6 +108,7 @@ class MessageStore:
         async with self._write_lock:
             existing = await self.get(thread_ts)
             combined = existing + list(new_messages)
-            dumped = ModelMessagesTypeAdapter.dump_json(combined)
-            await self._fs.awrite_path(_thread_key(thread_ts), dumped)  # type: ignore[attr-defined]
+            dumped = ModelMessagesTypeAdapter.dump_json(combined).decode()
+            block = ChatHistoryBlock(messages_json=dumped)
+            await block.save(_block_name(thread_ts), overwrite=True)
             return combined

--- a/examples/slackbot/src/slackbot/api.py
+++ b/examples/slackbot/src/slackbot/api.py
@@ -16,7 +16,7 @@ from pydantic_ai.agent import AgentRunResult
 from pydantic_ai.messages import ModelMessage
 
 from slackbot._internal.constants import WORKSPACE_TO_CHANNEL_ID
-from slackbot._internal.message_store import MessageStore, load_message_store
+from slackbot._internal.message_store import MessageStore
 from slackbot._internal.templates import CHANNEL_REDIRECT_MESSAGE, WELCOME_MESSAGE
 from slackbot._internal.thread_status import (
     get_status as get_thread_status,
@@ -325,12 +325,9 @@ async def summarize_thread_so_far(flow: Flow, flow_run: FlowRun, state: State[An
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    message_store = await load_message_store(
-        settings.message_store_block, settings.message_store_local_dir
-    )
     async with Database.connect(settings.db_file) as db:
         app.state.db = db
-        app.state.message_store = message_store
+        app.state.message_store = MessageStore()
         yield
 
 

--- a/examples/slackbot/src/slackbot/settings.py
+++ b/examples/slackbot/src/slackbot/settings.py
@@ -28,31 +28,12 @@ class SlackbotSettings(BaseSettings):
     def validate_log_level(cls, v: str) -> str:
         return v.upper()
 
-    # Existing settings...
+    # Used for ephemeral thread_status dedup state only; durable thread
+    # message history lives in Prefect block documents — see
+    # `_internal/message_store.py`.
     db_file: Path = Field(
         default=Path("marvin_chat.sqlite"),
-        description=(
-            "Path to SQLite database file. Used for ephemeral thread_status dedup "
-            "state only; durable thread message history is stored via "
-            "`message_store_block` (see below)."
-        ),
-    )
-
-    message_store_block: str | None = Field(
-        default=None,
-        description=(
-            "Slug of a Prefect `WritableFileSystem` block used to persist "
-            "thread message history (e.g. 'gcs-bucket/marvin-chat-history'). "
-            "If unset, falls back to a `LocalFileSystem` rooted at "
-            "`message_store_local_dir` — fine for dev, not durable in Cloud Run."
-        ),
-    )
-    message_store_local_dir: Path = Field(
-        default=Path("./marvin_chat_storage"),
-        description=(
-            "Local directory used as the message-store fallback when "
-            "`message_store_block` is unset."
-        ),
+        description="Path to SQLite database file used for thread dedup state.",
     )
 
     temperature: float = Field(
@@ -118,15 +99,6 @@ class SlackbotSettings(BaseSettings):
                 pass  # If secret doesn't exist, turbopuffer will handle the error
         if not self.admin_slack_user_id:
             self.admin_slack_user_id = Variable.get("admin-slack-id", _sync=True)
-        if self.message_store_block is None:
-            # Allow the message-store block slug to be configured via a Prefect
-            # Variable so we don't have to round-trip through Cloud Run env-var
-            # changes for it.
-            self.message_store_block = Variable.get(
-                "marvin_message_store_block",
-                default=None,
-                _sync=True,  # type: ignore
-            )
         return self
 
     @property


### PR DESCRIPTION
## Summary

Replace the WritableFileSystem-block backing for thread history (#1342 / #1344) with a custom \`ChatHistoryBlock(Block)\` stored in the Prefect workspace itself. One block document per thread, named \`chat-history-<sanitized_thread_ts>\`, holding the JSON-serialized \`ModelMessage[]\` in its \`messages_json\` field.

## Why

The GCS approach turned out to be the wrong shape — the bucket I provisioned in #1344 landed in \`prefect-sbx-natenowack\` because Cloud Run's SA can't \`storage.buckets.create\` in \`prefect-prd-internal-tools\`. Using a cross-project bucket is a non-starter, and getting a real one allocated requires platform involvement we don't want.

Block documents sidestep that entirely:
- No bucket allocation, no IAM grants — the bot already authenticates to the workspace via \`PREFECT_API_KEY\`.
- \`Block.aload(name)\` is O(1) by name and raises \`ValueError\` on miss → clean empty-thread path.
- \`block.save(name, overwrite=True)\` is an atomic upsert.

Alternatives considered:
- **Variables** — 5000-char value cap. A single agent turn with tool calls blows that.
- **Artifacts** — each \`create_*_artifact(key=...)\` call creates a new version rather than overwriting, so we'd accumulate one record per turn and \"read latest\" is awkward.

## Workspace state already cleaned up

Reverted from the previous session as part of the recovery:
- \`marvin_message_store_block\` Variable deleted
- \`gcs-bucket/marvin-chat-history\` block deleted
- \`gs://marvin-bot-chat-history\` (in \`prefect-sbx-natenowack\`) deleted

## What this PR removes

- \`message_store_block\` / \`message_store_local_dir\` settings
- The Variable lookup in \`_apply_post_validation_defaults\`
- The Dockerfile \`prefect-gcp\` install layer (no longer needed)
- The \`load_message_store\` factory (the store no longer needs a backend argument)
- \`google.api_core.exceptions.NotFound\` handling — backend-agnostic now

## Test plan
- [x] End-to-end smoke against the live workspace: empty-get → \`[]\`, single-turn round-trip preserves \`ModelRequest\`/\`ModelResponse\` types, multi-turn accumulates, three concurrent appends serialize correctly via the single store-wide lock (got expected 10 messages), malformed \`thread_ts\` (\`../etc/passwd\`, etc.) rejected with \`ValueError\`, block doc cleanup works.
- [x] \`slackbot.api\` imports clean.
- [x] Lint pass.
- [ ] After merge + deploy: send a mention in stg, confirm \`chat-history-<thread_ts>\` block document shows up in the workspace; send a second mention in the same thread, confirm history loaded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)