### PR TITLE
fix: constrain pydantic-ai to v1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
     "anthropic<1",
     "jinja2>=3.1.4",
     "partial-json-parser>=0.2.1.1.post5",
-    "pydantic-ai>=1.32.0",
+    "pydantic-ai>=1.32.0,<2",
     "pydantic-settings>=2.6.1",
     "pydantic[email]>=2.10.6",
     "rich>=13.9.4",

--- a/uv.lock
+++ b/uv.lock
@@ -3035,7 +3035,7 @@ requires-dist = [
     { name = "prefect", marker = "extra == 'prefect'", specifier = ">=3.6.11" },
     { name = "pyaudio", marker = "extra == 'audio'", specifier = ">=0.2.14" },
     { name = "pydantic", extras = ["email"], specifier = ">=2.10.6" },
-    { name = "pydantic-ai", specifier = ">=1.32.0" },
+    { name = "pydantic-ai", specifier = ">=1.32.0,<2" },
     { name = "pydantic-settings", specifier = ">=2.6.1" },
     { name = "rich", specifier = ">=13.9.4" },
     { name = "slackbot", marker = "extra == 'slackbot'", editable = "examples/slackbot" },


### PR DESCRIPTION
## Summary

- prevent Marvin 3.2.7 from resolving to the incompatible Pydantic AI 2.x API
- keep the lockfile's project dependency metadata aligned with `pyproject.toml`

Closes #1382.

## Validation

- `uv lock --check`
- confirmed Marvin imports with the locked Pydantic AI 1.81.0
- confirmed Pydantic AI 2.33.0 reproduces the reported missing `Usage` import and also removes other APIs Marvin currently uses
- `pytest tests/basic/engine/test_database.py tests/basic/engine/test_threads.py -q` (all 10 test bodies passed; teardown reports Windows SQLite file-lock cleanup errors)