### PR TITLE
feat(slackbot): see images shared in slack messages

### DIFF
--- a/examples/slackbot/src/slackbot/_internal/message_store.py
+++ b/examples/slackbot/src/slackbot/_internal/message_store.py
@@ -27,11 +27,18 @@ from __future__ import annotations
 
 import asyncio
 import re
+from dataclasses import replace
 
 from prefect.blocks.core import Block
 from prefect.logging.loggers import get_logger
 from pydantic import Field
-from pydantic_ai.messages import ModelMessage, ModelMessagesTypeAdapter
+from pydantic_ai.messages import (
+    BinaryContent,
+    ModelMessage,
+    ModelMessagesTypeAdapter,
+    ModelRequest,
+    UserPromptPart,
+)
 
 logger = get_logger(__name__)
 
@@ -58,6 +65,34 @@ class ChatHistoryBlock(Block):
         default="[]",
         description="pydantic-ai ModelMessage[] serialized via ModelMessagesTypeAdapter",
     )
+
+
+def strip_binary_content(messages: list[ModelMessage]) -> list[ModelMessage]:
+    """Replace binary parts (e.g. shared images) with a text placeholder.
+
+    Images are seen by the model on the turn they're shared, but persisting
+    raw bytes would balloon block-document size and re-bill every image as
+    input tokens on each subsequent turn in the thread.
+    """
+    stripped: list[ModelMessage] = []
+    for message in messages:
+        if isinstance(message, ModelRequest):
+            new_parts = []
+            for part in message.parts:
+                if isinstance(part, UserPromptPart) and not isinstance(
+                    part.content, str
+                ):
+                    new_content = [
+                        f"[image {item.identifier or 'attachment'} shared here — not retained in history]"
+                        if isinstance(item, BinaryContent)
+                        else item
+                        for item in part.content
+                    ]
+                    part = replace(part, content=new_content)
+                new_parts.append(part)
+            message = replace(message, parts=new_parts)
+        stripped.append(message)
+    return stripped
 
 
 def _block_name(thread_ts: str) -> str:
@@ -107,7 +142,7 @@ class MessageStore:
 
         async with self._write_lock:
             existing = await self.get(thread_ts)
-            combined = existing + list(new_messages)
+            combined = existing + strip_binary_content(list(new_messages))
             dumped = ModelMessagesTypeAdapter.dump_json(combined).decode()
             block = ChatHistoryBlock(messages_json=dumped)
             await block.save(_block_name(thread_ts), overwrite=True)

--- a/examples/slackbot/src/slackbot/api.py
+++ b/examples/slackbot/src/slackbot/api.py
@@ -3,7 +3,7 @@ import re
 import time
 from collections import defaultdict
 from contextlib import asynccontextmanager
-from typing import Any
+from typing import Any, Sequence
 
 from fastapi import FastAPI, HTTPException, Request
 from prefect import Flow, State, flow, get_run_logger, task
@@ -12,6 +12,7 @@ from prefect.cache_policies import NONE
 from prefect.client.schemas.objects import FlowRun
 from prefect.logging.loggers import get_logger
 from prefect.states import Completed
+from pydantic_ai import BinaryContent
 from pydantic_ai.agent import AgentRunResult
 from pydantic_ai.messages import ModelMessage
 
@@ -36,8 +37,10 @@ from slackbot.core import (
 )
 from slackbot.settings import settings
 from slackbot.slack import (
+    SlackFile,
     SlackPayload,
     create_progress_message,
+    fetch_shared_images,
     get_channel_name,
     get_workspace_domain,
     post_slack_message,
@@ -70,7 +73,7 @@ def check_if_designated_channel(channel_id: str, team_id: str) -> bool:
 
 @task(name="run agent loop")
 async def run_agent(
-    cleaned_message: str,
+    user_prompt: str | Sequence[str | BinaryContent],
     conversation: list[ModelMessage],
     user_context: UserContext,
     channel_id: str,
@@ -111,7 +114,7 @@ async def run_agent(
                 max_tool_calls=settings.max_tool_calls_per_turn,
             ):
                 result = await create_agent().run(
-                    user_prompt=cleaned_message,
+                    user_prompt=user_prompt,
                     message_history=conversation,
                     deps=user_context,
                 )
@@ -128,8 +131,10 @@ async def run_agent(
         raise
 
 
-def _extract_message_context(event: Any) -> tuple[bool, str | None, str | None, str]:
-    """Return (is_edit, message_ts, thread_ts, text) for Slack events.
+def _extract_message_context(
+    event: Any,
+) -> tuple[bool, str | None, str | None, str, list[SlackFile]]:
+    """Return (is_edit, message_ts, thread_ts, text, files) for Slack events.
 
     - For `message_changed` events, Slack nests the edited message under `event.message`.
     - For normal app_mention events, fields are at the top level.
@@ -152,7 +157,12 @@ def _extract_message_context(event: Any) -> tuple[bool, str | None, str | None, 
     # Text used for bot mention detection
     text = (msg.get("text") if is_edit else (getattr(event, "text", None) or "")) or ""
 
-    return is_edit, message_ts, thread_ts, text
+    if is_edit:
+        files = [SlackFile.model_validate(f) for f in (msg.get("files") or [])]
+    else:
+        files = getattr(event, "files", None) or []
+
+    return is_edit, message_ts, thread_ts, text, files
 
 
 @flow(name="Handle Slack Message", retries=1)
@@ -167,7 +177,9 @@ async def handle_message(
 
     USER_MESSAGE_MAX_TOKENS = settings.user_message_max_tokens
     # Determine message context accommodating edit events
-    is_edit, message_ts, thread_ts, user_message = _extract_message_context(event)
+    is_edit, message_ts, thread_ts, user_message, files = _extract_message_context(
+        event
+    )
     assert thread_ts is not None, "No thread_ts found"
     assert message_ts is not None, "No message_ts found"
     cleaned_message = re.sub(BOT_MENTION, "", user_message).strip()
@@ -266,9 +278,17 @@ async def handle_message(
             bot_id=bot_user_id or "unknown",
         )
 
+        images = await fetch_shared_images(files) if files else []
+        if images:
+            logger.info(f"Including {len(images)} shared image(s) in prompt")
+
+        user_prompt: str | Sequence[str | BinaryContent] = (
+            [cleaned_message, *images] if images else cleaned_message
+        )
+
         try:
             result = await run_agent(
-                cleaned_message,
+                user_prompt,
                 conversation,
                 user_context,
                 event.channel,

--- a/examples/slackbot/src/slackbot/slack.py
+++ b/examples/slackbot/src/slackbot/slack.py
@@ -4,9 +4,16 @@ import re
 from typing import Any, List, Union
 
 import httpx
+from prefect.logging.loggers import get_logger
 from pydantic import BaseModel, ValidationInfo, field_validator, model_validator
+from pydantic_ai import BinaryContent
 
 from slackbot.settings import settings
+
+logger = get_logger(__name__)
+
+MAX_IMAGES_PER_MESSAGE = 4
+MAX_IMAGE_BYTES = 5 * 1024 * 1024  # Anthropic's per-image limit
 
 
 class EventBlockElement(BaseModel):
@@ -26,6 +33,18 @@ class EventBlock(BaseModel):
     elements: List[Union[EventBlockElement, EventBlockElementGroup]]
 
 
+class SlackFile(BaseModel):
+    id: str
+    name: str | None = None
+    mimetype: str | None = None
+    size: int | None = None
+    url_private: str | None = None
+
+    @property
+    def is_image(self) -> bool:
+        return bool(self.mimetype and self.mimetype.startswith("image/"))
+
+
 class SlackEvent(BaseModel):
     client_msg_id: str | None = None
     type: str
@@ -41,6 +60,7 @@ class SlackEvent(BaseModel):
     thread_ts: str | None = None
     parent_user_id: str | None = None
     blocks: list[EventBlock] | None = None
+    files: list[SlackFile] | None = None
 
     @model_validator(mode="before")
     @classmethod
@@ -78,6 +98,65 @@ class SlackPayload(BaseModel):
         if v is None and info.data.get("type") != "url_verification":
             raise ValueError("event is required")
         return v
+
+
+async def fetch_shared_images(files: list[SlackFile]) -> list[BinaryContent]:
+    """Download images shared in a Slack message as `BinaryContent`.
+
+    Slack file URLs are private and require bot-token auth, so the model
+    provider can't fetch them itself — we download the bytes here. Requires
+    the `files:read` OAuth scope. Non-image files, oversized images, and
+    failed downloads are skipped rather than failing the whole message.
+    """
+    images: list[BinaryContent] = []
+    candidates = [f for f in files if f.is_image and f.url_private]
+    if len(candidates) > MAX_IMAGES_PER_MESSAGE:
+        logger.warning(
+            "Message has %d images; only including the first %d",
+            len(candidates),
+            MAX_IMAGES_PER_MESSAGE,
+        )
+        candidates = candidates[:MAX_IMAGES_PER_MESSAGE]
+
+    async with httpx.AsyncClient() as client:
+        for file in candidates:
+            if file.size and file.size > MAX_IMAGE_BYTES:
+                logger.warning(
+                    "Skipping oversized image %s (%s bytes)", file.id, file.size
+                )
+                continue
+            try:
+                assert file.url_private is not None
+                response = await client.get(
+                    file.url_private,
+                    headers={"Authorization": f"Bearer {settings.slack_api_token}"},
+                    follow_redirects=True,
+                )
+                response.raise_for_status()
+            except httpx.HTTPError as e:
+                logger.warning("Failed to download image %s: %s", file.id, e)
+                continue
+            # Slack returns an HTML login page (not an error status) when the
+            # token lacks the files:read scope — don't feed that to the model.
+            content_type = response.headers.get("content-type", "")
+            if not content_type.startswith("image/"):
+                logger.warning(
+                    "Unexpected content-type %r for image %s (missing files:read scope?)",
+                    content_type,
+                    file.id,
+                )
+                continue
+            if len(response.content) > MAX_IMAGE_BYTES:
+                logger.warning("Skipping oversized image %s after download", file.id)
+                continue
+            images.append(
+                BinaryContent(
+                    data=response.content,
+                    media_type=file.mimetype or content_type,
+                    identifier=file.name or file.id,
+                )
+            )
+    return images
 
 
 def convert_md_links_to_slack(text: str) -> str:

--- a/examples/slackbot/tests/conftest.py
+++ b/examples/slackbot/tests/conftest.py
@@ -1,0 +1,4 @@
+import os
+
+# settings are instantiated at import time and require a token
+os.environ.setdefault("MARVIN_SLACKBOT_SLACK_API_TOKEN", "xoxb-test-token")

--- a/examples/slackbot/tests/test_shared_images.py
+++ b/examples/slackbot/tests/test_shared_images.py
@@ -1,0 +1,241 @@
+"""Regression tests for image support in shared Slack messages.
+
+Marvin previously never saw files attached to messages: `SlackEvent`
+dropped the `files` array and only `event.text` reached the agent.
+"""
+
+import httpx
+import pytest
+from pydantic_ai import BinaryContent
+from pydantic_ai.messages import ModelRequest, ModelResponse, TextPart, UserPromptPart
+from slackbot._internal.message_store import strip_binary_content
+from slackbot.slack import (
+    MAX_IMAGE_BYTES,
+    SlackEvent,
+    SlackFile,
+    SlackPayload,
+    fetch_shared_images,
+)
+
+PNG_BYTES = b"\x89PNG\r\n\x1a\n" + b"\x00" * 32
+
+
+def make_event_payload(**event_overrides) -> dict:
+    event = {
+        "type": "app_mention",
+        "text": "<@U123BOT> here is a screenshot",
+        "user": "U456",
+        "ts": "1778543248.702039",
+        "channel": "C789",
+        "event_ts": "1778543248.702039",
+        **event_overrides,
+    }
+    return {
+        "token": "tok",
+        "type": "event_callback",
+        "team_id": "T1",
+        "event": event,
+        "authorizations": [
+            {
+                "team_id": "T1",
+                "user_id": "U123BOT",
+                "is_bot": True,
+                "is_enterprise_install": False,
+            }
+        ],
+    }
+
+
+class TestSlackFileParsing:
+    def test_event_parses_files(self):
+        payload = SlackPayload.model_validate(
+            make_event_payload(
+                files=[
+                    {
+                        "id": "F123",
+                        "name": "image.png",
+                        "mimetype": "image/png",
+                        "size": 12345,
+                        "url_private": "https://files.slack.com/files-pri/T1-F123/image.png",
+                    }
+                ]
+            )
+        )
+        assert payload.event is not None
+        assert payload.event.files is not None
+        file = payload.event.files[0]
+        assert file.is_image
+        assert file.url_private is not None
+
+    def test_event_without_files(self):
+        event = SlackEvent.model_validate(make_event_payload()["event"])
+        assert event.files is None
+
+    def test_non_image_file_is_not_image(self):
+        file = SlackFile(id="F1", mimetype="application/pdf")
+        assert not file.is_image
+
+    def test_extract_message_context_returns_files(self):
+        from slackbot.api import _extract_message_context
+
+        event = SlackEvent.model_validate(
+            make_event_payload(
+                files=[
+                    {"id": "F1", "mimetype": "image/png", "url_private": "https://x"}
+                ]
+            )["event"]
+        )
+        is_edit, message_ts, thread_ts, text, files = _extract_message_context(event)
+        assert not is_edit
+        assert len(files) == 1
+        assert files[0].id == "F1"
+
+    def test_extract_message_context_edit_event_files(self):
+        from slackbot.api import _extract_message_context
+
+        event = SlackEvent.model_validate(
+            {
+                "type": "message",
+                "subtype": "message_changed",
+                "channel": "C789",
+                "event_ts": "1778543249.000000",
+                "message": {
+                    "ts": "1778543248.702039",
+                    "text": "<@U123BOT> edited",
+                    "files": [
+                        {
+                            "id": "F2",
+                            "mimetype": "image/jpeg",
+                            "url_private": "https://y",
+                        }
+                    ],
+                },
+            }
+        )
+        is_edit, message_ts, thread_ts, text, files = _extract_message_context(event)
+        assert is_edit
+        assert len(files) == 1
+        assert files[0].id == "F2"
+
+
+def _mock_transport(content: bytes, content_type: str = "image/png"):
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.headers["Authorization"].startswith("Bearer ")
+        return httpx.Response(
+            200, content=content, headers={"content-type": content_type}
+        )
+
+    return httpx.MockTransport(handler)
+
+
+class TestFetchSharedImages:
+    @pytest.fixture(autouse=True)
+    def patch_httpx(self, monkeypatch: pytest.MonkeyPatch):
+        self.transport = _mock_transport(PNG_BYTES)
+        original_init = httpx.AsyncClient.__init__
+
+        def patched_init(client, **kwargs):
+            kwargs["transport"] = self.transport
+            original_init(client, **kwargs)
+
+        monkeypatch.setattr(httpx.AsyncClient, "__init__", patched_init)
+
+    async def test_downloads_image_as_binary_content(self):
+        files = [
+            SlackFile(
+                id="F1",
+                name="image.png",
+                mimetype="image/png",
+                url_private="https://files.slack.com/x",
+            )
+        ]
+        images = await fetch_shared_images(files)
+        assert len(images) == 1
+        assert isinstance(images[0], BinaryContent)
+        assert images[0].data == PNG_BYTES
+        assert images[0].media_type == "image/png"
+
+    async def test_skips_non_image_files(self):
+        files = [SlackFile(id="F1", mimetype="text/plain", url_private="https://x")]
+        assert await fetch_shared_images(files) == []
+
+    async def test_skips_files_without_url(self):
+        files = [SlackFile(id="F1", mimetype="image/png")]
+        assert await fetch_shared_images(files) == []
+
+    async def test_skips_oversized_images(self):
+        files = [
+            SlackFile(
+                id="F1",
+                mimetype="image/png",
+                size=MAX_IMAGE_BYTES + 1,
+                url_private="https://x",
+            )
+        ]
+        assert await fetch_shared_images(files) == []
+
+    async def test_caps_image_count(self):
+        files = [
+            SlackFile(id=f"F{i}", mimetype="image/png", url_private="https://x")
+            for i in range(10)
+        ]
+        images = await fetch_shared_images(files)
+        assert len(images) == 4
+
+    async def test_skips_non_image_response(self):
+        # e.g. HTML login page when token lacks files:read scope
+        self.transport = _mock_transport(
+            b"<html>login</html>", content_type="text/html"
+        )
+        files = [SlackFile(id="F1", mimetype="image/png", url_private="https://x")]
+        assert await fetch_shared_images(files) == []
+
+    async def test_download_failure_does_not_raise(self):
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(403)
+
+        self.transport = httpx.MockTransport(handler)
+        files = [SlackFile(id="F1", mimetype="image/png", url_private="https://x")]
+        assert await fetch_shared_images(files) == []
+
+
+class TestStripBinaryContent:
+    def test_replaces_binary_with_placeholder(self):
+        messages = [
+            ModelRequest(
+                parts=[
+                    UserPromptPart(
+                        content=[
+                            "look at this",
+                            BinaryContent(
+                                data=PNG_BYTES,
+                                media_type="image/png",
+                                identifier="image.png",
+                            ),
+                        ]
+                    )
+                ]
+            ),
+            ModelResponse(parts=[TextPart(content="I see a pod crashlooping")]),
+        ]
+        stripped = strip_binary_content(messages)
+        request = stripped[0]
+        assert isinstance(request, ModelRequest)
+        part = request.parts[0]
+        assert isinstance(part, UserPromptPart)
+        assert part.content[0] == "look at this"
+        assert isinstance(part.content[1], str)
+        assert "image.png" in part.content[1]
+
+    def test_plain_text_messages_unchanged(self):
+        messages = [
+            ModelRequest(parts=[UserPromptPart(content="hi")]),
+            ModelResponse(parts=[TextPart(content="hello")]),
+        ]
+        assert strip_binary_content(messages) == messages
+
+    def test_originals_not_mutated(self):
+        binary = BinaryContent(data=PNG_BYTES, media_type="image/png")
+        messages = [ModelRequest(parts=[UserPromptPart(content=["hi", binary])])]
+        strip_binary_content(messages)
+        assert messages[0].parts[0].content[1] is binary


### PR DESCRIPTION
marvin now sees images attached to slack messages: the `files` array on events is parsed, image files are downloaded with bot-token auth, and passed to the agent as `BinaryContent` alongside the message text.

previously `SlackEvent` silently dropped the `files` array, so the bot would reply "I don't see the screenshot" to any image upload.

<details>
<summary>details</summary>

- `slack.py`: new `SlackFile` model + `files` field on `SlackEvent`; `fetch_shared_images()` downloads with bearer auth (slack file urls are private, so `ImageUrl` won't work), caps at 4 images / 5MB each, and skips non-image responses (slack returns an HTML login page with a 200 when the token lacks `files:read`)
- `api.py`: `_extract_message_context` also returns files (including the `message_changed` nesting under `event.message`); `handle_message` builds a multimodal `user_prompt` when images exist
- `_internal/message_store.py`: `strip_binary_content()` replaces image bytes with a text placeholder before persisting — the model sees images on the turn they're shared, but stored history stays small and later turns don't re-bill them as input tokens
- `tests/`: new `test_shared_images.py` (payload parsing, edit events, download/skip behavior via `httpx.MockTransport`, history stripping) + `conftest.py` stubbing the token env var

deploy note: the bot token already has `files:read`, so no app config change needed.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)