### PR TITLE
fix: constrain anthropic to compatible releases

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ dynamic = ["version"]
 dependencies = [
     "aiosqlite>=0.20.0",
     "alembic>=1.12.0",
+    "anthropic<1",
     "jinja2>=3.1.4",
     "partial-json-parser>=0.2.1.1.post5",
     "pydantic-ai>=1.32.0",

--- a/tests/basic/test_anthropic.py
+++ b/tests/basic/test_anthropic.py
@@ -1,0 +1,7 @@
+from pydantic_ai.providers.anthropic import AnthropicProvider
+
+
+def test_anthropic_provider_accepts_pydantic_ai_http_client(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test")
+
+    AnthropicProvider()

--- a/uv.lock
+++ b/uv.lock
@@ -225,7 +225,7 @@ wheels = [
 
 [[package]]
 name = "anthropic"
-version = "0.120.2"
+version = "0.125.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -237,9 +237,9 @@ dependencies = [
     { name = "sniffio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d7/10/4ca013cb166f226bd89e0aeb0fcaff94f45ddf716d4925ce89475d3c587b/anthropic-0.120.2.tar.gz", hash = "sha256:9722efc10c27a30a69f5338ddacdb35bc6a64297a4e4ba729bf83af873d5fb3a", size = 1008421, upload-time = "2026-07-28T17:38:26.986Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/62/f8/6f0560884b5363848347bd640b6c1d04abc25e7aa61787a232f790c6b60a/anthropic-0.125.0.tar.gz", hash = "sha256:e0cdd336580cb7411c1cdab69f80973e9bf4bff7f8e08141811d46307d45c682", size = 1112593, upload-time = "2026-08-19T22:00:42.837Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/63/af/0f5db57b9397a0f3b7fc204cbef143401a7cadaf982330f97f1ce3d39f34/anthropic-0.120.2-py3-none-any.whl", hash = "sha256:0f0bc2b381dc0eb41c8d886b815d79c2041cd2374f83aed36f574b6dc9c579c1", size = 1022851, upload-time = "2026-07-28T17:38:25.466Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/1a/b1bd30cda3790557e8791bec5922a6ec8fabb6fa8b008c76a39cf7be6152/anthropic-0.125.0-py3-none-any.whl", hash = "sha256:3486013602eca76d8b12540764e53654f02cf4951110bca86cf06e67428a9f21", size = 1184067, upload-time = "2026-08-19T22:00:44.596Z" },
 ]
 
 [[package]]
@@ -2974,6 +2974,7 @@ source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },
     { name = "alembic" },
+    { name = "anthropic" },
     { name = "jinja2" },
     { name = "partial-json-parser" },
     { name = "pydantic", extra = ["email"] },
@@ -3027,6 +3028,7 @@ dev = [
 requires-dist = [
     { name = "aiosqlite", specifier = ">=0.20.0" },
     { name = "alembic", specifier = ">=1.12.0" },
+    { name = "anthropic", specifier = "<1" },
     { name = "fastmcp", marker = "extra == 'mcp'", git = "https://github.com/jlowin/fastmcp.git" },
     { name = "jinja2", specifier = ">=3.1.4" },
     { name = "partial-json-parser", specifier = ">=0.2.1.1.post5" },


### PR DESCRIPTION
Prevent Anthropic 1.0 from breaking Pydantic AI 1.81 provider construction by constraining Marvin to the latest compatible 0.x SDK.

<details>
<summary>validation</summary>

- Added a regression test that constructs `AnthropicProvider`
- `uv run --python 3.13 pytest -q tests/basic/test_anthropic.py`
- `uv run --python 3.13 ruff check tests/basic/test_anthropic.py`
- `uv run --python 3.13 ruff format --check tests/basic/test_anthropic.py`

</details>