### PR TITLE
fix(types): guard against IndexError on bare List in classifier fns

### DIFF
--- a/src/marvin/utilities/types.py
+++ b/src/marvin/utilities/types.py
@@ -164,7 +164,13 @@ def as_classifier(type_: type[T]) -> Labels:
     # Handle list[T] case for type-level classifiers
     origin = get_origin(typ)
     if origin is list:
-        arg = get_args(typ)[0]
+        type_args = get_args(typ)
+        if not type_args:
+            raise ValueError(
+                "Cannot use an unparameterised List as a classifier. "
+                "Use a parameterised form such as list[MyEnum] or list[Literal['a', 'b']]."
+            )
+        arg = type_args[0]
         # Handle list[Enum] or list[Literal]
         if (isinstance(arg, type) and issubclass(arg, enum.Enum)) or get_origin(
             arg,
@@ -222,7 +228,10 @@ def is_classifier(type_: type[T]) -> bool:
     # Handle list[T] case
     origin = get_origin(typ)
     if origin is list:
-        arg = get_args(typ)[0]
+        type_args = get_args(typ)
+        if not type_args:
+            return False
+        arg = type_args[0]
         # Check for list[Enum], list[Literal], or list[list]
         return (
             issubclass_safe(arg, enum.Enum)

--- a/tests/basic/utilities/test_types.py
+++ b/tests/basic/utilities/test_types.py
@@ -1,5 +1,5 @@
 import enum
-from typing import Literal
+from typing import List, Literal
 
 import pytest
 
@@ -106,6 +106,12 @@ class TestClassification:
             labels.validate(0)  # Wrong type
         with pytest.raises(ValueError):
             labels.validate([3])  # Out of range
+
+    def test_is_classifier_bare_list_no_indexerror(self):
+        """Bare List (no type parameter) must return False, not raise IndexError."""
+        assert not is_classifier(List)
+        with pytest.raises(ValueError, match="unparameterised"):
+            as_classifier(List)
 
     def test_labels_indexed_labels(self):
         """Test getting indexed labels."""


### PR DESCRIPTION
## What's broken

Calling `is_classifier(List)` or `as_classifier(List)` with an unparameterised `typing.List` (no type argument) raises `IndexError: tuple index out of range`. Both functions check `get_origin(typ) is list` and then unconditionally index `get_args(typ)[0]`, but bare `List` produces `get_args(List) == ()`, making the index crash immediately. Any `Task` constructed with `result_type=List` hits this path.

## Why it happens

`get_args` returns an empty tuple for unparameterised generic aliases, so indexing position 0 is always an error.

## Fix

Added a `type_args = get_args(typ)` guard before the index in both functions. In `is_classifier`, an empty `type_args` returns `False` (bare `List` is not a valid classifier). In `as_classifier`, it raises `ValueError` with a message directing callers to use a parameterised form like `list[MyEnum]`.

## Test

`test_is_classifier_bare_list_no_indexerror` confirms `is_classifier(List)` returns `False` and `as_classifier(List)` raises `ValueError` with the word "unparameterised", with no `IndexError` in either case.

Fixes #1355