### PR TITLE
fix(slackbot): repair the user-facts pipeline and consolidate model config

### DIFF
--- a/examples/slackbot/CLAUDE.md
+++ b/examples/slackbot/CLAUDE.md
@@ -49,7 +49,7 @@ docker run marvin-slackbot
 ## Configuration
 
 Key configuration points:
-- **Model Selection**: Configured via `marvin_ai_model` Prefect Variable (GPT-5 or Claude)
+- **Model Selection**: Three tiers via Prefect Variables — `marvin_bot_model` (answering agent, falls back to `marvin_ai_model`), `marvin_utility_model` (memory synthesis + thread summarization, falls back to `marvin_memory_synthesis_model`), `marvin_research_model` (research subagent). Full `provider:model` strings preferred; bare names normalized.
 - **Tool Limits**: Max 50 tool calls per turn (configurable via `MARVIN_SLACKBOT_MAX_TOOL_CALLS_PER_TURN`)
 - **Message Limits**: Max 500 tokens per user message (configurable)
 - **Temperature**: Auto-adjusts to 1.0 for GPT-5, 0.2 for others

--- a/examples/slackbot/README.md
+++ b/examples/slackbot/README.md
@@ -35,9 +35,10 @@ Create a `.env` file in your project directory:
 # - tpuf-api-key                  # TurboPuffer API key for vector storage
 
 # Required Prefect Variables (configured via UI or CLI)
-# - marvin_ai_model               # Default model to use (e.g., "gpt-5", "claude-sonnet-4-6")
-# - marvin_bot_model              # Optional override for the Slackbot response model
-# - marvin_memory_synthesis_model # Optional override for memory/profile synthesis (default: claude-haiku-4-5-20251001)
+# Model tiers (full pydantic-ai "provider:model" strings; bare legacy names still work)
+# - marvin_bot_model              # Main answering agent (default: anthropic:claude-sonnet-4-6; falls back to marvin_ai_model)
+# - marvin_utility_model          # Structured non-voice work: memory synthesis, thread summarization (default: anthropic:claude-haiku-4-5-20251001; falls back to marvin_memory_synthesis_model)
+# - marvin_research_model         # Claude Agent SDK research subagent (default: anthropic:claude-haiku-4-5-20251001)
 # - admin-slack-id                # Slack user ID for admin notifications
 
 # Optional Settings (with MARVIN_SLACKBOT_ prefix)

--- a/examples/slackbot/src/slackbot/__main__.py
+++ b/examples/slackbot/src/slackbot/__main__.py
@@ -9,7 +9,7 @@ if __name__ == "__main__":
     from slackbot.settings import settings
 
     logger = get_logger(__name__)
-    logger.debug(f"Starting Slackbot with model: {settings.model_name}")
+    logger.debug(f"Starting Slackbot with model: {settings.bot_model}")
 
     if not (openai_api_key := os.getenv("OPENAI_API_KEY")):  # Needed for embeddings
         os.environ["OPENAI_API_KEY"] = Secret.load(

--- a/examples/slackbot/src/slackbot/_internal/personalization.py
+++ b/examples/slackbot/src/slackbot/_internal/personalization.py
@@ -8,7 +8,7 @@ from pydantic_ai.providers import Provider
 from raggy.vectorstores.tpuf import TurboPuffer, query_namespace
 from turbopuffer import NotFoundError
 
-from slackbot.settings import settings
+from slackbot.settings import bare_model_name, settings
 
 
 @dataclass(frozen=True)
@@ -82,7 +82,7 @@ def _get_personalization_synth_agent() -> Agent[None, PersonalizationSynthesis]:
     if _personalization_synth_agent is None:
         _personalization_synth_agent = Agent[None, PersonalizationSynthesis](
             model=AnthropicModel(
-                model_name=settings.memory_synthesis_model_name,
+                model_name=bare_model_name(settings.utility_model),
                 provider=Provider(
                     api_key=Secret.load(
                         settings.anthropic_key_secret_name,

--- a/examples/slackbot/src/slackbot/_internal/personalization.py
+++ b/examples/slackbot/src/slackbot/_internal/personalization.py
@@ -1,14 +1,18 @@
+import logging
 from dataclasses import dataclass
 
 from prefect.blocks.system import Secret
 from pydantic import BaseModel, Field
 from pydantic_ai import Agent
 from pydantic_ai.models.anthropic import AnthropicModel
-from pydantic_ai.providers import Provider
-from raggy.vectorstores.tpuf import TurboPuffer, query_namespace
+from pydantic_ai.providers.anthropic import AnthropicProvider
+from raggy.vectorstores.tpuf import TurboPuffer
 from turbopuffer import NotFoundError
 
+from slackbot._internal.vectors import RELEVANCE_MAX_DISTANCE, row_distance
 from slackbot.settings import bare_model_name, settings
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -40,14 +44,7 @@ def load_personalization_snapshot(
             memory_warning="",
         )
 
-    relevant_facts = _split_facts(
-        query_namespace(
-            query_text=user_question,
-            namespace=namespace,
-            top_k=5,
-            max_tokens=500,
-        )
-    )
+    relevant_facts = _query_relevant_facts(namespace, user_question)
     base_memory_warning = _build_memory_warning(all_facts)
     synthesis = _synthesize_personalization(
         query=user_question,
@@ -83,7 +80,7 @@ def _get_personalization_synth_agent() -> Agent[None, PersonalizationSynthesis]:
         _personalization_synth_agent = Agent[None, PersonalizationSynthesis](
             model=AnthropicModel(
                 model_name=bare_model_name(settings.utility_model),
-                provider=Provider(
+                provider=AnthropicProvider(
                     api_key=Secret.load(
                         settings.anthropic_key_secret_name,
                         _sync=True,
@@ -135,10 +132,25 @@ def _synthesize_personalization(
 
     try:
         result = _get_personalization_synth_agent().run_sync("\n\n".join(payload))
-    except Exception:
+    except Exception as exc:
+        logger.warning(
+            "Personalization synthesis failed; falling back to raw facts: %s: %s",
+            type(exc).__name__,
+            exc,
+        )
         return PersonalizationSynthesis()
 
     return result.output or PersonalizationSynthesis()
+
+
+def _annotate_row(row: object) -> str:
+    text = str(getattr(row, "text", "")).strip()
+    if not text:
+        return ""
+    created_at = str(getattr(row, "created_at", "") or "")
+    if created_at:
+        return f"{text} (stored {created_at[:10]})"
+    return text
 
 
 def _load_all_facts(namespace: str) -> list[str]:
@@ -146,6 +158,7 @@ def _load_all_facts(namespace: str) -> list[str]:
         try:
             metadata = tpuf.ns.metadata()
         except NotFoundError:
+            logger.debug("No user-facts namespace %s; treating as new user", namespace)
             return []
 
         row_count = min(metadata.approx_row_count, 25)
@@ -156,18 +169,50 @@ def _load_all_facts(namespace: str) -> list[str]:
             tpuf.ns.query(
                 rank_by=("id", "asc"),
                 top_k=row_count,
-                include_attributes=["text"],
+                # True, not a list: naming attributes that predate a namespace's
+                # schema (e.g. created_at on legacy rows) is a 400
+                include_attributes=True,
             ).rows
             or []
         )
 
-    return _dedupe_facts(
-        [
-            str(getattr(row, "text", "")).strip()
-            for row in rows
-            if str(getattr(row, "text", "")).strip()
-        ]
+    facts = _dedupe_facts(
+        [annotated for annotated in (_annotate_row(row) for row in rows) if annotated]
     )
+    if rows and not facts:
+        logger.warning(
+            "User-facts namespace %s returned %d rows but no usable text",
+            namespace,
+            len(rows),
+        )
+    return facts
+
+
+def _query_relevant_facts(
+    namespace: str, user_question: str, top_k: int = 5
+) -> list[str]:
+    with TurboPuffer(namespace=namespace) as tpuf:
+        try:
+            rows = (
+                tpuf.query(
+                    user_question,
+                    top_k=top_k,
+                    include_attributes=True,  # type: ignore[arg-type]  # see _load_all_facts
+                ).rows
+                or []
+            )
+        except NotFoundError:
+            return []
+
+    relevant: list[str] = []
+    for row in rows:
+        distance = row_distance(row)
+        if distance is not None and distance > RELEVANCE_MAX_DISTANCE:
+            continue
+        annotated = _annotate_row(row)
+        if annotated:
+            relevant.append(annotated)
+    return _dedupe_facts(relevant)
 
 
 def _build_memory_warning(all_facts: list[str]) -> str:
@@ -232,10 +277,6 @@ def _fallback_relevant_facts(
             :4
         ]
     return relevant_facts[:4]
-
-
-def _split_facts(notes: str) -> list[str]:
-    return _dedupe_facts([line.strip() for line in notes.splitlines() if line.strip()])
 
 
 def _dedupe_facts(facts: list[str]) -> list[str]:

--- a/examples/slackbot/src/slackbot/_internal/prompting.py
+++ b/examples/slackbot/src/slackbot/_internal/prompting.py
@@ -1,8 +1,5 @@
 from slackbot.types import UserContext
 
-NO_NOTES_PLACEHOLDER = "<No notes found>"
-
-
 def build_system_prompt(base_prompt: str, user_context: UserContext) -> str:
     sections = [base_prompt]
 
@@ -18,10 +15,7 @@ def build_system_prompt(base_prompt: str, user_context: UserContext) -> str:
 
 
 def _normalize_user_notes(user_notes: str) -> str:
-    normalized = user_notes.strip()
-    if not normalized or normalized == NO_NOTES_PLACEHOLDER:
-        return ""
-    return normalized
+    return user_notes.strip()
 
 
 def _build_personalization_section(user_context: UserContext) -> str:

--- a/examples/slackbot/src/slackbot/_internal/prompting.py
+++ b/examples/slackbot/src/slackbot/_internal/prompting.py
@@ -1,5 +1,6 @@
 from slackbot.types import UserContext
 
+
 def build_system_prompt(base_prompt: str, user_context: UserContext) -> str:
     sections = [base_prompt]
 

--- a/examples/slackbot/src/slackbot/_internal/vectors.py
+++ b/examples/slackbot/src/slackbot/_internal/vectors.py
@@ -1,0 +1,34 @@
+"""distance thresholds and row helpers for the user-facts vector store.
+
+thresholds are empirical, measured with text-embedding-3-small (cosine
+distance): identical ~= 0.0, paraphrases ~= 0.12-0.15, contradictions
+("Prefect 2.x" vs "Prefect 3.x") ~= 0.06 — *closer* than paraphrases, so
+write-time dedup must be near-exact and contradiction handling stays with
+the synthesis model. related question<->fact ~= 0.3, unrelated >= 0.68.
+"""
+
+from typing import Any
+
+WRITE_DEDUP_MAX_DISTANCE = 0.03
+DELETE_MAX_DISTANCE = 0.5
+RELEVANCE_MAX_DISTANCE = 0.65
+
+
+def row_distance(row: Any) -> float | None:
+    try:
+        return float(row["$dist"])
+    except (KeyError, TypeError, ValueError):
+        return None
+
+
+def select_rows_to_delete(rows: list[Any]) -> list[tuple[str, str]]:
+    """Pick (id, text) of rows close enough to the delete query to remove.
+
+    Rows without a distance are kept (never deleted on missing evidence).
+    """
+    selected: list[tuple[str, str]] = []
+    for row in rows:
+        distance = row_distance(row)
+        if distance is not None and distance <= DELETE_MAX_DISTANCE:
+            selected.append((str(row.id), str(getattr(row, "text", ""))))
+    return selected

--- a/examples/slackbot/src/slackbot/api.py
+++ b/examples/slackbot/src/slackbot/api.py
@@ -102,9 +102,9 @@ async def run_agent(
         counts_token = _tool_usage_counts.set(defaultdict(int))
         logger = get_run_logger()
         logger.info(
-            "Agent config: response_model=%s memory_synthesis_model=%s temperature=%s max_tool_calls=%s seen_before=%s",
-            settings.bot_model_name,
-            settings.memory_synthesis_model_name,
+            "Agent config: bot_model=%s utility_model=%s temperature=%s max_tool_calls=%s seen_before=%s",
+            settings.bot_model,
+            settings.utility_model,
             settings.temperature,
             settings.max_tool_calls_per_turn,
             user_context["seen_before"],

--- a/examples/slackbot/src/slackbot/api.py
+++ b/examples/slackbot/src/slackbot/api.py
@@ -135,14 +135,16 @@ async def run_agent(
 
 def _extract_message_context(
     event: Any,
-) -> tuple[bool, str | None, str | None, str, list[SlackFile]]:
-    """Return (is_edit, message_ts, thread_ts, text, files) for Slack events.
+) -> tuple[bool, str | None, str | None, str, list[SlackFile], str | None]:
+    """Return (is_edit, message_ts, thread_ts, text, files, author) for Slack events.
 
-    - For `message_changed` events, Slack nests the edited message under `event.message`.
+    - For `message_changed` events, Slack nests the edited message under `event.message`,
+      and the author lives on the nested message — the outer `event.user` is unreliable.
     - For normal app_mention events, fields are at the top level.
     """
     is_edit = getattr(event, "subtype", None) == "message_changed"
     msg = (getattr(event, "message", None) or {}) if is_edit else {}
+    author = msg.get("user") if is_edit else getattr(event, "user", None)
 
     # Prefer the message ts for idempotency; fall back to event_ts if needed
     message_ts = (
@@ -164,7 +166,7 @@ def _extract_message_context(
     else:
         files = getattr(event, "files", None) or []
 
-    return is_edit, message_ts, thread_ts, text, files
+    return is_edit, message_ts, thread_ts, text, files, author
 
 
 @flow(name="Handle Slack Message", retries=1)
@@ -179,8 +181,8 @@ async def handle_message(
 
     USER_MESSAGE_MAX_TOKENS = settings.user_message_max_tokens
     # Determine message context accommodating edit events
-    is_edit, message_ts, thread_ts, user_message, files = _extract_message_context(
-        event
+    is_edit, message_ts, thread_ts, user_message, files, author = (
+        _extract_message_context(event)
     )
     assert thread_ts is not None, "No thread_ts found"
     assert message_ts is not None, "No message_ts found"
@@ -271,8 +273,16 @@ async def handle_message(
             if bot_auth:
                 bot_user_id = bot_auth.user_id
 
+        if not author or author == bot_user_id:
+            logger.warning(
+                "Could not attribute message %s to a human user (author=%s); "
+                "personalization will be skipped for this turn",
+                message_ts,
+                author,
+            )
+
         user_context = build_user_context(
-            user_id=event.user,
+            user_id=(author if author and author != bot_user_id else "unknown"),
             user_question=cleaned_message,
             thread_ts=thread_ts,
             workspace_name=await get_workspace_domain(),

--- a/examples/slackbot/src/slackbot/assets.py
+++ b/examples/slackbot/src/slackbot/assets.py
@@ -12,8 +12,8 @@ from turbopuffer import NotFoundError
 
 import marvin
 from marvin import cast_async
-from slackbot.settings import settings
 from slackbot._internal.vectors import WRITE_DEDUP_MAX_DISTANCE, row_distance
+from slackbot.settings import settings
 from slackbot.slack import get_channel_name
 from slackbot.types import UserContext
 

--- a/examples/slackbot/src/slackbot/assets.py
+++ b/examples/slackbot/src/slackbot/assets.py
@@ -1,6 +1,6 @@
 """Asset tracking for Slackbot - tracking data lineage."""
 
-from datetime import datetime
+from datetime import datetime, timezone
 
 from prefect.assets import Asset, AssetProperties, add_asset_metadata, materialize
 from pydantic import BaseModel
@@ -8,10 +8,12 @@ from pydantic_ai import RunContext
 from pydantic_ai.messages import ModelMessage, SystemPromptPart
 from raggy.documents import Document
 from raggy.vectorstores.tpuf import TurboPuffer
+from turbopuffer import NotFoundError
 
 import marvin
 from marvin import cast_async
 from slackbot.settings import settings
+from slackbot._internal.vectors import WRITE_DEDUP_MAX_DISTANCE, row_distance
 from slackbot.slack import get_channel_name
 from slackbot.types import UserContext
 
@@ -92,10 +94,35 @@ def user_facts_asset(user_context: UserContext) -> Asset:
 async def store_user_facts(ctx: RunContext[UserContext], facts: list[str]) -> str:
     """Store facts extracted from a Slack thread using context for namespacing."""
 
+    new_facts: list[str] = []
+    duplicates: list[str] = []
     with TurboPuffer(
         namespace=f"{settings.user_facts_namespace_prefix}{ctx.deps['user_id']}"
     ) as tpuf:
-        tpuf.upsert(documents=[Document(text=fact) for fact in facts])
+        for fact in facts:
+            normalized = " ".join(fact.split())
+            if not normalized or normalized in new_facts:
+                continue
+            try:
+                rows = tpuf.query(normalized, top_k=1).rows or []
+            except NotFoundError:
+                rows = []
+            nearest = row_distance(rows[0]) if rows else None
+            if nearest is not None and nearest <= WRITE_DEDUP_MAX_DISTANCE:
+                duplicates.append(normalized)
+                continue
+            new_facts.append(normalized)
+        if new_facts:
+            stored_at = datetime.now(timezone.utc).isoformat(timespec="seconds")
+            documents = [Document(text=fact) for fact in new_facts]
+            tpuf.upsert(
+                documents=documents,
+                attributes={
+                    "created_at": [stored_at] * len(documents),
+                    "thread_ts": [ctx.deps["thread_ts"]] * len(documents),
+                    "channel_id": [ctx.deps["channel_id"]] * len(documents),
+                },
+            )
 
     user_facts = user_facts_asset(ctx.deps)
 
@@ -108,17 +135,24 @@ async def store_user_facts(ctx: RunContext[UserContext], facts: list[str]) -> st
             user_facts,
             {
                 "user_id": ctx.deps["user_id"],
-                "fact_count": len(facts),
+                "fact_count": len(new_facts),
+                "duplicate_count": len(duplicates),
                 "timestamp": datetime.now().isoformat(),
                 "namespace": f"{settings.user_facts_namespace_prefix}{ctx.deps['user_id']}",
                 "thread_ts": ctx.deps["thread_ts"],
                 "workspace_name": ctx.deps["workspace_name"],
                 "channel_id": ctx.deps["channel_id"],
                 "bot_id": ctx.deps["bot_id"],
-                "facts": facts,
+                "facts": new_facts,
             },
         )
-        return f"Stored {len(facts)} facts about user {ctx.deps['user_id']} from thread {ctx.deps['thread_ts']}"
+        message = (
+            f"Stored {len(new_facts)} facts about user {ctx.deps['user_id']} "
+            f"from thread {ctx.deps['thread_ts']}"
+        )
+        if duplicates:
+            message += f" ({len(duplicates)} near-duplicates skipped)"
+        return message
 
     return await materialize_user_facts()
 

--- a/examples/slackbot/src/slackbot/assets.py
+++ b/examples/slackbot/src/slackbot/assets.py
@@ -9,6 +9,7 @@ from pydantic_ai.messages import ModelMessage, SystemPromptPart
 from raggy.documents import Document
 from raggy.vectorstores.tpuf import TurboPuffer
 
+import marvin
 from marvin import cast_async
 from slackbot.settings import settings
 from slackbot.slack import get_channel_name
@@ -141,6 +142,7 @@ async def summarize_thread(
         conversation_text,
         target=ThreadSummary,
         instructions="Summarize this slack thread - give a concise but descriptive title.",
+        agent=marvin.Agent(model=settings.utility_model),
     )
 
     slack_thread = await slack_thread_asset(user_context)

--- a/examples/slackbot/src/slackbot/assets.py
+++ b/examples/slackbot/src/slackbot/assets.py
@@ -137,7 +137,7 @@ async def store_user_facts(ctx: RunContext[UserContext], facts: list[str]) -> st
                 "user_id": ctx.deps["user_id"],
                 "fact_count": len(new_facts),
                 "duplicate_count": len(duplicates),
-                "timestamp": datetime.now().isoformat(),
+                "timestamp": datetime.now(timezone.utc).isoformat(),
                 "namespace": f"{settings.user_facts_namespace_prefix}{ctx.deps['user_id']}",
                 "thread_ts": ctx.deps["thread_ts"],
                 "workspace_name": ctx.deps["workspace_name"],
@@ -200,7 +200,7 @@ async def summarize_thread(
                 "bot_id": user_context["bot_id"],
                 "key_topics": thread_summary.key_topics,
                 "participant_count": thread_summary.participant_count,
-                "timestamp": datetime.now().isoformat(),
+                "timestamp": datetime.now(timezone.utc).isoformat(),
             },
         )
         return thread_summary

--- a/examples/slackbot/src/slackbot/core.py
+++ b/examples/slackbot/src/slackbot/core.py
@@ -112,7 +112,7 @@ def create_agent(
 ) -> Agent[UserContext, str]:
     logger = get_run_logger()
     logger.info("Creating new agent")
-    ai_model = model or settings.bot_model_name
+    ai_model = model or settings.bot_model
     slack_search_mcp = MCPServerStreamableHTTP(
         url="https://marvin-slack-thread-assets.fastmcp.app/mcp",
     )

--- a/examples/slackbot/src/slackbot/core.py
+++ b/examples/slackbot/src/slackbot/core.py
@@ -14,11 +14,13 @@ from pydantic_ai.mcp import MCPServerStreamableHTTP
 from pydantic_ai.models import KnownModelName, Model
 from pydantic_ai.settings import ModelSettings
 from raggy.vectorstores.tpuf import TurboPuffer
+from turbopuffer import NotFoundError
 
 from slackbot._internal.personalization import load_personalization_snapshot
 from slackbot._internal.prompting import build_system_prompt
 from slackbot._internal.templates import DEFAULT_SYSTEM_PROMPT
 from slackbot._internal.tolerant_toolset import TolerantToolset
+from slackbot._internal.vectors import select_rows_to_delete
 from slackbot.assets import store_user_facts
 from slackbot.github import (
     GitHubAuthError,
@@ -152,26 +154,41 @@ def create_agent(
         ctx: RunContext[UserContext], facts: list[str]
     ) -> str:
         """Store facts about the user that are useful for answering their questions."""
-        print(f"Storing {len(facts)} facts about user {ctx.deps['user_id']}")
+        user_id = ctx.deps["user_id"]
+        if not user_id or user_id == "unknown" or user_id == ctx.deps["bot_id"]:
+            logger.warning(
+                "Refusing to store facts: no reliable human user (user_id=%s)",
+                user_id,
+            )
+            return "Not storing facts: could not attribute them to a human user."
+        logger.info("Storing %d facts about user %s", len(facts), user_id)
         # This creates an asset dependency: USER_FACTS depends on SLACK_MESSAGES
         message = await store_user_facts(ctx, facts)
-        print(message)
+        logger.info(message)
         return message
 
     @agent.tool
     def delete_facts_about_user(ctx: RunContext[UserContext], related_to: str) -> str:
         """Delete facts about the user related to a specific topic."""
-        print(f"forgetting stuff about {ctx.deps['user_id']} related to {related_to}")
         user_id = ctx.deps["user_id"]
+        logger.info("Deleting facts about %s related to %r", user_id, related_to)
         with TurboPuffer(
             namespace=f"{settings.user_facts_namespace_prefix}{user_id}"
         ) as tpuf:
-            vector_result = tpuf.query(related_to)
-            ids = [str(v.id) for v in vector_result.rows or []]
-            tpuf.delete(ids)
-            message = f"Deleted {len(ids)} facts about user {user_id}"
-            print(message)
-            return message
+            try:
+                rows = tpuf.query(related_to).rows or []
+            except NotFoundError:
+                return f"No facts are stored for user {user_id}."
+            to_delete = select_rows_to_delete(rows)
+            if not to_delete:
+                return f"No stored facts matched {related_to!r}; nothing was deleted."
+            tpuf.delete([row_id for row_id, _ in to_delete])
+        deleted_lines = "\n".join(f"- {text}" for _, text in to_delete)
+        logger.info("Deleted %d facts for user %s", len(to_delete), user_id)
+        return (
+            f"Deleted {len(to_delete)} facts related to {related_to!r}:\n"
+            f"{deleted_lines}"
+        )
 
     @agent.tool
     async def create_discussion_and_notify(

--- a/examples/slackbot/src/slackbot/core.py
+++ b/examples/slackbot/src/slackbot/core.py
@@ -16,7 +16,10 @@ from pydantic_ai.settings import ModelSettings
 from raggy.vectorstores.tpuf import TurboPuffer
 from turbopuffer import NotFoundError
 
-from slackbot._internal.personalization import load_personalization_snapshot
+from slackbot._internal.personalization import (
+    PersonalizationSnapshot,
+    load_personalization_snapshot,
+)
 from slackbot._internal.prompting import build_system_prompt
 from slackbot._internal.templates import DEFAULT_SYSTEM_PROMPT
 from slackbot._internal.tolerant_toolset import TolerantToolset
@@ -94,8 +97,15 @@ def build_user_context(
     channel_id: str,
     bot_id: str,
 ) -> UserContext:
-    namespace = f"{settings.user_facts_namespace_prefix}{user_id}"
-    personalization = load_personalization_snapshot(namespace, user_question)
+    if user_id == "unknown":
+        # no reliable human author this turn — don't read (or ever seed) a
+        # shared user-facts-unknown namespace
+        personalization = PersonalizationSnapshot(
+            seen_before=False, profile_summary="", relevant_notes="", memory_warning=""
+        )
+    else:
+        namespace = f"{settings.user_facts_namespace_prefix}{user_id}"
+        personalization = load_personalization_snapshot(namespace, user_question)
     return UserContext(
         user_id=user_id,
         user_notes=personalization.relevant_notes,

--- a/examples/slackbot/src/slackbot/research_agent.py
+++ b/examples/slackbot/src/slackbot/research_agent.py
@@ -12,6 +12,8 @@ from claude_agent_sdk.types import AssistantMessage, TextBlock
 from prefect import task
 from prefect.cache_policies import INPUTS
 
+from slackbot.settings import bare_model_name, settings
+
 
 async def research_topic_with_code_access(question: str, version: str = "3.x") -> str:
     """
@@ -76,7 +78,7 @@ Do not use any Prefect syntax you have not verified by reading the actual source
     options = ClaudeAgentOptions(
         allowed_tools=["Read", "Grep", "Glob", "Bash"],
         cwd=str(Path.cwd()),
-        model="claude-haiku-4-5-20251001",
+        model=bare_model_name(settings.research_model),
         system_prompt=system_prompt,
     )
 

--- a/examples/slackbot/src/slackbot/settings.py
+++ b/examples/slackbot/src/slackbot/settings.py
@@ -7,6 +7,35 @@ from prefect.variables import Variable
 from pydantic import Field, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
+_PROVIDER_PREFIXES = {"claude": "anthropic", "gpt": "openai"}
+
+
+def _ensure_provider(model: str) -> str:
+    """Normalize a model name to pydantic-ai's `provider:model` format.
+
+    Prefect Variables may hold bare legacy names like "claude-sonnet-4-6".
+    """
+    if ":" in model:
+        return model
+    for prefix, provider in _PROVIDER_PREFIXES.items():
+        if model.startswith(prefix):
+            return f"{provider}:{model}"
+    return model
+
+
+def bare_model_name(model: str) -> str:
+    """Strip the provider prefix for consumers that want a bare model name
+    (Claude Agent SDK, explicit `AnthropicModel(...)` construction)."""
+    return model.split(":", 1)[-1]
+
+
+def _model_from_variables(names: list[str], default: str) -> str:
+    for name in names:
+        value = Variable.get(name, default=None, _sync=True)  # type: ignore
+        if value:
+            return _ensure_provider(value)
+    return default
+
 
 class SlackbotSettings(BaseSettings):
     model_config: ClassVar[SettingsConfigDict] = SettingsConfigDict(
@@ -102,7 +131,7 @@ class SlackbotSettings(BaseSettings):
 
     @model_validator(mode="after")
     def _apply_post_validation_defaults(self) -> "SlackbotSettings":
-        if "gpt-5" in self.model_name:
+        if "gpt-5" in self.bot_model:
             self.temperature = 1.0
         if not os.getenv("TURBOPUFFER_API_KEY"):
             try:
@@ -114,28 +143,34 @@ class SlackbotSettings(BaseSettings):
             self.admin_slack_user_id = Variable.get("admin-slack-id", _sync=True)
         return self
 
+    # Model tiers. All values are full pydantic-ai `provider:model` strings,
+    # overridable at runtime via Prefect Variables (legacy variable names kept
+    # as fallbacks). The bot model is the product-facing voice and stays on the
+    # strong tier; everything structured and non-voice runs on the utility tier.
+
     @property
-    def model_name(self) -> str:
-        return Variable.get(
-            "marvin_ai_model",
-            default="claude-sonnet-4-6",
-            _sync=True,  # type: ignore
+    def bot_model(self) -> str:
+        """Main answering agent."""
+        return _model_from_variables(
+            ["marvin_bot_model", "marvin_ai_model"],
+            default="anthropic:claude-sonnet-4-6",
         )
 
     @property
-    def bot_model_name(self) -> str:
-        return Variable.get(
-            "marvin_bot_model",
-            default=self.model_name,
-            _sync=True,  # type: ignore
+    def utility_model(self) -> str:
+        """Cheap tier for structured non-voice work: memory/profile synthesis,
+        thread summarization."""
+        return _model_from_variables(
+            ["marvin_utility_model", "marvin_memory_synthesis_model"],
+            default="anthropic:claude-haiku-4-5-20251001",
         )
 
     @property
-    def memory_synthesis_model_name(self) -> str:
-        return Variable.get(
-            "marvin_memory_synthesis_model",
-            default="claude-haiku-4-5-20251001",
-            _sync=True,  # type: ignore
+    def research_model(self) -> str:
+        """Claude Agent SDK subagent that reads Prefect source."""
+        return _model_from_variables(
+            ["marvin_research_model"],
+            default="anthropic:claude-haiku-4-5-20251001",
         )
 
 

--- a/examples/slackbot/tests/test_settings.py
+++ b/examples/slackbot/tests/test_settings.py
@@ -20,15 +20,21 @@ def test_bare_model_name():
 
 
 def test_model_from_variables_prefers_first_set_variable():
-    variables = {"marvin_utility_model": None, "marvin_memory_synthesis_model": "claude-haiku-4-5-20251001"}
+    variables = {
+        "marvin_utility_model": None,
+        "marvin_memory_synthesis_model": "claude-haiku-4-5-20251001",
+    }
     with patch(
         "slackbot.settings.Variable.get",
         side_effect=lambda name, default=None, _sync=True: variables.get(name, default),
     ):
-        assert _model_from_variables(
-            ["marvin_utility_model", "marvin_memory_synthesis_model"],
-            default="anthropic:claude-haiku-4-5-20251001",
-        ) == "anthropic:claude-haiku-4-5-20251001"
+        assert (
+            _model_from_variables(
+                ["marvin_utility_model", "marvin_memory_synthesis_model"],
+                default="anthropic:claude-haiku-4-5-20251001",
+            )
+            == "anthropic:claude-haiku-4-5-20251001"
+        )
 
 
 def test_model_from_variables_falls_back_to_default():
@@ -36,6 +42,9 @@ def test_model_from_variables_falls_back_to_default():
         "slackbot.settings.Variable.get",
         side_effect=lambda name, default=None, _sync=True: default,
     ):
-        assert _model_from_variables(
-            ["marvin_research_model"], default="anthropic:claude-haiku-4-5-20251001"
-        ) == "anthropic:claude-haiku-4-5-20251001"
+        assert (
+            _model_from_variables(
+                ["marvin_research_model"], default="anthropic:claude-haiku-4-5-20251001"
+            )
+            == "anthropic:claude-haiku-4-5-20251001"
+        )

--- a/examples/slackbot/tests/test_settings.py
+++ b/examples/slackbot/tests/test_settings.py
@@ -1,0 +1,41 @@
+from unittest.mock import patch
+
+from slackbot.settings import _ensure_provider, _model_from_variables, bare_model_name
+
+
+def test_ensure_provider_normalizes_bare_names():
+    assert _ensure_provider("claude-sonnet-4-6") == "anthropic:claude-sonnet-4-6"
+    assert _ensure_provider("gpt-5") == "openai:gpt-5"
+    assert _ensure_provider("anthropic:claude-sonnet-4-6") == (
+        "anthropic:claude-sonnet-4-6"
+    )
+    assert _ensure_provider("some-unknown-model") == "some-unknown-model"
+
+
+def test_bare_model_name():
+    assert bare_model_name("anthropic:claude-haiku-4-5-20251001") == (
+        "claude-haiku-4-5-20251001"
+    )
+    assert bare_model_name("claude-haiku-4-5-20251001") == "claude-haiku-4-5-20251001"
+
+
+def test_model_from_variables_prefers_first_set_variable():
+    variables = {"marvin_utility_model": None, "marvin_memory_synthesis_model": "claude-haiku-4-5-20251001"}
+    with patch(
+        "slackbot.settings.Variable.get",
+        side_effect=lambda name, default=None, _sync=True: variables.get(name, default),
+    ):
+        assert _model_from_variables(
+            ["marvin_utility_model", "marvin_memory_synthesis_model"],
+            default="anthropic:claude-haiku-4-5-20251001",
+        ) == "anthropic:claude-haiku-4-5-20251001"
+
+
+def test_model_from_variables_falls_back_to_default():
+    with patch(
+        "slackbot.settings.Variable.get",
+        side_effect=lambda name, default=None, _sync=True: default,
+    ):
+        assert _model_from_variables(
+            ["marvin_research_model"], default="anthropic:claude-haiku-4-5-20251001"
+        ) == "anthropic:claude-haiku-4-5-20251001"

--- a/examples/slackbot/tests/test_shared_images.py
+++ b/examples/slackbot/tests/test_shared_images.py
@@ -86,7 +86,7 @@ class TestSlackFileParsing:
                 ]
             )["event"]
         )
-        is_edit, message_ts, thread_ts, text, files = _extract_message_context(event)
+        is_edit, message_ts, thread_ts, text, files, author = _extract_message_context(event)
         assert not is_edit
         assert len(files) == 1
         assert files[0].id == "F1"
@@ -113,7 +113,7 @@ class TestSlackFileParsing:
                 },
             }
         )
-        is_edit, message_ts, thread_ts, text, files = _extract_message_context(event)
+        is_edit, message_ts, thread_ts, text, files, author = _extract_message_context(event)
         assert is_edit
         assert len(files) == 1
         assert files[0].id == "F2"

--- a/examples/slackbot/tests/test_shared_images.py
+++ b/examples/slackbot/tests/test_shared_images.py
@@ -86,7 +86,9 @@ class TestSlackFileParsing:
                 ]
             )["event"]
         )
-        is_edit, message_ts, thread_ts, text, files, author = _extract_message_context(event)
+        is_edit, message_ts, thread_ts, text, files, author = _extract_message_context(
+            event
+        )
         assert not is_edit
         assert len(files) == 1
         assert files[0].id == "F1"
@@ -113,7 +115,9 @@ class TestSlackFileParsing:
                 },
             }
         )
-        is_edit, message_ts, thread_ts, text, files, author = _extract_message_context(event)
+        is_edit, message_ts, thread_ts, text, files, author = _extract_message_context(
+            event
+        )
         assert is_edit
         assert len(files) == 1
         assert files[0].id == "F2"

--- a/examples/slackbot/tests/test_user_facts.py
+++ b/examples/slackbot/tests/test_user_facts.py
@@ -1,0 +1,96 @@
+"""Regression tests for the user-facts pipeline fixes."""
+
+from slackbot._internal.personalization import _annotate_row
+from slackbot._internal.vectors import (
+    DELETE_MAX_DISTANCE,
+    row_distance,
+    select_rows_to_delete,
+)
+from slackbot.api import _extract_message_context
+from slackbot.slack import SlackEvent
+
+
+class FakeRow:
+    def __init__(self, id: str, text: str, dist: float | None, created_at: str = ""):
+        self.id = id
+        self.text = text
+        self.created_at = created_at
+        self._dist = dist
+
+    def __getitem__(self, key: str) -> float:
+        if key == "$dist" and self._dist is not None:
+            return self._dist
+        raise KeyError(key)
+
+
+class TestRowDistance:
+    def test_reads_dist_key(self):
+        assert row_distance(FakeRow("a", "x", 0.42)) == 0.42
+
+    def test_missing_dist_is_none(self):
+        assert row_distance(FakeRow("a", "x", None)) is None
+
+
+class TestSelectRowsToDelete:
+    def test_only_deletes_within_threshold(self):
+        rows = [
+            FakeRow("close", "user uses k8s", DELETE_MAX_DISTANCE - 0.1),
+            FakeRow("far", "user likes coffee", DELETE_MAX_DISTANCE + 0.1),
+            FakeRow("no-dist", "user is on gcp", None),
+        ]
+        assert select_rows_to_delete(rows) == [("close", "user uses k8s")]
+
+    def test_empty_rows(self):
+        assert select_rows_to_delete([]) == []
+
+
+class TestAnnotateRow:
+    def test_appends_stored_date(self):
+        row = FakeRow("a", "user uses Prefect 3.x", None, "2026-08-15T01:02:03+00:00")
+        assert _annotate_row(row) == "user uses Prefect 3.x (stored 2026-08-15)"
+
+    def test_no_created_at(self):
+        assert _annotate_row(FakeRow("a", "user uses Prefect 3.x", None)) == (
+            "user uses Prefect 3.x"
+        )
+
+    def test_empty_text(self):
+        assert _annotate_row(FakeRow("a", "  ", None, "2026-08-15")) == ""
+
+
+class TestAuthorExtraction:
+    def test_app_mention_author_is_event_user(self):
+        event = SlackEvent(
+            type="app_mention",
+            user="U123",
+            text="<@UBOT> hi",
+            ts="1.0",
+            event_ts="1.0",
+            channel="C1",
+        )
+        *_, author = _extract_message_context(event)
+        assert author == "U123"
+
+    def test_edit_author_comes_from_nested_message(self):
+        event = SlackEvent(
+            type="message",
+            subtype="message_changed",
+            message={"user": "U456", "ts": "1.0", "text": "<@UBOT> edited"},
+            ts="2.0",
+            event_ts="2.0",
+            channel="C1",
+        )
+        *_, author = _extract_message_context(event)
+        assert author == "U456"
+
+    def test_missing_author_is_none(self):
+        event = SlackEvent(
+            type="message",
+            subtype="message_changed",
+            message={"ts": "1.0", "text": "hi"},
+            ts="2.0",
+            event_ts="2.0",
+            channel="C1",
+        )
+        *_, author = _extract_message_context(event)
+        assert author is None


### PR DESCRIPTION
**The problem.** Personalization synthesis has been silently broken in production. The agent constructed the abstract pydantic-ai `Provider` class instead of `AnthropicProvider`. A bare `except Exception` hid the `TypeError`. Every request fell back to the first four facts in UUID order, and the prompt looked identical either way. Model configuration was also spread across four mechanisms, and thread summarization silently used marvin's global default model.

**The fix.** Failure paths in the personalization pipeline now log at warning level. The first live run with that logging surfaced the broken provider, which is now fixed and verified. Model config is now three named tiers in settings: `bot_model`, `utility_model`, `research_model`.

<details>
<summary>user-facts changes</summary>

- Facts from edited messages are attributed to the nested message's author. Storage is refused when the author is missing or is the bot itself. Production had a fact namespace for the bot's own user ID.
- Rows now carry `created_at`, `thread_ts`, and `channel_id`. The synthesis model sees stored dates. Before, it was asked to judge staleness with no recency signal.
- Write-time dedup skips facts within cosine distance 0.03 of an existing row. Measured with text-embedding-3-small: contradictions such as "Prefect 2.x" vs "Prefect 3.x" sit at 0.06, closer than paraphrases at 0.12-0.15, so contradiction handling stays with the synthesis model.
- `delete_facts_about_user` previously deleted the 10 nearest rows with no threshold, which wiped the whole namespace for users with 10 or fewer facts. It now deletes only rows within distance 0.5 and reports the deleted facts.
- The relevance query filters at distance 0.65 and returns facts directly instead of concatenating and re-splitting text.
- Tool logging uses loggers instead of `print`.

</details>

<details>
<summary>model config changes</summary>

- Tiers are full `provider:model` strings with Prefect Variable overrides. Legacy variables (`marvin_ai_model`, `marvin_memory_synthesis_model`) and bare model names still work as fallbacks.
- The research agent's model was hardcoded; it now reads `research_model`.
- Thread summarization (`cast_async`) now runs on `utility_model` instead of marvin's global default (`openai:gpt-4o` unless overridden).

</details>

## Rollout caveats

- no-op for storage schema: all legacy `user-facts-*` namespaces were deleted before this ships, so every row is written by the new code.
- watch: `Personalization synthesis failed` warnings — any occurrence means the synthesis path regressed again.

<details>
<summary>Session context</summary>

Started from a discussion about matching model tier to task difficulty in agent systems. A review of the slackbot found the hand-wired model config and an unmeasured personalization pipeline. Live inspection of the vector store showed the largest fact namespace belonged to the bot's own Slack user ID, and adding failure logging exposed the broken synthesis provider on the first run. Dedup and relevance thresholds were chosen by measuring embedding distances on sample fact pairs, not guessed.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
