### PR TITLE
fix(slackbot): route bare gpt-* variable values to the responses api

### DIFF
--- a/examples/slackbot/src/slackbot/settings.py
+++ b/examples/slackbot/src/slackbot/settings.py
@@ -7,7 +7,9 @@ from prefect.variables import Variable
 from pydantic import Field, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
-_PROVIDER_PREFIXES = {"claude": "anthropic", "gpt": "openai"}
+# gpt-* must route to the responses api: openai reasoning models reject
+# function tools + reasoning on /v1/chat/completions
+_PROVIDER_PREFIXES = {"claude": "anthropic", "gpt": "openai-responses"}
 
 
 def _ensure_provider(model: str) -> str:

--- a/examples/slackbot/tests/test_settings.py
+++ b/examples/slackbot/tests/test_settings.py
@@ -5,7 +5,7 @@ from slackbot.settings import _ensure_provider, _model_from_variables, bare_mode
 
 def test_ensure_provider_normalizes_bare_names():
     assert _ensure_provider("claude-sonnet-4-6") == "anthropic:claude-sonnet-4-6"
-    assert _ensure_provider("gpt-5") == "openai:gpt-5"
+    assert _ensure_provider("gpt-5") == "openai-responses:gpt-5"
     assert _ensure_provider("anthropic:claude-sonnet-4-6") == (
         "anthropic:claude-sonnet-4-6"
     )
@@ -48,3 +48,12 @@ def test_model_from_variables_falls_back_to_default():
             )
             == "anthropic:claude-haiku-4-5-20251001"
         )
+
+
+def test_bare_gpt_names_route_to_responses_api():
+    from slackbot.settings import _ensure_provider
+
+    # openai reasoning models 400 on chat/completions with function tools;
+    # a bare name in a prefect variable must land on the responses api
+    assert _ensure_provider("gpt-5.6-sol") == "openai-responses:gpt-5.6-sol"
+    assert _ensure_provider("openai:gpt-4o") == "openai:gpt-4o"  # explicit wins


### PR DESCRIPTION
**The problem.** `_ensure_provider` normalizes bare model names from Prefect Variables. Bare `gpt-*` mapped to `openai:`, which routes through `/v1/chat/completions` — where OpenAI reasoning models reject function tools + reasoning with a 400. This exact failure took the bot down earlier today when a variable briefly held the wrong prefix; the mapping left it one casual variable edit (`gpt-5.6-sol` without a prefix) away from recurring.

**The fix.** Bare `gpt-*` names normalize to `openai-responses:`. Explicit `provider:model` values pass through untouched, so anyone who genuinely wants chat-completions can still say `openai:` explicitly. Regression test included.

## Rollout caveats

- no-op today: both prod variables hold explicit `openai-responses:` prefixes; this only changes what a future bare value resolves to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
