### PR TITLE
fix(jsonschema): preserve all string enum values in create_enum

### DIFF
--- a/src/marvin/utilities/jsonschema.py
+++ b/src/marvin/utilities/jsonschema.py
@@ -203,7 +203,17 @@ def create_numeric_type(
 def create_enum(name: str, values: list[Any]) -> type | Enum:
     """Create enum type from list of values."""
     if all(isinstance(v, str) for v in values):
-        return Enum(name, {v.upper(): v for v in values})
+        # Derive a valid, unique member name for each value. Using ``v.upper()``
+        # directly is not injective (e.g. "yes"/"YES" collide, silently dropping a
+        # value) and can produce invalid member names (e.g. "" -> ValueError), so
+        # sanitize and de-duplicate to preserve every declared value.
+        members: dict[str, str] = {}
+        for i, value in enumerate(values):
+            key = sanitize_name(value).upper() or f"VALUE_{i}"
+            while key in members:
+                key = f"{key}_{i}"
+            members[key] = value
+        return Enum(name, members)
     return Literal[tuple(values)]  # type: ignore
 
 

--- a/tests/basic/utilities/test_jsonschema.py
+++ b/tests/basic/utilities/test_jsonschema.py
@@ -1163,3 +1163,25 @@ class TestNameHandling:
         assert result.name == "parent"
         assert result.child.name == "child"
         assert result.child.child is None
+
+
+class TestEnumTypes:
+    def test_string_enum_case_variants_preserved(self):
+        from pydantic import TypeAdapter
+
+        va = TypeAdapter(jsonschema_to_type({"enum": ["yes", "YES"]}))
+        assert va.validate_python("YES").value == "YES"
+        assert va.validate_python("yes").value == "yes"
+
+    def test_string_enum_empty_value_allowed(self):
+        from pydantic import TypeAdapter
+
+        va = TypeAdapter(jsonschema_to_type({"enum": ["", "nonempty"]}))
+        assert va.validate_python("").value == ""
+        assert va.validate_python("nonempty").value == "nonempty"
+
+    def test_string_enum_normal_still_works(self):
+        from pydantic import TypeAdapter
+
+        va = TypeAdapter(jsonschema_to_type({"enum": ["positive", "negative", "neutral"]}))
+        assert va.validate_python("neutral").value == "neutral"


### PR DESCRIPTION
### What's broken

`create_enum` builds the Enum member names from the values via `v.upper()`:

```python
return Enum(name, {v.upper(): v for v in values})
```

That mapping is **not injective**, so the reconstructed type is corrupted (reachable from the public `jsonschema_to_type` for any string enum):

- **Silent value drop:** `["yes", "YES"]` → both map to key `"YES"`; the dict keeps only the last, so the type has one member and **rejects the valid value `"yes"`** (no error — just wrong validation).
- **Crash:** `["", "nonempty"]` (empty string is a legal JSON-Schema enum value) → member name `""` → `ValueError: invalid enum member name(s) ''` at build time.

A JSON-Schema enum enumerates the exact permitted set, so the generated type must accept every declared value; member names are an internal detail.

### Fix

Sanitize (via the module's existing `sanitize_name`) and de-duplicate the member names so every value is preserved. Ordinary non-colliding enums keep identical member names, so their behavior is unchanged.

### Tests

Adds a `TestEnumTypes` class to `tests/basic/utilities/test_jsonschema.py` (case-variant values preserved; empty-string value allowed; normal enum unchanged) — the enum branch previously had no test. Full file passes (121).