### PR TITLE
fix(types): handle bare List in is_classifier/as_classifier

### DIFF
--- a/src/marvin/utilities/types.py
+++ b/src/marvin/utilities/types.py
@@ -164,7 +164,10 @@ def as_classifier(type_: type[T]) -> Labels:
     # Handle list[T] case for type-level classifiers
     origin = get_origin(typ)
     if origin is list:
-        arg = get_args(typ)[0]
+        args = get_args(typ)
+        if not args:
+            return Labels(typ)
+        arg = args[0]
         # Handle list[Enum] or list[Literal]
         if (isinstance(arg, type) and issubclass(arg, enum.Enum)) or get_origin(
             arg,
@@ -222,7 +225,10 @@ def is_classifier(type_: type[T]) -> bool:
     # Handle list[T] case
     origin = get_origin(typ)
     if origin is list:
-        arg = get_args(typ)[0]
+        args = get_args(typ)
+        if not args:
+            return False
+        arg = args[0]
         # Check for list[Enum], list[Literal], or list[list]
         return (
             issubclass_safe(arg, enum.Enum)

--- a/tests/basic/utilities/test_types.py
+++ b/tests/basic/utilities/test_types.py
@@ -1,5 +1,5 @@
 import enum
-from typing import Literal
+from typing import List, Literal
 
 import pytest
 
@@ -47,6 +47,8 @@ class TestClassification:
         assert not is_classifier(list[str])
         assert not is_classifier(list[int])
         assert not is_classifier(dict[str, int])
+        # Bare List without type parameter must not crash
+        assert not is_classifier(List)
 
     def test_as_classifier_with_raw_types(self):
         """Test converting raw types to Labels."""
@@ -87,6 +89,11 @@ class TestClassification:
         assert isinstance(labels, Labels)
         assert labels.many
         assert labels.labels == ("alpha", "beta")
+
+    def test_as_classifier_with_bare_list(self):
+        """Bare List must raise ValueError, not IndexError."""
+        with pytest.raises(ValueError):
+            as_classifier(List)
 
     def test_labels_validation(self):
         """Test validation of Labels."""


### PR DESCRIPTION
Fixes #1355

Bare typing.List has get_origin() is list but empty get_args(), so [0] raised IndexError. Guard empty args: is_classifier returns False, as_classifier raises ValueError via Labels.

Tests: uv run pytest tests/basic/utilities/test_types.py (7 passed), ruff check/format clean.