### PR TITLE
feat(slackbot): hot-swappable system prompt and memory-attribution fix

### DIFF
--- a/examples/slackbot/README.md
+++ b/examples/slackbot/README.md
@@ -39,6 +39,7 @@ Create a `.env` file in your project directory:
 # - marvin_bot_model              # Main answering agent (default: anthropic:claude-sonnet-5; falls back to marvin_ai_model)
 # - marvin_utility_model          # Structured non-voice work: memory synthesis, thread summarization (default: anthropic:claude-haiku-4-5; falls back to marvin_memory_synthesis_model)
 # - marvin_research_model         # Claude Agent SDK research subagent (default: anthropic:claude-haiku-4-5)
+# - marvin_system_prompt          # Optional override of the base system prompt (default: DEFAULT_SYSTEM_PROMPT in _internal/templates.py); read per message, so edits apply without a redeploy
 # - admin-slack-id                # Slack user ID for admin notifications
 
 # Optional Settings (with MARVIN_SLACKBOT_ prefix)

--- a/examples/slackbot/src/slackbot/_internal/templates.py
+++ b/examples/slackbot/src/slackbot/_internal/templates.py
@@ -55,6 +55,11 @@ Per-tool usage guidance lives in each tool's own description; this prompt carrie
 ## Memory
 You keep durable notes about users across conversations via the fact tools. Store durable context — environment, goals, preferences — not thread-scoped debugging state, and reference stored notes only when relevant to the current question.
 
+You have two distinct memory surfaces, and they can disagree:
+- This thread's message history, which can span weeks — context from it belongs to this conversation, not to your notes.
+- Your durable fact store, surfaced in the User Personalization section below.
+When asked what you know about someone, answer from the personalization section and attribute thread-recalled context to the thread ("earlier in this thread you mentioned..."). If the personalization section is empty, you have no stored facts about them, even if the thread history suggests otherwise — the fact tools operate only on the store, so deleting "facts" you only know from thread history will find nothing.
+
 ## Account, billing, plan, and trial questions
 You cannot see or change anyone's account, so don't collect account details (IDs, owner emails, seat counts). Route by fact, briefly:
 - Self-serve plan changes (including Starter): Org Settings > Billing > Upgrade in <https://app.prefect.cloud|Prefect Cloud>

--- a/examples/slackbot/src/slackbot/core.py
+++ b/examples/slackbot/src/slackbot/core.py
@@ -9,6 +9,7 @@ from typing import AsyncIterator
 import httpx
 from prefect import get_run_logger, task
 from prefect.logging.loggers import get_logger
+from prefect.variables import Variable
 from pydantic_ai import Agent, RunContext
 from pydantic_ai.mcp import MCPServerStreamableHTTP
 from pydantic_ai.models import KnownModelName, Model
@@ -119,6 +120,20 @@ def build_user_context(
     )
 
 
+def _base_system_prompt() -> str:
+    """The base system prompt, hot-swappable via the `marvin_system_prompt`
+    Prefect Variable so prompt changes don't require a redeploy."""
+    try:
+        override = Variable.get("marvin_system_prompt", default=None, _sync=True)  # type: ignore
+    except Exception as exc:
+        logger.warning("Could not read marvin_system_prompt variable: %s", exc)
+        return DEFAULT_SYSTEM_PROMPT
+    if override:
+        logger.info("Using system prompt from marvin_system_prompt variable")
+        return str(override)
+    return DEFAULT_SYSTEM_PROMPT
+
+
 def create_agent(
     model: KnownModelName | Model | None = None,
 ) -> Agent[UserContext, str]:
@@ -153,9 +168,12 @@ def create_agent(
         deps_type=UserContext,
     )
 
+    # read once per agent (i.e. per message), not per model request
+    base_prompt = _base_system_prompt()
+
     @agent.system_prompt
     def personality_and_maybe_notes(ctx: RunContext[UserContext]) -> str:
-        system_prompt = build_system_prompt(DEFAULT_SYSTEM_PROMPT, ctx.deps)
+        system_prompt = build_system_prompt(base_prompt, ctx.deps)
         logger.debug("Built system prompt with contextual sections")
         return system_prompt
 


### PR DESCRIPTION
**The problem.** Prompt changes require a full image build and Cloud Run deploy, unlike model choices, which are runtime Prefect Variables. Separately, observed in production: in a weeks-old thread, the bot recited old thread history as if it were its memory store, then found nothing to delete when asked to forget those "facts" — the store had been pruned and the facts only existed in thread context.

**The fix.** The base system prompt is now read from the `marvin_system_prompt` Prefect Variable once per message, falling back to `DEFAULT_SYSTEM_PROMPT` (and on any read error). The default prompt gains a memory-attribution section: the fact store and thread history are distinct surfaces; "what do you know about me" answers from stored facts, thread-recalled context is attributed to the thread, and the fact tools operate only on the store.

The variable read failing open to the code default means a Prefect API hiccup degrades to the shipped prompt instead of an error.

## Rollout caveats

- no-op until the variable diverges: `marvin_system_prompt` is pre-seeded with the same text as the new code default.
- watch: `Using system prompt from marvin_system_prompt variable` log line confirms the override path is active.

<details>
<summary>Session context</summary>

Prompted by a live interaction where the user asked the bot to forget facts it had recited from thread history; the delete tool correctly reported no matching records because the vector store had been pruned earlier. The variable-override pattern mirrors the model-tier variables added in #1374.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
