### PR TITLE
Retry transient Slackbot model failures without replaying tools

### DIFF
--- a/examples/slackbot/src/slackbot/_internal/retrying_model.py
+++ b/examples/slackbot/src/slackbot/_internal/retrying_model.py
@@ -1,0 +1,45 @@
+"""Retry transient provider failures without replaying completed agent tools."""
+
+import asyncio
+
+from prefect.logging.loggers import get_logger
+from pydantic_ai.exceptions import ModelHTTPError
+from pydantic_ai.messages import ModelMessage, ModelResponse
+from pydantic_ai.models import ModelRequestParameters
+from pydantic_ai.models.wrapper import WrapperModel
+from pydantic_ai.settings import ModelSettings
+
+logger = get_logger(__name__)
+TRANSIENT_STATUS_CODES = {429, 500, 502, 503, 504, 529}
+
+
+class RetryingModel(WrapperModel):
+    """Allow two delayed retries of a non-streaming model request.
+
+    The provider SDK may also perform its own bounded transport retries.
+    Cancellation, authentication errors, and malformed requests propagate.
+    """
+
+    async def request(
+        self,
+        messages: list[ModelMessage],
+        model_settings: ModelSettings | None,
+        model_request_parameters: ModelRequestParameters,
+    ) -> ModelResponse:
+        for attempt in range(3):
+            try:
+                return await self.wrapped.request(
+                    messages, model_settings, model_request_parameters
+                )
+            except ModelHTTPError as exc:
+                if exc.status_code not in TRANSIENT_STATUS_CODES or attempt == 2:
+                    raise
+                delay = (1, 3)[attempt]
+                logger.warning(
+                    "Retrying model request after HTTP %s (retry %s/2 in %ss)",
+                    exc.status_code,
+                    attempt + 1,
+                    delay,
+                )
+                await asyncio.sleep(delay)
+        raise AssertionError("Unreachable")

--- a/examples/slackbot/src/slackbot/api.py
+++ b/examples/slackbot/src/slackbot/api.py
@@ -207,8 +207,8 @@ async def run_agent(
             f"✅ thought for {time.monotonic() - start_time:.1f} seconds"
         )
         return result
-    except Exception as e:
-        await progress.update(f"❌ Error: {str(e)}")
+    except Exception:
+        await progress.update("⚠️ I couldn’t finish this reply.")
         raise
 
 

--- a/examples/slackbot/src/slackbot/core.py
+++ b/examples/slackbot/src/slackbot/core.py
@@ -20,6 +20,7 @@ from slackbot._internal.personalization import (
     load_personalization_snapshot,
 )
 from slackbot._internal.prompting import build_system_prompt
+from slackbot._internal.retrying_model import RetryingModel
 from slackbot._internal.templates import DEFAULT_SYSTEM_PROMPT
 from slackbot._internal.tolerant_toolset import TolerantToolset
 from slackbot.assets import (
@@ -170,7 +171,7 @@ def create_agent(
     agent = Agent[
         UserContext, str
     ](
-        model=ai_model,
+        model=RetryingModel(ai_model),
         model_settings=ModelSettings(temperature=settings.temperature),
         tools=[
             research_prefect_topic,  # Tool for researching Prefect topics

--- a/examples/slackbot/tests/test_progress_blurb.py
+++ b/examples/slackbot/tests/test_progress_blurb.py
@@ -25,7 +25,7 @@ async def test_slow_blurb_never_delays_or_overwrites_final_status(monkeypatch, f
     async def answer(**kwargs):
         await started.wait()
         if fails:
-            raise ValueError("answer failed")
+            raise ValueError("provider_secret_detail")
         return result
 
     monkeypatch.setattr(api, "_personality_blurb", blurb)
@@ -48,10 +48,11 @@ async def test_slow_blurb_never_delays_or_overwrites_final_status(monkeypatch, f
     )
     call = api.run_agent.fn("hello", [], {"seen_before": True}, "C1", "1.0")
     if fails:
-        with pytest.raises(ValueError, match="answer failed"):
+        with pytest.raises(ValueError, match="provider_secret_detail"):
             await asyncio.wait_for(call, 1)
     else:
         assert await asyncio.wait_for(call, 1) is result
     assert cancelled.is_set()
     final = progress.update.call_args.args[0]
-    assert final.startswith("❌" if fails else "✅")
+    assert final.startswith("⚠️" if fails else "✅")
+    assert "provider_secret_detail" not in final

--- a/examples/slackbot/tests/test_provider_retries.py
+++ b/examples/slackbot/tests/test_provider_retries.py
@@ -1,0 +1,72 @@
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+from pydantic_ai import Agent
+from pydantic_ai.exceptions import ModelHTTPError
+from pydantic_ai.messages import ModelResponse, TextPart, ToolCallPart
+from pydantic_ai.models.function import FunctionModel
+from slackbot._internal import retrying_model
+from slackbot._internal.retrying_model import RetryingModel
+
+
+async def test_retry_preserves_completed_tool_results(monkeypatch):
+    sleep = AsyncMock()
+    monkeypatch.setattr(retrying_model.asyncio, "sleep", sleep)
+    requests = []
+    tool_calls = []
+
+    async def model(messages, info):
+        requests.append(messages)
+        if len(requests) == 1:
+            return ModelResponse(parts=[ToolCallPart("lookup", {}, "call-1")])
+        if len(requests) == 2:
+            raise ModelHTTPError(503, "test", {"message": "overloaded"})
+        return ModelResponse(parts=[TextPart("Here is the answer.")])
+
+    def lookup() -> str:
+        tool_calls.append(1)
+        return "Verified result"
+
+    agent = Agent(RetryingModel(FunctionModel(model)), tools=[lookup])
+    result = await agent.run("Help me")
+    assert result.output == "Here is the answer."
+    assert len(tool_calls) == 1
+    assert len(requests) == 3
+    assert requests[1] is requests[2]
+    sleep.assert_awaited_once_with(1)
+
+
+@pytest.mark.parametrize(
+    "status, attempts", [(503, 3), (429, 3), (529, 3), (401, 1), (400, 1)]
+)
+async def test_retry_budget_and_permanent_errors(monkeypatch, status, attempts):
+    sleep = AsyncMock()
+    monkeypatch.setattr(retrying_model.asyncio, "sleep", sleep)
+    calls = []
+
+    async def model(messages, info):
+        calls.append(1)
+        raise ModelHTTPError(status, "test", {"message": "provider detail"})
+
+    with pytest.raises(ModelHTTPError):
+        await Agent(RetryingModel(FunctionModel(model))).run("hello")
+    assert len(calls) == attempts
+    assert [call.args[0] for call in sleep.await_args_list] == (
+        [1, 3] if attempts == 3 else []
+    )
+
+
+async def test_cancellation_during_backoff_propagates(monkeypatch):
+    monkeypatch.setattr(
+        retrying_model.asyncio, "sleep", AsyncMock(side_effect=asyncio.CancelledError)
+    )
+    calls = []
+
+    async def model(messages, info):
+        calls.append(1)
+        raise ModelHTTPError(503, "test")
+
+    with pytest.raises(asyncio.CancelledError):
+        await Agent(RetryingModel(FunctionModel(model))).run("hello")
+    assert len(calls) == 1


### PR DESCRIPTION
Temporary provider overloads currently surface raw model exceptions in Slack. Retry transient HTTP failures at the model-request boundary so an overloaded request can recover without restarting the agent or replaying completed tools. If retries are exhausted, the progress message shows a short failure notice; exception details remain in logs.

The answering model gets two additional attempts after 1- and 3-second waits for HTTP 429, 500, 502, 503, 504, and 529. Provider SDK retries remain in effect. Authentication and malformed-request errors propagate immediately, as does cancellation. This applies to the non-streaming request path used by the Slackbot.

Validation: all 79 Slackbot tests pass, including a 503 after a successful tool call that recovers without repeating the tool, bounded exhaustion, permanent errors, cancellation during backoff, and removal of raw exception details from the Slack progress message. Ruff and formatting pass.

![bufo-thinking](https://all-the.bufo.zone/bufo-thinking.png)

generated with Codex (GPT-6)
