### PR TITLE
Add OrcaRouter provider-specific example scripts

### DIFF
--- a/examples/provider_specific/orcarouter/run_agent.py
+++ b/examples/provider_specific/orcarouter/run_agent.py
@@ -1,0 +1,49 @@
+"""
+» ORCAROUTER_API_KEY=your-api-key \
+uv run examples/provider_specific/orcarouter/run_agent.py
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from pydantic_ai.models.openai import OpenAIModel
+from pydantic_ai.providers.openai import OpenAIProvider
+
+import marvin
+
+ORCAROUTER_API_URL = "https://api.orcarouter.ai/v1"
+
+
+def get_provider() -> OpenAIProvider:
+    api_key = os.getenv("ORCAROUTER_API_KEY")
+    if not api_key:
+        raise RuntimeError(
+            "Set ORCAROUTER_API_KEY environment variable to your OrcaRouter API key."
+        )
+    return OpenAIProvider(api_key=api_key, base_url=ORCAROUTER_API_URL)
+
+
+def write_file(path: str, content: str) -> None:
+    """Write content to a file."""
+    Path(path).write_text(content)
+
+
+def main() -> None:
+    writer = marvin.Agent(
+        model=OpenAIModel("orcarouter/auto", provider=get_provider()),
+        name="OrcaRouter Writer",
+        instructions="Write concise, engaging content for developers",
+        tools=[write_file],
+    )
+
+    result = marvin.run(
+        "how to use pydantic? write haiku to docs.md",
+        agents=[writer],
+    )
+    print(result)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/provider_specific/orcarouter/structured_output.py
+++ b/examples/provider_specific/orcarouter/structured_output.py
@@ -1,0 +1,54 @@
+"""
+» ORCAROUTER_API_KEY=your-api-key \
+uv run examples/provider_specific/orcarouter/structured_output.py
+"""
+
+from __future__ import annotations
+
+import os
+
+from pydantic_ai.models.openai import OpenAIModel
+from pydantic_ai.providers.openai import OpenAIProvider
+from typing_extensions import TypedDict
+
+import marvin
+
+ORCAROUTER_API_URL = "https://api.orcarouter.ai/v1"
+
+
+class LearningResource(TypedDict):
+    title: str
+    url: str
+    summary: str
+
+
+def get_provider() -> OpenAIProvider:
+    api_key = os.getenv("ORCAROUTER_API_KEY")
+    if not api_key:
+        raise RuntimeError(
+            "Set ORCAROUTER_API_KEY environment variable to your OrcaRouter API key."
+        )
+    return OpenAIProvider(api_key=api_key, base_url=ORCAROUTER_API_URL)
+
+
+def main() -> None:
+    researcher = marvin.Agent(
+        model=OpenAIModel("openai/gpt-5", provider=get_provider()),
+        name="Resource Researcher",
+        instructions=(
+            "Return structured JSON describing useful developer resources for OrcaRouter."
+        ),
+    )
+
+    resources = marvin.run(
+        "share three quickstart resources for building with OrcaRouter",
+        result_type=list[LearningResource],
+        agents=[researcher],
+    )
+
+    for resource in resources:
+        print(f"- {resource['title']}\n  {resource['url']}\n  {resource['summary']}\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/provider_specific/orcarouter/tools_agent.py
+++ b/examples/provider_specific/orcarouter/tools_agent.py
@@ -1,0 +1,58 @@
+"""
+» ORCAROUTER_API_KEY=your-api-key \
+uv run examples/provider_specific/orcarouter/tools_agent.py
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import date, timedelta
+
+from pydantic_ai.models.openai import OpenAIModel
+from pydantic_ai.providers.openai import OpenAIProvider
+
+import marvin
+
+ORCAROUTER_API_URL = "https://api.orcarouter.ai/v1"
+
+
+def get_provider() -> OpenAIProvider:
+    api_key = os.getenv("ORCAROUTER_API_KEY")
+    if not api_key:
+        raise RuntimeError(
+            "Set ORCAROUTER_API_KEY environment variable to your OrcaRouter API key."
+        )
+    return OpenAIProvider(api_key=api_key, base_url=ORCAROUTER_API_URL)
+
+
+def get_event_date(offset_days: int = 0) -> str:
+    """Return an ISO formatted date offset from today."""
+    today = date.today()
+    return (today + timedelta(days=offset_days)).isoformat()
+
+
+def mock_weather_lookup(city: str) -> str:
+    """Pretend to look up weather for a city."""
+    return f"The forecast in {city} calls for mild temperatures and light winds."
+
+
+def main() -> None:
+    planner = marvin.Agent(
+        model=OpenAIModel("openai/gpt-5", provider=get_provider()),
+        name="OrcaRouter Event Planner",
+        instructions=(
+            "Plan concise community events for OrcaRouter enthusiasts."
+            " Use the available tools for dates and weather when helpful."
+        ),
+        tools=[get_event_date, mock_weather_lookup],
+    )
+
+    plan = marvin.run(
+        "Design a Saturday workshop introducing OrcaRouter in Berlin",
+        agents=[planner],
+    )
+    print(plan)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Added three example scripts under `examples/provider_specific/orcarouter`, mirroring the structure of the existing `aimlapi` provider examples (#1243):

- `run_agent.py` — agent execution with file-writing tool, using OrcaRouter's `orcarouter/auto` smart router
- `structured_output.py` — structured JSON output via `result_type` (`openai/gpt-5`)
- `tools_agent.py` — multi-tool agent (`openai/gpt-5`)

OrcaRouter (https://www.orcarouter.ai) exposes an OpenAI-compatible API at `https://api.orcarouter.ai/v1`, so it plugs into marvin through pydantic-ai's `OpenAIProvider(base_url=...)` with no changes to marvin internals.

Set `ORCAROUTER_API_KEY` before running:

    ORCAROUTER_API_KEY=your-api-key uv run examples/provider_specific/orcarouter/run_agent.py

Disclosure: I'm an engineer on the OrcaRouter team.
