### PR TITLE
fix(jsonschema): handle null-only type lists in schema_to_type

### DIFF
--- a/src/marvin/utilities/jsonschema.py
+++ b/src/marvin/utilities/jsonschema.py
@@ -296,6 +296,9 @@ def schema_to_type(
             types.append(schema_to_type(type_schema, schemas))
         has_null = type(None) in types
         types = [t for t in types if t is not type(None)]
+        if not types:
+            # {"type": ["null"]} (or only-null unions) previously hit types[0] IndexError.
+            return type(None)
         if has_null:
             from typing import Union
 

--- a/tests/basic/utilities/test_jsonschema.py
+++ b/tests/basic/utilities/test_jsonschema.py
@@ -1063,6 +1063,11 @@ class TestEdgeCases:
         result = validator.validate_python(["test", 123, True])
         assert result == ["test", 123, True]
 
+    def test_null_only_type_list_returns_none_type(self):
+        # {"type": ["null"]} previously raised IndexError after filtering out NoneType
+        result = jsonschema_to_type({"type": ["null"]})
+        assert result is type(None)
+
 
 class TestNameHandling:
     """Test suite for schema name handling."""


### PR DESCRIPTION
## Summary

Fixes #1353.

`schema_to_type()` filters `type(None)` out of list-valued `type` fields. For `{"type": ["null"]}` the remaining list is empty and `types[0]` raises `IndexError`. Return `type(None)` when no non-null types remain.

## Test plan

- Added `test_null_only_type_list_returns_none_type`.
- Isolated module verification: `jsonschema_to_type({"type": ["null"]}) is type(None)`.

## AI assistance

AI-generated. I reviewed the change and ran the focused verification above.

Made with [Cursor](https://cursor.com)