### PR TITLE
fix(slackbot): recover files omitted from app_mention events

### DIFF
--- a/examples/slackbot/src/slackbot/api.py
+++ b/examples/slackbot/src/slackbot/api.py
@@ -42,6 +42,7 @@ from slackbot.slack import (
     create_progress_message,
     fetch_shared_images,
     get_channel_name,
+    get_message_files,
     get_workspace_domain,
     post_slack_message,
 )
@@ -278,6 +279,9 @@ async def handle_message(
             bot_id=bot_user_id or "unknown",
         )
 
+        if not files:
+            # app_mention events omit `files` — recover them from the thread
+            files = await get_message_files(event.channel, thread_ts, message_ts)
         images = await fetch_shared_images(files) if files else []
         if images:
             logger.info(f"Including {len(images)} shared image(s) in prompt")

--- a/examples/slackbot/src/slackbot/slack.py
+++ b/examples/slackbot/src/slackbot/slack.py
@@ -100,6 +100,28 @@ class SlackPayload(BaseModel):
         return v
 
 
+async def get_message_files(
+    channel: str, thread_ts: str, message_ts: str
+) -> list[SlackFile]:
+    """Recover the `files` array for a message by re-fetching it from Slack.
+
+    `app_mention` event payloads omit `files` even when the message has
+    attachments — only `message` events carry them — so we look the message
+    up in its thread via `conversations.replies`.
+    """
+    try:
+        messages = await get_thread_messages(
+            channel, thread_ts, settings.slack_api_token
+        )
+    except httpx.HTTPError as e:
+        logger.warning("Failed to fetch thread messages for files: %s", e)
+        return []
+    for msg in messages:
+        if msg.get("ts") == message_ts:
+            return [SlackFile.model_validate(f) for f in msg.get("files") or []]
+    return []
+
+
 async def fetch_shared_images(files: list[SlackFile]) -> list[BinaryContent]:
     """Download images shared in a Slack message as `BinaryContent`.
 

--- a/examples/slackbot/tests/test_shared_images.py
+++ b/examples/slackbot/tests/test_shared_images.py
@@ -15,6 +15,7 @@ from slackbot.slack import (
     SlackFile,
     SlackPayload,
     fetch_shared_images,
+    get_message_files,
 )
 
 PNG_BYTES = b"\x89PNG\r\n\x1a\n" + b"\x00" * 32
@@ -197,6 +198,65 @@ class TestFetchSharedImages:
         self.transport = httpx.MockTransport(handler)
         files = [SlackFile(id="F1", mimetype="image/png", url_private="https://x")]
         assert await fetch_shared_images(files) == []
+
+
+class TestGetMessageFiles:
+    """app_mention event payloads omit `files`; we recover them from the thread."""
+
+    @pytest.fixture(autouse=True)
+    def patch_httpx(self, monkeypatch: pytest.MonkeyPatch):
+        def handler(request: httpx.Request) -> httpx.Response:
+            assert "conversations.replies" in str(request.url)
+            return httpx.Response(
+                200,
+                json={
+                    "ok": True,
+                    "messages": [
+                        {"ts": "1784560875.892419", "text": "parent, no files"},
+                        {
+                            "ts": "1784560880.000001",
+                            "text": "<@U123BOT> what is in this image?",
+                            "files": [
+                                {
+                                    "id": "F123",
+                                    "name": "image.png",
+                                    "mimetype": "image/png",
+                                    "url_private": "https://files.slack.com/x",
+                                }
+                            ],
+                        },
+                    ],
+                },
+            )
+
+        transport = httpx.MockTransport(handler)
+        original_init = httpx.AsyncClient.__init__
+
+        def patched_init(client, **kwargs):
+            kwargs["transport"] = transport
+            original_init(client, **kwargs)
+
+        monkeypatch.setattr(httpx.AsyncClient, "__init__", patched_init)
+
+    async def test_recovers_files_for_message(self):
+        files = await get_message_files(
+            "C789", "1784560875.892419", "1784560880.000001"
+        )
+        assert len(files) == 1
+        assert files[0].id == "F123"
+        assert files[0].is_image
+
+    async def test_message_without_files(self):
+        files = await get_message_files(
+            "C789", "1784560875.892419", "1784560875.892419"
+        )
+        assert files == []
+
+    async def test_unknown_message_ts(self):
+        files = await get_message_files(
+            "C789", "1784560875.892419", "9999999999.000000"
+        )
+        assert files == []
 
 
 class TestStripBinaryContent:


### PR DESCRIPTION
follow-up to #1367: slack's `app_mention` event payload omits the `files` array even when the message has attachments (only `message` events carry it), so image support silently no-oped in staging. when the event has no files, we now re-fetch the message via `conversations.replies` and pull `files` from there.

<details>
<summary>details</summary>

- `slack.py`: new `get_message_files(channel, thread_ts, message_ts)` — fetches the thread, finds the message by ts, parses its `files`; API failures log a warning and return `[]`
- `api.py`: `handle_message` falls back to `get_message_files` when the event carried no files
- tests: `TestGetMessageFiles` covers recovery, no-files, and unknown-ts cases

verified empirically: the staging run for "what is in this image?" logged no image inclusion and no skip warnings, i.e. `files` was empty at the handler despite the upload.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)