### PR TITLE
docs(slackbot): fix deployment links

### DIFF
--- a/examples/slackbot/README.md
+++ b/examples/slackbot/README.md
@@ -125,5 +125,5 @@ WORKSPACE_TO_CHANNEL_ID = {
 ### Production Deployment
 
 For deploying to Cloud Run or similar services, refer to:
-- [Dockerfile.slackbot](/examples/slackbot/Dockerfile.slackbot)
-- [CI/CD Configuration](/.github/workflows/image-build-and-push-community.yaml)
+- [Dockerfile.slackbot](./Dockerfile.slackbot)
+- [CI/CD Configuration](../../.github/workflows/image-build-and-push-community.yaml)


### PR DESCRIPTION
## Summary

- make the Slackbot Dockerfile link relative to the README
- point the CI/CD link to the repository-level workflow

## Why

The existing leading-slash URLs resolve from github.com rather than from this repository, so both deployment references are broken.

## Verification

- confirmed both relative paths resolve to files on `main`
- ran `git diff --check`