### PR TITLE
fix(jsonschema): guard against empty items list in create_array_type

### DIFF
--- a/src/marvin/utilities/jsonschema.py
+++ b/src/marvin/utilities/jsonschema.py
@@ -215,10 +215,13 @@ def create_array_type(
     if isinstance(items, list):
         # Handle positional item schemas
         item_types = [schema_to_type(s, schemas) for s in items]
-        from typing import Union
+        if not item_types:
+            base = list[Any]
+        else:
+            from typing import Union
 
-        combined = Union[tuple(item_types)]
-        base = list[combined]
+            combined = Union[tuple(item_types)] if len(item_types) > 1 else item_types[0]
+            base = list[combined]
     else:
         # Handle single item schema
         item_type = schema_to_type(items, schemas)

--- a/tests/basic/utilities/test_jsonschema.py
+++ b/tests/basic/utilities/test_jsonschema.py
@@ -281,6 +281,11 @@ class TestArrayTypes:
         result = validator.validate_python(["a", "a", "b"])
         assert result == {"a", "b"}
 
+    def test_empty_items_list_does_not_crash(self):
+        # items=[] (empty tuple schema) must not raise TypeError from Union[()]
+        result = jsonschema_to_type({"type": "array", "items": []})
+        assert TypeAdapter(result).validate_python([1, "x", None]) == [1, "x", None]
+
 
 class TestObjectTypes:
     """Test suite for object validation."""


### PR DESCRIPTION
## What's broken

`jsonschema_to_type` crashes with `TypeError: Cannot take a Union of no types.` when an array schema has `items` set to an empty list (`[]`), which is valid JSON Schema for a zero-element positional tuple. Any caller that generates such a schema — for example, an LLM emitting a function signature with no positional items — will hit this unconditionally.

## Why it happens

In `create_array_type()`, when `items` is a list, the code collects `item_types` by iterating over it and then calls `Union[tuple(item_types)]`. When the list is empty, `Union[()]` raises `TypeError: Cannot take a Union of no types.` The analogous code in `schema_to_type()` already uses `Union[tuple(types)] if len(types) > 1 else types[0]` to guard this, but `create_array_type` had no such guard.

## Fix

Added an early path in the `isinstance(items, list)` branch: if `item_types` is empty, fall back to `list[Any]`. For the single-type case, skip the `Union` wrapper entirely (matching the `schema_to_type` pattern). This keeps the change minimal — 6 lines touched.

## Test

Added `test_empty_items_list_does_not_crash` to `TestArrayTypes`: passes `{"type": "array", "items": []}` to `jsonschema_to_type` and asserts the returned type validates a mixed list without raising.

Fixes #1351