### PR TITLE
feat: add SambaNova provider example

### DIFF
--- a/examples/provider_specific/sambanova/run_agent.py
+++ b/examples/provider_specific/sambanova/run_agent.py
@@ -1,0 +1,44 @@
+"""
+SambaNova provider example for Marvin.
+
+» SAMBANOVA_API_KEY=your-api-key \
+uv run examples/provider_specific/sambanova/run_agent.py
+"""
+
+from __future__ import annotations
+
+import os
+
+from pydantic_ai.models.openai import OpenAIModel
+from pydantic_ai.providers.openai import OpenAIProvider
+
+import marvin
+
+SAMBANOVA_API_URL = "https://api.sambanova.ai/v1"
+
+
+def get_provider() -> OpenAIProvider:
+    api_key = os.getenv("SAMBANOVA_API_KEY")
+    if not api_key:
+        raise RuntimeError(
+            "Set SAMBANOVA_API_KEY environment variable to your SambaNova API key."
+        )
+    return OpenAIProvider(api_key=api_key, base_url=SAMBANOVA_API_URL)
+
+
+def main() -> None:
+    samba_agent = marvin.Agent(
+        model=OpenAIModel("Meta-Llama-3.3-70B-Instruct", provider=get_provider()),
+        name="SambaNova Assistant",
+        instructions="You are a helpful coding assistant powered by SambaNova.",
+    )
+
+    result = marvin.run(
+        "Explain what a trie data structure is in 2 sentences.",
+        agents=[samba_agent],
+    )
+    print(result)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Why
Add SambaNova as a usable provider example in Marvin (built on pydantic-ai/openai).

## Root cause
N/A - new feature

## Fix
Added `examples/provider_specific/sambanova/run_agent.py` demonstrating usage with `OpenAIModel` + `OpenAIProvider` pointing to `https://api.sambanova.ai/v1`.

Live models enumerated from `/v1/models`:
- `Meta-Llama-3.3-70B-Instruct` (used in example)
- `DeepSeek-V3.1`, `DeepSeek-V3.2`
- `gemma-4-31B-it`, `gpt-oss-120b`, `MiniMax-M2.7`

## Tests
Example runs successfully with SambaNova API.