### PR TITLE
fix(jsonschema): guard against empty items list in create_array_type

### DIFF
--- a/src/marvin/utilities/jsonschema.py
+++ b/src/marvin/utilities/jsonschema.py
@@ -215,10 +215,14 @@ def create_array_type(
     if isinstance(items, list):
         # Handle positional item schemas
         item_types = [schema_to_type(s, schemas) for s in items]
-        from typing import Union
+        if not item_types:
+            # JSON Schema items=[] is a zero-element tuple; Union[()] raises TypeError.
+            base = list[Any]
+        else:
+            from typing import Union
 
-        combined = Union[tuple(item_types)]
-        base = list[combined]
+            combined = Union[tuple(item_types)] if len(item_types) > 1 else item_types[0]
+            base = list[combined]
     else:
         # Handle single item schema
         item_type = schema_to_type(items, schemas)

--- a/tests/basic/utilities/test_jsonschema.py
+++ b/tests/basic/utilities/test_jsonschema.py
@@ -281,6 +281,11 @@ class TestArrayTypes:
         result = validator.validate_python(["a", "a", "b"])
         assert result == {"a", "b"}
 
+    def test_empty_items_list_does_not_crash(self):
+        # items=[] (empty tuple schema) must not raise TypeError from Union[()]
+        result = jsonschema_to_type({"type": "array", "items": []})
+        assert TypeAdapter(result).validate_python([1, "x", None]) == [1, "x", None]
+
 
 class TestObjectTypes:
     """Test suite for object validation."""


### PR DESCRIPTION
## Summary

Fixes #1351.

`create_array_type()` built `Union[tuple(item_types)]` for positional `items` schemas. When `items` is `[]` (valid JSON Schema for a zero-element tuple), `Union[()]` raises `TypeError: Cannot take a Union of no types.`

Treat an empty positional items list as `list[Any]`, and use a single item type (not a one-element Union) when there is exactly one positional schema.

## Test plan

- Added `test_empty_items_list_does_not_crash`.
- Standalone verification: baseline `Union[()]` TypeError confirmed; fixed `jsonschema_to_type({"type":"array","items":[]})` validates `[1, "x", None]` via Pydantic `TypeAdapter`.

Full suite install was blocked locally by an unrelated `pydantic_ai.usage.Usage` import mismatch in package `__init__`; the changed module was verified in isolation.

## AI assistance

AI-generated. I reviewed the change and ran the focused verification above.

Made with [Cursor](https://cursor.com)