### PR TITLE
fix(slackbot): image-only mentions no longer crash personalization

### DIFF
--- a/examples/slackbot/src/slackbot/_internal/personalization.py
+++ b/examples/slackbot/src/slackbot/_internal/personalization.py
@@ -191,6 +191,9 @@ def _load_all_facts(namespace: str) -> list[str]:
 def _query_relevant_facts(
     namespace: str, user_question: str, top_k: int = 5
 ) -> list[str]:
+    if not user_question.strip():
+        # image-only or mention-only messages have no text to embed
+        return []
     with TurboPuffer(namespace=namespace) as tpuf:
         try:
             rows = (

--- a/examples/slackbot/src/slackbot/core.py
+++ b/examples/slackbot/src/slackbot/core.py
@@ -98,15 +98,26 @@ def build_user_context(
     channel_id: str,
     bot_id: str,
 ) -> UserContext:
+    empty = PersonalizationSnapshot(
+        seen_before=False, profile_summary="", relevant_notes="", memory_warning=""
+    )
     if user_id == "unknown":
         # no reliable human author this turn — don't read (or ever seed) a
         # shared user-facts-unknown namespace
-        personalization = PersonalizationSnapshot(
-            seen_before=False, profile_summary="", relevant_notes="", memory_warning=""
-        )
+        personalization = empty
     else:
         namespace = f"{settings.user_facts_namespace_prefix}{user_id}"
-        personalization = load_personalization_snapshot(namespace, user_question)
+        try:
+            personalization = load_personalization_snapshot(namespace, user_question)
+        except Exception as exc:
+            # a dead memory store means a thinner prompt, never a dead reply
+            logger.warning(
+                "Personalization failed for %s; continuing without it: %s: %s",
+                user_id,
+                type(exc).__name__,
+                exc,
+            )
+            personalization = empty
     return UserContext(
         user_id=user_id,
         user_notes=personalization.relevant_notes,

--- a/examples/slackbot/tests/test_user_facts.py
+++ b/examples/slackbot/tests/test_user_facts.py
@@ -94,3 +94,32 @@ class TestAuthorExtraction:
         )
         *_, author = _extract_message_context(event)
         assert author is None
+
+
+class TestPersonalizationResilience:
+    def test_empty_question_skips_vector_query(self):
+        from slackbot._internal.personalization import _query_relevant_facts
+
+        # must return without touching the vector store (no client, no network)
+        assert _query_relevant_facts("user-facts-U1", "") == []
+        assert _query_relevant_facts("user-facts-U1", "   ") == []
+
+    def test_build_user_context_survives_personalization_failure(self):
+        from unittest.mock import patch
+
+        from slackbot.core import build_user_context
+
+        with patch(
+            "slackbot.core.load_personalization_snapshot",
+            side_effect=RuntimeError("store down"),
+        ):
+            ctx = build_user_context.fn(
+                user_id="U123",
+                user_question="",
+                thread_ts="1.0",
+                workspace_name="w",
+                channel_id="C1",
+                bot_id="B1",
+            )
+        assert ctx["seen_before"] is False
+        assert ctx["user_profile"] == ""


### PR DESCRIPTION
**The problem.** An `@Marvin` mention containing only an image produces an empty question string after the mention is stripped. The personalization relevance query passed that empty string to the vector store, which raised `ValueError('Either text or vector must be provided')`. The flow failed, and the Prefect retry then hit the message-dedup table and finished as `SKIPPED_DUPLICATE` — the user got silence. Triggering requires a user with stored facts, so it appeared only after tonight's facts were written.

**The fix.** Two layers:
- `_query_relevant_facts` returns no results when there is no text to embed.
- `build_user_context` wraps the whole personalization fetch and fails open with a warning-level log — any personalization failure now degrades to an un-personalized reply instead of no reply.

Regression tests cover both layers.

## Rollout caveats

- watch: `Personalization failed for <user>` warnings — the reply survives, but frequent occurrences mean the memory store path is unhealthy.
- note: this failure produced no Logfire spans (instrumentation covers pydantic-ai/MCP/FastAPI; personalization runs before the agent) — closing that gap is a known follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
