### PR TITLE
fix: stop cast/classify/extract/generate/say/summarize/plan from mutating the caller's context dict

### DIFF
--- a/src/marvin/fns/cast.py
+++ b/src/marvin/fns/cast.py
@@ -82,7 +82,7 @@ async def cast_async(
     if target is str and instructions is None:
         raise ValueError("Instructions are required when casting to string values.")
 
-    task_context = context or {}
+    task_context = dict(context) if context else {}
     task_context["Data to transform"] = data
     prompt = prompt or DEFAULT_PROMPT
     if instructions:

--- a/src/marvin/fns/classify.py
+++ b/src/marvin/fns/classify.py
@@ -130,7 +130,7 @@ async def classify_async(
         True
 
     """
-    task_context = context or {}
+    task_context = dict(context) if context else {}
     task_context.update({"Data to classify": data})
 
     prompt = prompt or PROMPT

--- a/src/marvin/fns/extract.py
+++ b/src/marvin/fns/extract.py
@@ -67,7 +67,7 @@ async def extract_async(
     if target is str and instructions is None:
         raise ValueError("Instructions are required when extracting string values.")
 
-    task_context = context or {}
+    task_context = dict(context) if context else {}
     task_context["Data to extract"] = data
     prompt = prompt or PROMPT
     if instructions:

--- a/src/marvin/fns/generate.py
+++ b/src/marvin/fns/generate.py
@@ -74,7 +74,7 @@ async def generate_async(
     if _target is str and instructions is None:
         raise ValueError("Instructions are required when generating string values.")
 
-    task_context = context or {}
+    task_context = dict(context) if context else {}
     task_context["Number to generate"] = n
 
     prompt = prompt or DEFAULT_PROMPT

--- a/src/marvin/fns/plan.py
+++ b/src/marvin/fns/plan.py
@@ -174,7 +174,7 @@ async def plan_async(
     agent_map = {i: a for i, a in enumerate(available_agents or [])}
     tool_map = {i: t for i, t in enumerate(tools or [])}
 
-    task_context = context or {}
+    task_context = dict(context) if context else {}
     task_context["Available agents"] = agent_map
     task_context["Available tools"] = tool_map
     prompt = (

--- a/src/marvin/fns/say.py
+++ b/src/marvin/fns/say.py
@@ -37,7 +37,7 @@ async def say_async(
     Returns:
         str: The assistant's response to the user's message.
     """
-    task_context = context or {}
+    task_context = dict(context) if context else {}
     if instructions:
         task_context["Additional instructions"] = instructions
 

--- a/src/marvin/fns/summarize.py
+++ b/src/marvin/fns/summarize.py
@@ -64,7 +64,7 @@ async def summarize_async(
         'Major API updates include...'
 
     """
-    task_context = context or {}
+    task_context = dict(context) if context else {}
     task_context["Data to summarize"] = data
     prompt = prompt or DEFAULT_PROMPT
     if instructions:

--- a/tests/ai/fns/test_cast.py
+++ b/tests/ai/fns/test_cast.py
@@ -1,10 +1,13 @@
 import json
 from typing import Any
 
+import pydantic_ai.models
 import pytest
 from pydantic import BaseModel, Field
+from pydantic_ai.models.test import TestModel
 
 import marvin
+from marvin.defaults import override_defaults
 
 
 class Location(BaseModel):
@@ -121,3 +124,26 @@ class TestAsync:
     async def test_cast_text_to_int(self):
         result = await marvin.cast_async("one", int)
         assert result == 1
+
+
+class TestContextIsolation:
+    def test_cast_does_not_mutate_caller_context(self):
+        """A caller-supplied `context` dict must not be mutated in place.
+
+        `cast_async` used to do `task_context = context or {}` and then
+        write into `task_context` directly, which aliases (rather than
+        copies) any non-empty caller-supplied dict.
+        """
+        with pydantic_ai.models.override_allow_model_requests(False):
+            with override_defaults(model=TestModel()):
+                my_context = {"user_supplied_key": "should not change"}
+                before = dict(my_context)
+
+                marvin.cast(
+                    "one",
+                    int,
+                    instructions="the arabic numeral for the provided word",
+                    context=my_context,
+                )
+
+                assert my_context == before

--- a/tests/ai/fns/test_classify.py
+++ b/tests/ai/fns/test_classify.py
@@ -1,9 +1,12 @@
 from enum import Enum
 
+import pydantic_ai.models
 import pytest
 from pydantic import BaseModel
+from pydantic_ai.models.test import TestModel
 
 import marvin
+from marvin.defaults import override_defaults
 
 sentiment = ["Negative", "Positive"]
 
@@ -200,3 +203,21 @@ class TestMultiLabel:
             multi_label=True,
         )
         assert result == [True, False]
+
+
+class TestContextIsolation:
+    def test_classify_does_not_mutate_caller_context(self):
+        """A caller-supplied `context` dict must not be mutated in place.
+
+        `classify_async` used to do `task_context = context or {}` and then
+        write into `task_context` directly, which aliases (rather than
+        copies) any non-empty caller-supplied dict.
+        """
+        with pydantic_ai.models.override_allow_model_requests(False):
+            with override_defaults(model=TestModel()):
+                my_context = {"user_supplied_key": "should not change"}
+                before = dict(my_context)
+
+                marvin.classify("red car", ["red", "blue", "green"], context=my_context)
+
+                assert my_context == before

--- a/tests/ai/fns/test_extract.py
+++ b/tests/ai/fns/test_extract.py
@@ -1,7 +1,10 @@
+import pydantic_ai.models
 import pytest
 from pydantic import BaseModel, Field
+from pydantic_ai.models.test import TestModel
 
 import marvin
+from marvin.defaults import override_defaults
 
 
 class Location(BaseModel):
@@ -121,3 +124,26 @@ class TestAsync:
     async def test_extract_numbers(self):
         result = await marvin.extract_async("one, two, three", int)
         assert result == [1, 2, 3]
+
+
+class TestContextIsolation:
+    def test_extract_does_not_mutate_caller_context(self):
+        """A caller-supplied `context` dict must not be mutated in place.
+
+        `extract_async` used to do `task_context = context or {}` and then
+        write into `task_context` directly, which aliases (rather than
+        copies) any non-empty caller-supplied dict.
+        """
+        with pydantic_ai.models.override_allow_model_requests(False):
+            with override_defaults(model=TestModel()):
+                my_context = {"user_supplied_key": "should not change"}
+                before = dict(my_context)
+
+                marvin.extract(
+                    "hello world",
+                    str,
+                    instructions="extract greeting",
+                    context=my_context,
+                )
+
+                assert my_context == before

--- a/tests/ai/fns/test_generate.py
+++ b/tests/ai/fns/test_generate.py
@@ -1,8 +1,11 @@
+import pydantic_ai.models
 import pytest
 from dirty_equals import IsPartialDict
 from pydantic import BaseModel, Field, TypeAdapter, ValidationError
+from pydantic_ai.models.test import TestModel
 
 import marvin
+from marvin.defaults import override_defaults
 from marvin.utilities.jsonschema import jsonschema_to_type
 from marvin.utilities.testing import assert_llm_equal
 
@@ -167,3 +170,21 @@ class TestGenerateSchema:
             "minItems": 4,
             "maxItems": 6,
         }
+
+
+class TestContextIsolation:
+    def test_generate_does_not_mutate_caller_context(self):
+        """A caller-supplied `context` dict must not be mutated in place.
+
+        `generate_async` used to do `task_context = context or {}` and then
+        write into `task_context` directly, which aliases (rather than
+        copies) any non-empty caller-supplied dict.
+        """
+        with pydantic_ai.models.override_allow_model_requests(False):
+            with override_defaults(model=TestModel()):
+                my_context = {"user_supplied_key": "should not change"}
+                before = dict(my_context)
+
+                marvin.generate(str, n=1, instructions="one word", context=my_context)
+
+                assert my_context == before

--- a/tests/ai/fns/test_plan.py
+++ b/tests/ai/fns/test_plan.py
@@ -5,24 +5,11 @@ import marvin
 from marvin.defaults import override_defaults
 
 
-def test_summarize_text():
-    result = marvin.summarize("I bought a new car")
-    assert isinstance(result, str)
-
-
-def test_summarize_bullets():
-    result = marvin.summarize(
-        "I bought a new car", instructions='return two "-" bullet points'
-    )
-    assert result.startswith("-")
-    assert "\n-" in result
-
-
 class TestContextIsolation:
-    def test_summarize_does_not_mutate_caller_context(self):
+    def test_plan_does_not_mutate_caller_context(self):
         """A caller-supplied `context` dict must not be mutated in place.
 
-        `summarize_async` used to do `task_context = context or {}` and then
+        `plan_async` used to do `task_context = context or {}` and then
         write into `task_context` directly, which aliases (rather than
         copies) any non-empty caller-supplied dict.
         """
@@ -31,6 +18,6 @@ class TestContextIsolation:
                 my_context = {"user_supplied_key": "should not change"}
                 before = dict(my_context)
 
-                marvin.summarize("a long text about cars", context=my_context)
+                marvin.plan("write a blog post", context=my_context)
 
                 assert my_context == before

--- a/tests/ai/fns/test_say.py
+++ b/tests/ai/fns/test_say.py
@@ -1,4 +1,8 @@
+import pydantic_ai.models
+from pydantic_ai.models.test import TestModel
+
 import marvin
+from marvin.defaults import override_defaults
 
 
 class TestSay:
@@ -74,3 +78,21 @@ class TestSay:
         marvin.say("Hello", thread=thread1.id)
         assert len(thread1.get_messages()) > l1_1
         assert len(thread2.get_messages()) == l2_1
+
+
+class TestContextIsolation:
+    def test_say_does_not_mutate_caller_context(self):
+        """A caller-supplied `context` dict must not be mutated in place.
+
+        `say_async` used to do `task_context = context or {}` and then
+        write into `task_context` directly, which aliases (rather than
+        copies) any non-empty caller-supplied dict.
+        """
+        with pydantic_ai.models.override_allow_model_requests(False):
+            with override_defaults(model=TestModel()):
+                my_context = {"user_supplied_key": "should not change"}
+                before = dict(my_context)
+
+                marvin.say("hello", instructions="be nice", context=my_context)
+
+                assert my_context == before


### PR DESCRIPTION
Seven public marvin functions build their task context with `context or {}` and
then write marvin-internal keys into it in place:

- `cast_async` (`src/marvin/fns/cast.py`) adds `"Data to transform"`
- `classify_async` (`src/marvin/fns/classify.py`) adds `"Data to classify"`
- `extract_async` (`src/marvin/fns/extract.py`) adds `"Data to extract"`
- `generate_async` (`src/marvin/fns/generate.py`) adds `"Number to generate"`
- `plan_async` (`src/marvin/fns/plan.py`) adds `"Available agents"` and `"Available tools"`
- `say_async` (`src/marvin/fns/say.py`) adds `"Additional instructions"`
- `summarize_async` (`src/marvin/fns/summarize.py`) adds `"Data to summarize"`

`context or {}` evaluates to the caller's own dict object whenever it is truthy,
so the in-place write mutates the caller's dict instead of a private copy. No
exception is raised: the caller's dict silently gains marvin-internal keys after
the call returns. A caller that reuses one `context` dict across several marvin
calls, or inspects it afterward, sees keys they never set, and repeated calls
accumulate more of them.

The fix replaces `context or {}` with `dict(context) if context else {}` at all
seven call sites, so a shallow private copy is mutated instead of the caller's
dict. The falsy-input path (`None` or empty dict) still yields a fresh empty
dict, so behavior is unchanged there. A shallow copy is sufficient because these
functions only add or replace top-level keys.

### Testing

- Added one regression test per function, `TestContextIsolation` in each
  `tests/ai/fns/test_*.py` (and a new `tests/ai/fns/test_plan.py`), mirroring the
  existing offline test style in that directory: pass a `context` dict, call the
  function under `override_allow_model_requests(False)` with pydantic-ai's
  `TestModel`, and assert the dict is unchanged afterward. No network or API key
  is required.
- Confirmed RED: with the source fixes reverted and the tests kept, all seven
  fail, each showing the injected marvin-internal key (`7 failed`).
- Confirmed GREEN: with the fixes applied, the seven tests pass (`7 passed`).
- The rest of `tests/ai/fns/` requires live-model credentials and fails with
  `openai.OpenAIError: Missing credentials` identically with and without this
  change; there are zero non-credential failures introduced by this diff.

### Diff

```
 src/marvin/fns/cast.py         |  2 +-
 src/marvin/fns/classify.py     |  2 +-
 src/marvin/fns/extract.py      |  2 +-
 src/marvin/fns/generate.py     |  2 +-
 src/marvin/fns/plan.py         |  2 +-
 src/marvin/fns/say.py          |  2 +-
 src/marvin/fns/summarize.py    |  2 +-
 tests/ai/fns/test_cast.py      | 26 +++++
 tests/ai/fns/test_classify.py  | 21 +++++
 tests/ai/fns/test_extract.py   | 26 +++++
 tests/ai/fns/test_generate.py  | 21 +++++
 tests/ai/fns/test_plan.py      | 23 +++++
 tests/ai/fns/test_say.py       | 22 +++++
 tests/ai/fns/test_summarize.py | 22 +++++
 14 files changed, 168 insertions(+), 7 deletions(-)
```

### Notes

- `src/marvin/tasks/task.py` also uses `context or {}` (`self.context = context
  or {}`). That case stores the alias rather than mutating through it, so it is a
  separate concern and is intentionally out of scope for this PR, which stays
  tightly focused on the seven `fns/` entry points that write into the aliased
  dict.
- The seven source edits are one line each and use no version-specific syntax.
