### PR TITLE
fix(slackbot): add is:issue qualifier required by github search api

### DIFF
--- a/examples/slackbot/src/slackbot/github/issues.py
+++ b/examples/slackbot/src/slackbot/github/issues.py
@@ -34,6 +34,10 @@ async def search_issues(
         # Add repo to query if not already present
         search_query = query if "repo:" in query else f"repo:{repo} {query}"
 
+        # github's search API rejects queries without an is: qualifier
+        if "is:issue" not in search_query and "is:pull-request" not in search_query:
+            search_query = f"is:issue {search_query}"
+
         response = await client.get(
             "https://api.github.com/search/issues",
             params={


### PR DESCRIPTION
github's `/search/issues` endpoint now rejects queries lacking an `is:issue` or `is:pull-request` qualifier with a 422, which broke the slackbot's issue search. prepend `is:issue` when no qualifier is present.

verified end-to-end against the live API via `slackbot.github.issues.search_issues`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)