### PR TITLE
fix(jsonschema): guard against empty types list in schema_to_type and create_array_type

### DIFF
--- a/src/marvin/utilities/jsonschema.py
+++ b/src/marvin/utilities/jsonschema.py
@@ -217,7 +217,7 @@ def create_array_type(
         item_types = [schema_to_type(s, schemas) for s in items]
         from typing import Union
 
-        combined = Union[tuple(item_types)]
+        combined = Union[tuple(item_types)] if item_types else Any
         base = list[combined]
     else:
         # Handle single item schema
@@ -296,6 +296,8 @@ def schema_to_type(
             types.append(schema_to_type(type_schema, schemas))
         has_null = type(None) in types
         types = [t for t in types if t is not type(None)]
+        if not types:
+            return type(None)
         if has_null:
             from typing import Union
 

--- a/tests/basic/utilities/test_jsonschema.py
+++ b/tests/basic/utilities/test_jsonschema.py
@@ -1063,6 +1063,17 @@ class TestEdgeCases:
         result = validator.validate_python(["test", 123, True])
         assert result == ["test", 123, True]
 
+    def test_null_only_type_list_returns_none_type(self):
+        # {"type": ["null"]} previously raised IndexError after filtering out NoneType
+        result = jsonschema_to_type({"type": ["null"]})
+        assert result is type(None)
+
+    def test_array_with_empty_items_list_does_not_crash(self):
+        # {"type": "array", "items": []} previously raised TypeError in Union
+        result = jsonschema_to_type({"type": "array", "items": []})
+        validator = TypeAdapter(result)
+        assert validator.validate_python([]) == []
+
 
 class TestNameHandling:
     """Test suite for schema name handling."""


### PR DESCRIPTION
## What's broken

Calling `jsonschema_to_type({"type": ["null"]})` raises `IndexError: list index out of range` in `schema_to_type()`. The code collects Python types for each entry in the list, then filters out `type(None)`. When all entries were `"null"`, the list becomes empty and `types[0]` crashes. A related crash affects `create_array_type()`: passing `{"type": "array", "items": []}` raises `TypeError: Cannot take a Union of no types` because `Union[tuple([])]` is invalid.

## Why it happens

After the null-filter in `schema_to_type()`, there is no guard for an empty list before accessing `types[0]`. In `create_array_type()`, the tuple passed to `Union` can be empty when `items` is `[]`.

## Fix

Added `if not types: return type(None)` before line 302 in `schema_to_type()`. In `create_array_type()`, changed `Union[tuple(item_types)]` to `Union[tuple(item_types)] if item_types else Any`.

## Test

Two new tests in `TestEdgeCases`: one confirms `{"type": ["null"]}` returns `type(None)` without crashing; the other confirms `{"type": "array", "items": []}` returns a list type that validates an empty list.

Fixes #1353