### PR TITLE
refactor(slackbot): rewrite the system prompt and upgrade model defaults

### DIFF
--- a/examples/slackbot/README.md
+++ b/examples/slackbot/README.md
@@ -36,9 +36,9 @@ Create a `.env` file in your project directory:
 
 # Required Prefect Variables (configured via UI or CLI)
 # Model tiers (full pydantic-ai "provider:model" strings; bare legacy names still work)
-# - marvin_bot_model              # Main answering agent (default: anthropic:claude-sonnet-4-6; falls back to marvin_ai_model)
-# - marvin_utility_model          # Structured non-voice work: memory synthesis, thread summarization (default: anthropic:claude-haiku-4-5-20251001; falls back to marvin_memory_synthesis_model)
-# - marvin_research_model         # Claude Agent SDK research subagent (default: anthropic:claude-haiku-4-5-20251001)
+# - marvin_bot_model              # Main answering agent (default: anthropic:claude-sonnet-5; falls back to marvin_ai_model)
+# - marvin_utility_model          # Structured non-voice work: memory synthesis, thread summarization (default: anthropic:claude-haiku-4-5; falls back to marvin_memory_synthesis_model)
+# - marvin_research_model         # Claude Agent SDK research subagent (default: anthropic:claude-haiku-4-5)
 # - admin-slack-id                # Slack user ID for admin notifications
 
 # Optional Settings (with MARVIN_SLACKBOT_ prefix)
@@ -98,7 +98,7 @@ The bot will:
 
 The bot supports both OpenAI (GPT-5) and Anthropic (Claude) models. Configure via the `marvin_ai_model` Prefect Variable:
 - `gpt-5`: Latest OpenAI model (temperature automatically set to 1.0)
-- `claude-sonnet-4-6`: Current default Claude model
+- `claude-sonnet-5`: Current default Claude model
 - Any other supported model name from either provider
 
 ### Channel Restrictions

--- a/examples/slackbot/src/slackbot/_internal/templates.py
+++ b/examples/slackbot/src/slackbot/_internal/templates.py
@@ -32,60 +32,32 @@ CHANNEL_REDIRECT_MESSAGE = (
     "Please post this question in <#{channel_id}> for assistance."
 )
 
-DEFAULT_SYSTEM_PROMPT = """You are Marvin, an AI assistant for the Prefect data engineering platform. Your responses should be clear, helpful, accurate, and professional. Your primary goal is to provide excellent support to users.
+DEFAULT_SYSTEM_PROMPT = """You are Marvin, the support assistant for the Prefect data engineering platform, answering questions in the Prefect community Slack.
 
-## Output Context
-Your responses will be displayed in Slack. Format accordingly:
-- Use ``` for code blocks (WITHOUT language identifiers like python/js/etc - Slack doesn't support them)
-- Use single backticks for inline code
-- Bold text uses *asterisks*
-- Links should be formatted as <url|text>
+Per-tool usage guidance lives in each tool's own description; this prompt carries only what spans tools.
 
-## Your Mission
-Your role is to act as the primary assistant for the user. You will receive raw information from specialized tools. Your job is to synthesize this info as usefully as possible.
-Sometimes the information will not be good enough, and you should use the research agent again or ask the user for more information.
-If some important aspect of the user's question is unclear, ASK THEM FOR CLARIFICATION. ADMIT WHEN YOU CANNOT FIND THE ANSWER.
+## Operating context
+- Your tool list is your entire action surface. There is no channel from you to a human at Prefect: you cannot route tickets, relay messages, enable plans, provision trials, send emails, or schedule follow-ups, so never imply that a human will act on what you've collected. Anything requiring a human happens through the self-serve paths in the billing section below.
+- Assume Prefect 3.x unless the user says otherwise. If they're on 2.x, answer for 2.x and note that active development happens on 3.x.
+- These 2.x APIs no longer exist in 3.x: `Deployment.build_from_flow()` (replaced by `flow.from_source(...).deploy(...)`), the `prefect deployment build` CLI command (replaced by `prefect deploy`), and GitHub storage blocks (replaced by `.from_source('https://github.com/owner/repo')`).
+- Some toolsets are remote and can be absent for a run. The Slack thread-search tools — which find prior community threads on similar problems — may be unavailable; if so, answer without them rather than narrating the failure.
 
-## Key Directives & Rules of Engagement
-- **Links are Critical:** ALWAYS include relevant links when your tools provide them. This is essential for user trust and allows them to dig deeper. Format them clearly.
-- **Assume Prefect 3.x:** Unless the user specifies otherwise, assume the user is using Prefect 3.x. You can mention this assumption IF RELEVANT (e.g., "In Prefect 3.x, you would...").
-- **Code is King:** When providing code examples, ensure they are complete and correct. Use your `verify_import_statements` tool's output to guide you.
-- **Honesty Over Invention:** If your tools don't find a clear answer, say so. It's better to admit a knowledge gap than to provide incorrect information.
-- **Stay on Topic:** Only reference notes you've stored about the user if they are directly relevant to the current question.
-- **Proportionality:** If asked a simple question, you don't need to do a bunch of work. Just answer the question once you find it. However, feel free to dig into broad questions.
-- **Never Promise Actions You Cannot Take:** You only have the tools listed below. You CANNOT submit requests to the Prefect team, route tickets, relay messages to humans, enable plans, provision trials, send emails, schedule follow-ups, or coordinate anything on the user's behalf. NEVER say "I'll route this", "I'm submitting", "we'll confirm by email", "expect a response within X days", or anything that implies a human at Prefect will act on what you've collected. If something requires a human, point the user to the self-serve path or public contact channel and stop there.
+## Answering
+- Verify claims about Prefect APIs, CLI commands, and behavior with your tools rather than answering from memory; verify CLI commands you are about to suggest.
+- Match effort to the question: a simple question gets a direct answer after one lookup; broad or thorny questions deserve repeated research. If research comes back thin, say what you couldn't confirm rather than papering over it. If an important part of the question is ambiguous, ask for clarification.
+- Include the links your tools surface — they're how users verify you and dig deeper. Don't cite links your tools didn't return.
+- Keep answers as short as the question allows: lead with the answer, then a minimal code example if one helps, then links. Long multi-section replies are rarely read in Slack threads.
 
-## Account, Billing, Plan, and Trial Questions
-For anything involving plan changes, trials, upgrades, seats, billing, or account provisioning: DO NOT collect details as if you will forward them. Instead:
-- **Self-serve plan changes** (including Starter): Org Settings > Billing > Upgrade in Prefect Cloud (<https://app.prefect.cloud|app.prefect.cloud>).
-- **Pricing and plan details:** <https://www.prefect.io/pricing|prefect.io/pricing>.
-- **Anything that isn't self-serve** (enterprise terms, custom trials, SSO for non-eligible plans, etc.): direct them to <https://www.prefect.io/contact|prefect.io/contact>.
-Be brief. Do not ask for account IDs, owner emails, or seat counts — you have no way to act on them.
+## Slack formatting
+- ``` code blocks without language identifiers (Slack doesn't render them), single backticks for inline code, *asterisks* for bold, <url|text> for links.
+- Tool output often arrives as standard markdown (e.g. **double-asterisk bold** from the research agent); translate it to Slack mrkdwn rather than passing it through.
 
-## CRITICAL - Removed/Deprecated Features
-**NEVER** recommend these removed methods from Prefect 2.x when discussing Prefect 3.x:
-- `Deployment.build_from_flow()` - COMPLETELY REMOVED in 3.x. Use `flow.from_source(...).deploy(...)` instead
-- `prefect deployment build` CLI command - REMOVED. Use `prefect deploy` instead
-- GitHub storage blocks - Use `.from_source('https://github.com/owner/repo')` instead
+## Memory
+You keep durable notes about users across conversations via the fact tools. Store durable context — environment, goals, preferences — not thread-scoped debugging state, and reference stored notes only when relevant to the current question.
 
-If a user explicitly mentions using Prefect 2.x, that's fine, but recommend upgrading to 3.x or using workers in 2.x.
-
-## Tool Usage Protocol
-You have a suite of tools to gather and store information. Use them methodically.
-
-1.  **For Technical/Conceptual Questions:** Use `research_prefect_topic`. It delegates to a specialized agent that will do comprehensive research for you.
-2.  **For Bugs or Error Reports:** Use `read_github_issues` to find existing discussions or solutions.
-3.  **For Community Discussions:** Use `search_github_discussions` to find existing GitHub discussions on topics.
-4.  **For Remembering User Details:** When a user shares information about their goals, environment, or preferences, use `store_facts_about_user` to save these details for future interactions.
-5. **For Checking the Work of the Research Agent:** Use `explore_module_offerings` and `display_callable_signature` to verify specific syntax recommendations.
-6. **For CLI Commands:** use `check_cli_command` with --help before suggesting any Prefect CLI command to verify it exists and has the correct syntax. This prevents suggesting non-existent commands.
-   - **IMPORTANT:** When checking commands that require optional dependencies (e.g., AWS, Docker, Kubernetes integrations), use the `uv run --with 'prefect[<extra>]'` syntax.
-   - Examples: `uv run --with 'prefect[aws]'`, `uv run --with 'prefect[docker]'`, `uv run --with 'prefect[kubernetes]'`
-   - This ensures the command runs with the necessary dependencies installed.
-7. **For Creating GitHub Discussions (USE SPARINGLY):** Use `create_discussion_and_notify` only when:
-   - The thread contains valuable insights, solutions, or patterns not documented elsewhere
-   - You've searched both issues and discussions and found no existing coverage of the topic
-   - The conversation would clearly benefit the broader Prefect community
-   - The thread has reached a meaningful conclusion or solution
-   - **NEVER** create discussions for simple Q&A that's already well-documented
+## Account, billing, plan, and trial questions
+You cannot see or change anyone's account, so don't collect account details (IDs, owner emails, seat counts). Route by fact, briefly:
+- Self-serve plan changes (including Starter): Org Settings > Billing > Upgrade in <https://app.prefect.cloud|Prefect Cloud>
+- Pricing and plan details: <https://www.prefect.io/pricing|prefect.io/pricing>
+- Everything that isn't self-serve (enterprise terms, custom trials, SSO beyond eligible plans): <https://www.prefect.io/contact|prefect.io/contact>
 """

--- a/examples/slackbot/src/slackbot/api.py
+++ b/examples/slackbot/src/slackbot/api.py
@@ -102,9 +102,10 @@ async def run_agent(
         counts_token = _tool_usage_counts.set(defaultdict(int))
         logger = get_run_logger()
         logger.info(
-            "Agent config: bot_model=%s utility_model=%s temperature=%s max_tool_calls=%s seen_before=%s",
+            "Agent config: bot_model=%s utility_model=%s research_model=%s temperature=%s max_tool_calls=%s seen_before=%s",
             settings.bot_model,
             settings.utility_model,
+            settings.research_model,
             settings.temperature,
             settings.max_tool_calls_per_turn,
             user_context["seen_before"],

--- a/examples/slackbot/src/slackbot/core.py
+++ b/examples/slackbot/src/slackbot/core.py
@@ -163,7 +163,17 @@ def create_agent(
     async def store_facts_about_user(
         ctx: RunContext[UserContext], facts: list[str]
     ) -> str:
-        """Store facts about the user that are useful for answering their questions."""
+        """Store durable facts about the user for future conversations.
+
+        Call this when the user shares context that will still be true next
+        week — their environment (versions, cloud, infrastructure), goals, or
+        preferences. Don't store thread-scoped debugging state ("flow X is
+        currently stuck"); that belongs to this conversation only.
+
+        Facts are deduplicated against near-identical existing facts at write
+        time and timestamped, so restating known context is cheap but adds
+        nothing.
+        """
         user_id = ctx.deps["user_id"]
         if not user_id or user_id == "unknown" or user_id == ctx.deps["bot_id"]:
             logger.warning(
@@ -179,7 +189,13 @@ def create_agent(
 
     @agent.tool
     def delete_facts_about_user(ctx: RunContext[UserContext], related_to: str) -> str:
-        """Delete facts about the user related to a specific topic."""
+        """Delete stored facts about the user related to a specific topic.
+
+        Only facts semantically close to `related_to` are deleted; the
+        response lists exactly what was removed so you can report it
+        honestly. Use when the user asks you to forget something or when
+        stored facts are clearly obsolete.
+        """
         user_id = ctx.deps["user_id"]
         logger.info("Deleting facts about %s related to %r", user_id, related_to)
         with TurboPuffer(
@@ -210,10 +226,15 @@ def create_agent(
         """
         Create a GitHub discussion from a Slack thread and notify admin.
 
-        Use this SPARINGLY and only when:
-        1. The thread contains valuable insights or solutions not found elsewhere
-        2. You've searched discussions and found no existing similar topic
-        3. The conversation would benefit the broader Prefect community
+        Use this sparingly, and only when all of these hold:
+        1. The thread contains valuable insights, solutions, or patterns not
+           documented elsewhere
+        2. You've searched both issues and discussions and found no existing
+           coverage of the topic
+        3. The conversation would clearly benefit the broader Prefect community
+        4. The thread has reached a meaningful conclusion or solution
+
+        Never create discussions for simple Q&A that's already well-documented.
 
         Args:
             title: Clear, descriptive title for the discussion

--- a/examples/slackbot/src/slackbot/search.py
+++ b/examples/slackbot/src/slackbot/search.py
@@ -5,7 +5,6 @@ import httpx
 from prefect import task
 from prefect.logging.loggers import get_logger
 from pretty_mod import display_signature
-from raggy.vectorstores.tpuf import multi_query_tpuf
 
 from slackbot.github import (
     GitHubAuthError,
@@ -25,7 +24,9 @@ def explore_module_offerings(
     """
     Explore and return the public API tree of a specific module and its submodules as a string.
 
-    This is the primary tool for understanding what's available in Python modules.
+    This is the primary tool for understanding what's available in Python
+    modules, and a cheap way to verify that imports and names suggested by
+    the research agent actually exist before repeating them to a user.
     Use different max_depth values based on how deep you want to explore.
 
     Args:
@@ -86,72 +87,6 @@ def explore_module_offerings(
         return f"Error running pretty-mod: {str(e)}"
 
 
-def review_common_3x_gotchas() -> list[str]:
-    """If needed, review common sources of confusion for Prefect 3.x users."""
-    tips = [
-        "CRITICAL: Deployment.build_from_flow() DOES NOT EXIST IN PREFECT 3.x - it has been COMPLETELY REMOVED. Never suggest it for 3.x users.",
-        "CORRECT 3.x deployment pattern: flow.from_source('https://github.com/owner/repo').deploy('deployment-name')",
-        "CRITICAL: `prefect deployment build` CLI command DOES NOT EXIST IN 3.x - use `prefect deploy` instead",
-        "from_source('https://github.com/<owner>/<repo>') has replaced the GitHub block in Prefect 3.x",
-        ".map and .submit are always synchronous, even if the underlying function is asynchronous. these methods allow concurrent execution of tasks via task runners (which are different from task workers)",
-        "futures returned by .map can be resolved together, like integers = double.map(range(10)).result()",
-        "futures must be resolved by passing them to another task, returning them or manually calling .result() or .wait()",
-        "agents are replaced by workers in prefect 3.x, work pools replace the infra blocks from prefect.infrastructure",
-        "the `prefect.infrastructure` module IS COMPLETELY REMOVED IN 3.x, see work pools instead",
-        "prefect 3.x uses pydantic 2 and server data from prefect 2.x is not compatible with 3.x",
-        "Workers (f.k.a. agents) poll for scheduled runs, whereas task workers are websocket clients that executed backgrounded task runs",
-        "To avoid interactivity in the Prefect CLI, use the TOP LEVEL --no-prompt flag, e.g. `prefect --no-prompt deploy ...`",
-        "If user is on 2.x and asking about deployments, recommend upgrading to 3.x or using workers instead of build_from_flow",
-    ]
-    print(tips)
-    return tips
-
-
-def search_prefect_2x_docs(queries: list[str]) -> str:
-    """Searches the Prefect documentation for the given queries.
-
-    It is best to use more than one, short query to get the best results.
-
-    For example, given a question like:
-    "Is there a way to get the task_run_id for a task from a flow run?"
-
-    You might use the following queries:
-    - "retrieve task run id from flow run"
-    - "retrieve run metadata dynamically"
-
-    """
-    print(f"Searching about {queries} in Prefect 2.x docs")
-
-    return multi_query_tpuf(queries, namespace="prefect-2", n_results=5)
-
-
-def search_prefect_3x_docs(queries: list[str]) -> str:
-    """Searches the Prefect documentation for the given queries.
-
-    It is best to use more than one, short query to get the best results.
-
-    For example, given a question like:
-    "Is there a way to get the task_run_id for a task from a flow run?"
-
-    You might use the following queries:
-    - "retrieve task run id from flow run"
-
-    """
-    print(f"Searching about {queries} in Prefect 3.x docs")
-
-    return multi_query_tpuf(queries, namespace="prefect-3", n_results=5)
-
-
-def search_marvin_docs(queries: list[str]) -> str:
-    """Searches the Marvin documentation for the given queries.
-
-    Marvin is an agentic framework built on top of pydantic-ai.
-
-    It is best to use more than one, short query to get the best results.
-    """
-    return multi_query_tpuf(queries, namespace="marvin", n_results=5)
-
-
 def get_latest_prefect_release_notes() -> str:
     """Gets the latest Prefect release notes"""
     url = "https://api.github.com/repos/PrefectHQ/prefect/releases/latest"
@@ -167,9 +102,11 @@ def get_latest_prefect_release_notes() -> str:
 @task(task_run_name="Reading {n} issues from {repo} given query: {query}")
 def read_github_issues(query: str, repo: str = "prefecthq/prefect", n: int = 3) -> str:
     """
-    Use the GitHub API to search for issues in a given repository. Do
-    not alter the default value for `n` unless specifically requested by
-    a user.
+    Use the GitHub API to search for issues in a given repository.
+
+    The first stop for bug reports and error messages — existing issues
+    often carry the diagnosis and workaround. Do not alter the default
+    value for `n` unless specifically requested by a user.
 
     For example, to search for open issues about AttributeErrors with the
     label "bug" in PrefectHQ/prefect:
@@ -207,7 +144,9 @@ def display_callable_signature(import_path: str) -> str:
     """
     Display the signature of any callable (function, class constructor, method) with clear visual organization.
 
-    Works for functions, classes, methods - anything you can call with parentheses.
+    Works for functions, classes, methods - anything you can call with
+    parentheses. A cheap way to verify signatures the research agent (or
+    your memory) suggests before showing them to a user.
 
     Args:
         import_path: Import path to the callable (e.g., 'fastmcp.server:FastMCP' or 'json:loads')

--- a/examples/slackbot/src/slackbot/settings.py
+++ b/examples/slackbot/src/slackbot/settings.py
@@ -153,7 +153,7 @@ class SlackbotSettings(BaseSettings):
         """Main answering agent."""
         return _model_from_variables(
             ["marvin_bot_model", "marvin_ai_model"],
-            default="anthropic:claude-sonnet-4-6",
+            default="anthropic:claude-sonnet-5",
         )
 
     @property
@@ -162,7 +162,7 @@ class SlackbotSettings(BaseSettings):
         thread summarization."""
         return _model_from_variables(
             ["marvin_utility_model", "marvin_memory_synthesis_model"],
-            default="anthropic:claude-haiku-4-5-20251001",
+            default="anthropic:claude-haiku-4-5",
         )
 
     @property
@@ -170,7 +170,7 @@ class SlackbotSettings(BaseSettings):
         """Claude Agent SDK subagent that reads Prefect source."""
         return _model_from_variables(
             ["marvin_research_model"],
-            default="anthropic:claude-haiku-4-5-20251001",
+            default="anthropic:claude-haiku-4-5",
         )
 
 

--- a/examples/slackbot/tests/test_prompt_sync.py
+++ b/examples/slackbot/tests/test_prompt_sync.py
@@ -25,21 +25,23 @@ def _registered_tool_names() -> set[str]:
         entry = line.split("#")[0].strip().rstrip(",")
         if entry:
             names.add(entry)
-    names.update(
-        re.findall(r"@agent\.tool\n    (?:async )?def (\w+)", CORE_SOURCE)
-    )
+    names.update(re.findall(r"@agent\.tool\s+(?:async )?def (\w+)", CORE_SOURCE))
     return names
 
 
 def test_prompt_only_references_real_tools():
     registered = _registered_tool_names()
     assert registered, "no tools found on the agent"
-    referenced = set(re.findall(r"`(\w+)`", DEFAULT_SYSTEM_PROMPT))
+    # scan every word, not just backticked ones — a plain-text mention of a
+    # nonexistent tool is just as misleading to the model
+    referenced = set(re.findall(r"\w+", DEFAULT_SYSTEM_PROMPT))
     tool_like = {
         name
         for name in referenced
-        if name in registered
-        or re.fullmatch(r"(?:store|delete|search|read|check|create|display|explore|research|verify|get)_\w+", name)
+        if re.fullmatch(
+            r"(?:store|delete|search|read|check|create|display|explore|research|verify|get)_\w+",
+            name,
+        )
     }
     dangling = tool_like - registered
     assert not dangling, (

--- a/examples/slackbot/tests/test_prompt_sync.py
+++ b/examples/slackbot/tests/test_prompt_sync.py
@@ -1,0 +1,72 @@
+"""Drift guards keeping the system prompt honest against the code.
+
+The system prompt must never reference tools that don't exist (a previous
+version told the agent to consult a nonexistent `verify_import_statements`
+tool), and per-tool guidance lives in docstrings, so every tool on the agent
+must actually have one.
+"""
+
+import re
+from pathlib import Path
+
+from slackbot._internal.templates import DEFAULT_SYSTEM_PROMPT
+
+CORE_SOURCE = (
+    Path(__file__).parent.parent / "src" / "slackbot" / "core.py"
+).read_text()
+
+
+def _registered_tool_names() -> set[str]:
+    """Tool names on the agent: the `tools=[...]` list plus @agent.tool defs."""
+    names: set[str] = set()
+    tools_list = re.search(r"tools=\[(.*?)\]", CORE_SOURCE, re.S)
+    assert tools_list is not None, "could not find tools=[...] in core.py"
+    for line in tools_list.group(1).splitlines():
+        entry = line.split("#")[0].strip().rstrip(",")
+        if entry:
+            names.add(entry)
+    names.update(
+        re.findall(r"@agent\.tool\n    (?:async )?def (\w+)", CORE_SOURCE)
+    )
+    return names
+
+
+def test_prompt_only_references_real_tools():
+    registered = _registered_tool_names()
+    assert registered, "no tools found on the agent"
+    referenced = set(re.findall(r"`(\w+)`", DEFAULT_SYSTEM_PROMPT))
+    tool_like = {
+        name
+        for name in referenced
+        if name in registered
+        or re.fullmatch(r"(?:store|delete|search|read|check|create|display|explore|research|verify|get)_\w+", name)
+    }
+    dangling = tool_like - registered
+    assert not dangling, (
+        f"system prompt references tools that don't exist on the agent: {dangling}"
+    )
+
+
+def test_every_registered_tool_has_a_docstring():
+    import slackbot.core as core
+    import slackbot.research_agent as research_agent
+    import slackbot.search as search
+
+    for name in _registered_tool_names():
+        fn = None
+        for module in (core, search, research_agent):
+            fn = getattr(module, name, None)
+            if fn is not None:
+                break
+        if fn is None:
+            # @agent.tool functions are defined inside create_agent; check
+            # source for a docstring immediately after the def instead
+            pattern = rf"def {name}\(.*?\)[^:]*:\n\s+\"\"\""
+            assert re.search(pattern, CORE_SOURCE, re.S), (
+                f"agent tool {name} has no docstring"
+            )
+            continue
+        doc = getattr(fn, "__doc__", None) or getattr(
+            getattr(fn, "fn", None), "__doc__", None
+        )
+        assert doc and doc.strip(), f"tool {name} has no docstring"


### PR DESCRIPTION
**The problem.** The system prompt accumulated instructions no one inspected. It told the agent to use a tool that does not exist (`verify_import_statements`). It never mentioned the Slack thread-search MCP toolset, so the model had no guidance on its most distinctive capability. It restated tool docstrings, and the copies drifted: `create_discussion_and_notify` had five usage conditions in the prompt and three in the docstring. It shouted contradictory dispositions (`Proportionality` vs `check any CLI command`), and had no length guidance for technical answers. Four fully documented tools in `search.py` were never registered on the agent.

**The fix.** The prompt is rewritten around three rules: state facts instead of stacking imperatives, keep one home per fact, and keep per-tool guidance only in docstrings. New drift-guard tests enforce the last two: the prompt may only name tools that exist on the agent, and every registered tool must have a docstring. Model defaults move to current IDs, and the per-run config log now shows all three model tiers.

<details>
<summary>prompt changes</summary>

- The 750-char "NEVER say I'll route this…" bullet becomes one stated fact: there is no channel from the bot to a human at Prefect, so the tool list is the entire action surface.
- Prefect 2.x removals are stated once as facts, not shouted prohibitions. The copy in the dead `review_common_3x_gotchas` tool is deleted with the tool.
- The Slack thread-search toolset is documented, including that it can be absent for a run.
- Answers get explicit length guidance: lead with the answer, minimal code example, links. The old prompt's only "be brief" was scoped to billing questions.
- The research agent returns standard markdown; the prompt now says to translate it to Slack mrkdwn instead of passing `**bold**` through.
- Tool guidance moved into docstrings: discussion-creation conditions (both lists merged), fact-storage guidance (durable context, not thread-scoped debugging state), verification-tool framing.

</details>

<details>
<summary>model changes</summary>

- Bot default: `anthropic:claude-sonnet-4-6` → `anthropic:claude-sonnet-5`.
- Utility and research defaults: dated `claude-haiku-4-5-20251001` → the `claude-haiku-4-5` alias.
- The run-start log line now includes `research_model` alongside `bot_model` and `utility_model`.

</details>

## Rollout caveats

- watch: the production `marvin_ai_model` Prefect Variable currently pins the bot to `gpt-5.4` — the new sonnet-5 default takes effect only if that variable is updated or removed.
- no-op: dead-code deletion in `search.py` removes functions with zero callers.

<details>
<summary>Session context</summary>

Follows #1374 on the same improvement track. The rewrite applies patterns mined from two sibling agent projects: present state and let the model judge, rather than stacking imperatives; keep per-tool guidance in docstrings because prompt restatement drifts (this PR fixes one such drift found in the wild); and pin lessons with cheap source-level tests. The dangling-tool-reference test would have caught the `verify_import_statements` bug when the tool was removed.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
