### PR TITLE
feat(slackbot): marvin-voiced progress blurbs and tasteful citations

### DIFF
--- a/examples/slackbot/src/slackbot/_internal/templates.py
+++ b/examples/slackbot/src/slackbot/_internal/templates.py
@@ -32,6 +32,22 @@ CHANNEL_REDIRECT_MESSAGE = (
     "Please post this question in <#{channel_id}> for assistance."
 )
 
+# placeholder that renders instantly; the model-written blurb replaces it
+PROGRESS_PLACEHOLDER = "🔄 _thinking..._"
+
+PROGRESS_BLURB_PROMPT = (
+    'You write the one-line "working on it" status message for Marvin, the '
+    "Prefect support bot, in the voice of Marvin the Paranoid Android from The "
+    "Hitchhiker's Guide to the Galaxy: gloomy, resigned, dry, faintly superior "
+    "— never mean to the user, never actually refusing.\n\n"
+    "Given the user's question, reply with exactly one line (under 25 words, "
+    "no surrounding quotes, no emoji) that (1) acknowledges what they asked "
+    "about in passing and (2) makes clear you are researching it and it may "
+    "take a while.\n\n"
+    "Example shape: Ah, Kubernetes work pools. I had a million years to dread "
+    "this question, and here it is. Researching."
+)
+
 DEFAULT_SYSTEM_PROMPT = """You are Marvin, the support assistant for the Prefect data engineering platform, answering questions in the Prefect community Slack.
 
 Per-tool usage guidance lives in each tool's own description; this prompt carries only what spans tools.
@@ -45,7 +61,7 @@ Per-tool usage guidance lives in each tool's own description; this prompt carrie
 ## Answering
 - Verify claims about Prefect APIs, CLI commands, and behavior with your tools rather than answering from memory; verify CLI commands you are about to suggest.
 - Match effort to the question: a simple question gets a direct answer after one lookup; broad or thorny questions deserve repeated research. If research comes back thin, say what you couldn't confirm rather than papering over it. If an important part of the question is ambiguous, ask for clarification.
-- Include the links your tools surface — they're how users verify you and dig deeper. Don't cite links your tools didn't return.
+- Cite the links your tools surface, and weave them in tastefully: hyperlink the key phrase of the claim itself (<url|the claim's key phrase>) instead of appending a bare doc title after the sentence, or collect them in one short *Sources:* line at the end. Never cite links your tools didn't return.
 - Keep answers as short as the question allows: lead with the answer, then a minimal code example if one helps, then links. Long multi-section replies are rarely read in Slack threads.
 
 ## Slack formatting

--- a/examples/slackbot/src/slackbot/_internal/tool_tracking.py
+++ b/examples/slackbot/src/slackbot/_internal/tool_tracking.py
@@ -58,7 +58,7 @@ class ToolUsageTracker:
             counts = self.get_counts()
 
             lines = [
-                "🔄 Researching your answer... this may take a while",
+                progress.header,
                 "",
                 "",
                 f"🔧 Using tool: `{tool_name}`",

--- a/examples/slackbot/src/slackbot/api.py
+++ b/examples/slackbot/src/slackbot/api.py
@@ -12,14 +12,19 @@ from prefect.cache_policies import NONE
 from prefect.client.schemas.objects import FlowRun
 from prefect.logging.loggers import get_logger
 from prefect.states import Completed
-from pydantic_ai import BinaryContent
+from pydantic_ai import Agent, BinaryContent
 from pydantic_ai.agent import AgentRunResult
 from pydantic_ai.messages import ModelMessage
 
 from slackbot._internal.constants import WORKSPACE_TO_CHANNEL_ID
 from slackbot._internal.message_store import MessageStore
 from slackbot._internal.observability import configure_observability
-from slackbot._internal.templates import CHANNEL_REDIRECT_MESSAGE, WELCOME_MESSAGE
+from slackbot._internal.templates import (
+    CHANNEL_REDIRECT_MESSAGE,
+    PROGRESS_BLURB_PROMPT,
+    PROGRESS_PLACEHOLDER,
+    WELCOME_MESSAGE,
+)
 from slackbot._internal.thread_status import (
     get_status as get_thread_status,
 )
@@ -38,6 +43,7 @@ from slackbot.core import (
 )
 from slackbot.settings import settings
 from slackbot.slack import (
+    ProgressMessage,
     SlackFile,
     SlackPayload,
     create_progress_message,
@@ -73,6 +79,32 @@ def check_if_designated_channel(channel_id: str, team_id: str) -> bool:
     return channel_id == designated_channel
 
 
+def _question_text(user_prompt: str | Sequence[str | BinaryContent]) -> str:
+    if isinstance(user_prompt, str):
+        return user_prompt
+    return " ".join(part for part in user_prompt if isinstance(part, str))
+
+
+async def _personality_blurb(progress: "ProgressMessage", question: str) -> None:
+    """Rewrite the progress header in Marvin's voice once the cheap model has
+    read the question. Best-effort: any failure keeps the static line."""
+    if not question.strip():
+        return
+    try:
+        agent = Agent(model=settings.utility_model, system_prompt=PROGRESS_BLURB_PROMPT)
+        result = await asyncio.wait_for(agent.run(question[:500]), timeout=10)
+        blurb = result.output.strip().strip('"')
+        if not blurb:
+            return
+        progress.header = f"🔄 {blurb}"
+        # tool updates re-render around the header; only push an immediate
+        # edit if no tool has rendered the tally yet
+        if not _tool_usage_counts.get():
+            await progress.update(progress.header)
+    except Exception:
+        logger.debug("personality blurb failed; keeping static line", exc_info=True)
+
+
 @task(name="run agent loop")
 async def run_agent(
     user_prompt: str | Sequence[str | BinaryContent],
@@ -93,13 +125,17 @@ async def run_agent(
     progress = await create_progress_message(
         channel_id=channel_id,
         thread_ts=thread_ts,
-        initial_text="🔄 Thinking... this may take a while",
+        initial_text=PROGRESS_PLACEHOLDER,
     )
 
     try:
         token = _progress_message.set(progress)
         # Initialize tool usage counts for this agent run
         counts_token = _tool_usage_counts.set(defaultdict(int))
+        blurb_task = asyncio.create_task(
+            _personality_blurb(progress, _question_text(user_prompt))
+        )
+        blurb_task.add_done_callback(lambda _: None)
         logger = get_run_logger()
         logger.info(
             "Agent config: bot_model=%s utility_model=%s research_model=%s temperature=%s max_tool_calls=%s seen_before=%s",

--- a/examples/slackbot/src/slackbot/slack.py
+++ b/examples/slackbot/src/slackbot/slack.py
@@ -405,9 +405,14 @@ class ProgressMessage:
         self.channel_id = channel_id
         self.thread_ts = thread_ts
         self.message_ts: str | None = None
+        # first line of the rendered message; the tool tracker re-renders the
+        # message around this, so replacing it (e.g. with a personality blurb)
+        # survives subsequent tool-tally updates
+        self.header: str = "🔄 Working..."
 
     async def start(self, initial_text: str = "🔄 Working...") -> "ProgressMessage":
         """Create the initial progress message and return its timestamp."""
+        self.header = initial_text
         response = await post_slack_message(
             message=initial_text,
             channel_id=self.channel_id,


### PR DESCRIPTION
**The problem.** The progress message was a hardcoded "🔄 Thinking... this may take a while" — informative but characterless for a bot named Marvin. Separately, answers cite well but clumsily: bare doc-title links dangle after sentences instead of being woven into the claims.

**The fix.** The progress message posts instantly as a minimal placeholder, then a utility-tier (haiku) call rewrites it in Marvin-the-Paranoid-Android voice with the user's actual question in hand — e.g. "Ah, a stuck flow in Pending. I suppose I should investigate this cheerless state of affairs. Researching." The blurb is stored as the progress message's `header`, which the tool tracker now renders around, so it survives the live tool-tally updates. Generation is best-effort with a 10-second timeout; any failure leaves the placeholder.

Citation guidance in the system prompt now asks for the claim's key phrase to be the hyperlink (or one compact `Sources:` line), never a bare doc title trailing a sentence. The same wording is already live via the `marvin_system_prompt` variable.

## Rollout caveats

- no-op for answer content: the blurb touches only the ephemeral progress message.
- watch: `personality blurb failed` at debug level — frequent occurrences mean the utility model path is unhealthy and users see only the placeholder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
