### PR TITLE
fix: install timezone data on Windows

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "pydantic[email]>=2.10.6",
     "rich>=13.9.4",
     "sqlalchemy[asyncio]>=2.0.36",
+    "tzdata; sys_platform == 'win32'",
     "typer>=0.15.1",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -2982,6 +2982,7 @@ dependencies = [
     { name = "pydantic-settings" },
     { name = "rich" },
     { name = "sqlalchemy", extra = ["asyncio"] },
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
     { name = "typer" },
 ]
 
@@ -3040,6 +3041,7 @@ requires-dist = [
     { name = "rich", specifier = ">=13.9.4" },
     { name = "slackbot", marker = "extra == 'slackbot'", editable = "examples/slackbot" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0.36" },
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
     { name = "typer", specifier = ">=0.15.1" },
 ]
 provides-extras = ["audio", "mcp", "prefect", "slackbot"]


### PR DESCRIPTION
Fixes #1383

Add `tzdata` as a Windows-only runtime dependency so `zoneinfo` can resolve UTC on systems without an IANA time zone database. The platform marker avoids installing it unnecessarily on Unix-like hosts.

## Tests

- `uv lock --check --offline`
- `ruff check src tests` (Ruff 0.9.1)
- `pytest tests/settings/test_settings_object.py` (4 passed)
- Built the wheel and verified its `Requires-Dist: tzdata; sys_platform == 'win32'` metadata
